### PR TITLE
perf: aggregate raft outbound by physical node, batch TCP writes

### DIFF
--- a/.claude/skills/build-actor/SKILL.md
+++ b/.claude/skills/build-actor/SKILL.md
@@ -56,6 +56,16 @@ impl YourStateMachine {
     pub fn take_timer_commands(&mut self) -> Vec<TimerCommand<YourTimer>> {
         std::mem::take(&mut self.pending_timer_commands)
     }
+
+    /// Top-level command dispatch. Called by the actor's drain loop.
+    /// Lives on the state machine because it's pure sync — no I/O.
+    pub fn process(&mut self, event: YourActorCommand) {
+        match event {
+            YourActorCommand::PacketReceived { src, data } => self.step(/* ... */),
+            YourActorCommand::Timeout(callback) => self.handle_timeout(callback),
+            YourActorCommand::Query(cmd) => self.handle_query(cmd),
+        }
+    }
 }
 ```
 
@@ -166,20 +176,16 @@ impl YourActor {
         // Flush any side effects from initialization
         Self::flush(&mut state, &transport_tx, &scheduler_tx).await;
 
-        while let Some(event) = mailbox.recv().await {
-            match event {
-                YourActorCommand::PacketReceived { src, data } => {
-                    state.step(/* ... */);
-                }
-                YourActorCommand::Timeout(callback) => {
-                    state.handle_timeout(callback);
-                }
-                YourActorCommand::Query(cmd) => {
-                    state.handle_query(cmd);
-                }
+        // Drain-then-flush: recv_many batches up to `limit` messages,
+        // then flush once. Under load N messages = 1 flush instead of N.
+        let mut buf = Vec::with_capacity(64);
+        loop {
+            if mailbox.recv_many(&mut buf, 64).await == 0 {
+                break;
             }
-
-            // THIS MUST HAPPEN AFTER EVERY EVENT -- no exceptions
+            for event in buf.drain(..) {
+                state.process(event);
+            }
             Self::flush(&mut state, &transport_tx, &scheduler_tx).await;
         }
     }
@@ -209,13 +215,36 @@ impl YourActor {
 }
 ```
 
-**Critical: flush must happen after EVERY event.** Existing actors enforce this with single flush call at bottom of match, no early returns or continues before it. Branch that skips flush = side effects silently lost.
+**Critical: flush must happen after draining all pending events.** Output buffers (`pending_*` vecs) accumulate across multiple `process()` calls, so one flush handles the entire batch. `process()` lives on the state machine when dispatch is pure sync (no I/O). If command handling requires async I/O (e.g. sending transport commands), keep it as an actor associated fn instead. Branch that skips flush = side effects silently lost.
 
 ### Multiplexing pattern (like RaftActor)
 
-If actor manages multiple state machine instances (e.g., one per shard), same unit-like struct pattern. Domain state declared as local variables inside `run()`:
+If actor manages multiple state machine instances (e.g., one per shard), extract a `Groups` struct to encapsulate group lifecycle, dirty tracking, and timer seq namespacing. Actor stays thin — just the mailbox loop.
 
 ```rust
+/// Encapsulates multiplexed state machines and their bookkeeping.
+struct YourGroups {
+    node_id: NodeId,
+    groups: HashMap<GroupId, YourStateMachine>,
+    seq_counter: u32,
+    shard_tokens: HashMap<ShardToken, u32>,
+    dirty: HashSet<GroupId>,
+}
+
+impl YourGroups {
+    async fn process_command(&mut self, cmd: YourActorCommand, ...) {
+        // match cmd, mutate groups, insert into self.dirty
+    }
+
+    async fn flush_dirty(&mut self, transport_tx: ..., scheduler_tx: ...) {
+        let to_flush: Vec<_> = self.dirty.drain().collect();
+        for group_id in to_flush {
+            // take_outbound, take_timer_commands, translate seqs, send
+        }
+    }
+}
+
+/// Thin async boundary.
 pub struct MultiplexActor;
 
 impl MultiplexActor {
@@ -225,18 +254,28 @@ impl MultiplexActor {
         transport_tx: mpsc::Sender<YourOutboundPacket>,
         scheduler_tx: mpsc::Sender<TickerCommand<YourTimer>>,
     ) {
-        let mut groups: HashMap<GroupId, YourStateMachine> = HashMap::new();
-        let mut seq_counter: u32 = 0;
-        let mut shard_tokens: HashMap<ShardToken, u32> = HashMap::new();
+        let mut state = YourGroups::new(node_id);
+        let mut buf = Vec::with_capacity(64);
 
-        while let Some(cmd) = mailbox.recv().await {
-            // match cmd, mutate groups, call Self::flush(...)
+        loop {
+            if mailbox.recv_many(&mut buf, 64).await == 0 {
+                break;
+            }
+            for cmd in buf.drain(..) {
+                state.process_command(cmd, &transport_tx, &scheduler_tx).await;
+            }
+            state.flush_dirty(&transport_tx, &scheduler_tx).await;
         }
     }
 }
 ```
 
-Each instance emits local seq values for timers. Actor must namespace them to avoid collisions in shared ticker. See `RaftActor.flush()` in `src/raft/actor.rs` for translation pattern: `get_or_alloc_seq(shard_group_id.token(local_seq))` maps each `(group_id, local_seq)` pair to unique global seq.
+See `RaftGroups` in `src/clusters/raft/actor.rs` for the full implementation. Key details:
+
+- `process_command` is async when some commands need I/O (e.g. `DisconnectPeer`, `CancelSchedule`). Channel senders passed as params, not stored in the struct.
+- `flush_dirty` collects dirty group IDs into a local Vec before iterating, avoiding borrow conflicts with `&mut self` methods like `get_or_alloc_seq`.
+
+Each instance emits local seq values for timers. The groups struct namespaces them to avoid collisions in shared ticker: `get_or_alloc_seq(group_id.token(local_seq))` maps each `(group_id, local_seq)` pair to a unique global seq.
 
 When removing group, cancel all its timers by iterating over known local seqs and removing their global mappings.
 
@@ -304,7 +343,7 @@ Biggest advantage of sync-first design: test protocol logic without async machin
 - [ ] State machine is `pub struct` with no async, no channels, no I/O
 - [ ] Side effects buffered in `pending_outbound` and `pending_timer_commands`
 - [ ] `take_outbound()` and `take_timer_commands()` drain via `std::mem::take`
-- [ ] Actor calls flush after every event (no early returns before flush)
+- [ ] Actor drains pending messages via `try_recv()` then flushes once (no early returns before flush)
 - [ ] TTimer implemented if using timers (with `Default` callback)
 - [ ] Channels created and actor spawned in `lib.rs` startup
 - [ ] Sync unit tests exercise state machine directly

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -53,12 +53,283 @@ impl From<RaftTimeoutCallback> for RaftCommand {
     }
 }
 
-/// Async boundary that multiplexes multiple Raft state machines — one per
-/// shard group.
+/// Multiplexes multiple Raft state machines — one per shard group.
+///
+/// Manages group lifecycle, timer seq namespacing, and dirty-group tracking
+/// for drain-then-flush batching.
 ///
 /// Timer seqs are namespaced: each `Raft` emits local seqs (0 = election,
-/// 1 = heartbeat). The actor translates these to globally unique seqs via a
+/// 1 = heartbeat). This struct translates them to globally unique seqs via a
 /// monotonic counter, preventing collisions across groups in the shared Ticker.
+struct RaftGroups {
+    node_id: NodeId,
+    groups: HashMap<ShardGroupId, Raft<crate::storage::MemoryLogStore>>,
+    /// Monotonic counter for globally unique timer seqs.
+    seq_counter: u32,
+    /// Maps (ShardGroupId, local_seq) → global_seq for timer namespacing.
+    shard_tokens: HashMap<ShardToken, u32>,
+    /// Groups modified since last flush.
+    dirty: HashSet<ShardGroupId>,
+}
+
+impl RaftGroups {
+    fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            groups: HashMap::new(),
+            seq_counter: 0,
+            shard_tokens: HashMap::new(),
+            dirty: HashSet::new(),
+        }
+    }
+
+    async fn process_command(
+        &mut self,
+        cmd: RaftCommand,
+        transport_tx: &mpsc::Sender<RaftTransportCommand>,
+        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
+    ) {
+        match cmd {
+            RaftCommand::PacketReceived {
+                shard_group_id,
+                from,
+                rpc,
+            } => {
+                if let Some(raft) = self.groups.get_mut(&shard_group_id) {
+                    raft.step(from, rpc);
+                    self.dirty.insert(shard_group_id);
+                }
+            }
+
+            RaftCommand::Timeout(cb) => {
+                let shard_group_id = match &cb {
+                    RaftTimeoutCallback::Ignored => return,
+                    RaftTimeoutCallback::ElectionTimeout { shard_group_id } => *shard_group_id,
+                    RaftTimeoutCallback::HeartbeatTimeout { shard_group_id } => *shard_group_id,
+                };
+                if let Some(raft) = self.groups.get_mut(&shard_group_id) {
+                    raft.handle_timeout(cb);
+                    self.dirty.insert(shard_group_id);
+                }
+            }
+
+            RaftCommand::EnsureGroup { group } => {
+                let group_id = group.id;
+                self.ensure_group(group);
+                self.dirty.insert(group_id);
+            }
+
+            RaftCommand::RemoveGroup { group_id } => {
+                self.remove_group(group_id, scheduler_tx).await;
+            }
+
+            RaftCommand::GetLeader { group_id, reply } => {
+                let leader = self
+                    .groups
+                    .get(&group_id)
+                    .and_then(|raft| raft.current_leader().cloned());
+                let _ = reply.send(leader);
+            }
+
+            RaftCommand::Propose {
+                shard_group_id,
+                command,
+                reply,
+            } => {
+                let result = match self.groups.get_mut(&shard_group_id) {
+                    Some(raft) => raft.propose(command),
+                    None => Err(ProposeError::NotLeader),
+                };
+                let _ = reply.send(result);
+                self.dirty.insert(shard_group_id);
+            }
+
+            RaftCommand::HandleNodeDeath { dead_node_id } => {
+                // Evict stale connection + cached address so the transport
+                // stops sending RPCs to the dead node's address.
+                let _ = transport_tx
+                    .send(RaftTransportCommand::DisconnectPeer(dead_node_id.clone()))
+                    .await;
+
+                let affected: Vec<ShardGroupId> = self
+                    .groups
+                    .iter()
+                    .filter(|(_, raft)| raft.is_leader() && raft.has_peer(&dead_node_id))
+                    .map(|(id, _)| *id)
+                    .collect();
+
+                for group_id in &affected {
+                    if let Some(raft) = self.groups.get_mut(group_id) {
+                        let cmd = crate::clusters::raft::messages::RaftCommand::RemovePeer(
+                            dead_node_id.clone(),
+                        );
+                        let _ = raft.propose(cmd);
+                    }
+                }
+
+                self.dirty.extend(affected);
+            }
+
+            RaftCommand::HandleNodeJoin {
+                new_node_id,
+                affected_groups,
+            } => {
+                for group in &affected_groups {
+                    if let Some(raft) = self.groups.get_mut(&group.id)
+                        && raft.is_leader()
+                        && !raft.has_peer(&new_node_id)
+                    {
+                        let cmd = crate::clusters::raft::messages::RaftCommand::AddPeer(
+                            new_node_id.clone(),
+                        );
+                        let _ = raft.propose(cmd);
+                        self.dirty.insert(group.id);
+                    }
+                }
+
+                for group in affected_groups {
+                    if !self.groups.contains_key(&group.id) && group.members.contains(&self.node_id)
+                    {
+                        let group_id = group.id;
+                        self.ensure_group(group);
+                        self.dirty.insert(group_id);
+                    }
+                }
+            }
+        }
+    }
+
+    fn ensure_group(&mut self, group: ShardGroup) {
+        if self.groups.contains_key(&group.id) {
+            return;
+        }
+        if !group.members.contains(&self.node_id) {
+            return;
+        }
+
+        let peers: HashSet<NodeId> = group
+            .members
+            .iter()
+            .filter(|id| *id != &self.node_id)
+            .cloned()
+            .collect();
+
+        let jitter = {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            self.node_id.hash(&mut hasher);
+            (hasher.finish() % 20) as u32
+        };
+        let raft = Raft::new(
+            self.node_id.clone(),
+            peers,
+            jitter,
+            crate::storage::MemoryLogStore::default(),
+            group.id,
+        );
+
+        tracing::info!(
+            "[{}] Created Raft group {:?} with {} peers",
+            self.node_id,
+            group.id,
+            raft.peers_count()
+        );
+
+        self.groups.insert(group.id, raft);
+    }
+
+    async fn remove_group(
+        &mut self,
+        group_id: ShardGroupId,
+        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
+    ) {
+        if self.groups.remove(&group_id).is_none() {
+            return;
+        }
+
+        for local_seq in [0, 1] {
+            if let Some(global_seq) = self.shard_tokens.remove(&group_id.token(local_seq)) {
+                let _ = scheduler_tx
+                    .send(TimerCommand::CancelSchedule { seq: global_seq }.into())
+                    .await;
+            }
+        }
+
+        tracing::info!("[{}] Removed Raft group {:?}", self.node_id, group_id);
+    }
+
+    /// Flush outbound packets and timer commands for all dirty groups.
+    ///
+    /// Aggregates outbound packets by target NodeId — 200 shard groups
+    /// producing messages for the same 2 physical nodes result in 2 batched
+    /// channel sends, not 200 individual ones.
+    async fn flush_dirty(
+        &mut self,
+        transport_tx: &mpsc::Sender<RaftTransportCommand>,
+        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
+    ) {
+        let to_flush: Vec<_> = self.dirty.drain().collect();
+
+        let mut all_timer_commands = Vec::new();
+        let mut packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>> = HashMap::new();
+
+        for group_id in to_flush {
+            let Some(raft) = self.groups.get_mut(&group_id) else {
+                continue;
+            };
+
+            let timer_commands = raft.take_timer_commands();
+            let outbound_packets = raft.take_outbound();
+
+            for cmd in timer_commands {
+                let translated = match cmd {
+                    TimerCommand::SetSchedule {
+                        seq: local_seq,
+                        timer,
+                    } => Some(TimerCommand::SetSchedule {
+                        seq: self.get_or_alloc_seq(group_id.token(local_seq)),
+                        timer,
+                    }),
+                    TimerCommand::CancelSchedule { seq: local_seq } => self
+                        .shard_tokens
+                        .get(&group_id.token(local_seq))
+                        .map(|&global_seq| TimerCommand::CancelSchedule { seq: global_seq }),
+                };
+                if let Some(cmd) = translated {
+                    all_timer_commands.push(cmd);
+                }
+            }
+
+            for pkt in outbound_packets {
+                packets_by_target
+                    .entry(pkt.target.clone())
+                    .or_default()
+                    .push(pkt);
+            }
+        }
+
+        tokio::join!(
+            async {
+                for cmd in all_timer_commands {
+                    let _ = scheduler_tx.send(cmd.into()).await;
+                }
+            },
+            async {
+                for (_, packets) in packets_by_target {
+                    let _ = transport_tx.send(RaftTransportCommand::Send(packets)).await;
+                }
+            }
+        );
+    }
+
+    fn get_or_alloc_seq(&mut self, token: ShardToken) -> u32 {
+        *self.shard_tokens.entry(token).or_insert_with(|| {
+            self.seq_counter = self.seq_counter.wrapping_add(1);
+            self.seq_counter
+        })
+    }
+}
+
+/// Async boundary — receives commands from mailbox, delegates to `RaftGroups`.
 pub struct RaftActor;
 
 impl RaftActor {
@@ -68,313 +339,19 @@ impl RaftActor {
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
     ) {
-        let mut groups: HashMap<ShardGroupId, Raft<crate::storage::MemoryLogStore>> =
-            HashMap::new();
+        let mut state = RaftGroups::new(node_id);
+        let mut buf = Vec::with_capacity(64);
 
-        // Timer seq namespacing: (ShardGroupId, local_seq) → global_seq
-        // Every Raft instance emits the same local seqs — 0 for election timer,
-        // 1 for heartbeat timer. The actor translates to globally unique seqs so
-        // the shared Ticker doesn't overwrite one group's timer with another's.
-        let mut seq_counter: u32 = 0;
-        let mut shard_tokens: HashMap<ShardToken, u32> = HashMap::new();
-
-        while let Some(cmd) = mailbox.recv().await {
-            match cmd {
-                RaftCommand::PacketReceived {
-                    shard_group_id,
-                    from,
-                    rpc,
-                } => {
-                    if let Some(raft) = groups.get_mut(&shard_group_id) {
-                        raft.step(from, rpc);
-                        Self::flush(
-                            shard_group_id,
-                            &mut groups,
-                            &mut seq_counter,
-                            &mut shard_tokens,
-                            &transport_tx,
-                            &scheduler_tx,
-                        )
-                        .await;
-                    }
-                }
-
-                RaftCommand::Timeout(cb) => {
-                    let shard_group_id = match &cb {
-                        RaftTimeoutCallback::Ignored => continue,
-                        RaftTimeoutCallback::ElectionTimeout { shard_group_id } => *shard_group_id,
-                        RaftTimeoutCallback::HeartbeatTimeout { shard_group_id } => *shard_group_id,
-                    };
-                    if let Some(raft) = groups.get_mut(&shard_group_id) {
-                        raft.handle_timeout(cb);
-                        Self::flush(
-                            shard_group_id,
-                            &mut groups,
-                            &mut seq_counter,
-                            &mut shard_tokens,
-                            &transport_tx,
-                            &scheduler_tx,
-                        )
-                        .await;
-                    }
-                }
-
-                RaftCommand::EnsureGroup { group } => {
-                    let group_id = group.id;
-                    Self::ensure_group(&node_id, &mut groups, group);
-                    Self::flush(
-                        group_id,
-                        &mut groups,
-                        &mut seq_counter,
-                        &mut shard_tokens,
-                        &transport_tx,
-                        &scheduler_tx,
-                    )
-                    .await;
-                }
-
-                RaftCommand::RemoveGroup { group_id } => {
-                    Self::remove_group(
-                        &node_id,
-                        group_id,
-                        &mut groups,
-                        &mut shard_tokens,
-                        &scheduler_tx,
-                    )
-                    .await;
-                }
-
-                RaftCommand::GetLeader { group_id, reply } => {
-                    let leader = groups
-                        .get(&group_id)
-                        .and_then(|raft| raft.current_leader().cloned());
-                    let _ = reply.send(leader);
-                }
-
-                RaftCommand::Propose {
-                    shard_group_id,
-                    command,
-                    reply,
-                } => {
-                    let result = match groups.get_mut(&shard_group_id) {
-                        Some(raft) => raft.propose(command),
-                        None => Err(ProposeError::NotLeader),
-                    };
-                    let _ = reply.send(result);
-                    Self::flush(
-                        shard_group_id,
-                        &mut groups,
-                        &mut seq_counter,
-                        &mut shard_tokens,
-                        &transport_tx,
-                        &scheduler_tx,
-                    )
-                    .await;
-                }
-
-                RaftCommand::HandleNodeDeath { dead_node_id } => {
-                    // Evict stale connection + cached address so the transport
-                    // stops sending RPCs to the dead node's address.
-                    let _ = transport_tx
-                        .send(RaftTransportCommand::DisconnectPeer(dead_node_id.clone()))
-                        .await;
-
-                    let affected: Vec<ShardGroupId> = groups
-                        .iter()
-                        .filter(|(_, raft)| raft.is_leader() && raft.has_peer(&dead_node_id))
-                        .map(|(id, _)| *id)
-                        .collect();
-
-                    for group_id in &affected {
-                        if let Some(raft) = groups.get_mut(group_id) {
-                            let cmd = crate::clusters::raft::messages::RaftCommand::RemovePeer(
-                                dead_node_id.clone(),
-                            );
-                            let _ = raft.propose(cmd);
-                        }
-                    }
-
-                    for group_id in affected {
-                        Self::flush(
-                            group_id,
-                            &mut groups,
-                            &mut seq_counter,
-                            &mut shard_tokens,
-                            &transport_tx,
-                            &scheduler_tx,
-                        )
-                        .await;
-                    }
-                }
-
-                RaftCommand::HandleNodeJoin {
-                    new_node_id,
-                    affected_groups,
-                } => {
-                    let mut flushed = Vec::new();
-
-                    for group in &affected_groups {
-                        if let Some(raft) = groups.get_mut(&group.id)
-                            && raft.is_leader()
-                            && !raft.has_peer(&new_node_id)
-                        {
-                            let cmd = crate::clusters::raft::messages::RaftCommand::AddPeer(
-                                new_node_id.clone(),
-                            );
-                            let _ = raft.propose(cmd);
-                            flushed.push(group.id);
-                        }
-                    }
-
-                    for group in affected_groups {
-                        if !groups.contains_key(&group.id)
-                            && group.members.contains(&node_id)
-                        {
-                            let group_id = group.id;
-                            Self::ensure_group(&node_id, &mut groups, group);
-                            flushed.push(group_id);
-                        }
-                    }
-
-                    for group_id in flushed {
-                        Self::flush(
-                            group_id,
-                            &mut groups,
-                            &mut seq_counter,
-                            &mut shard_tokens,
-                            &transport_tx,
-                            &scheduler_tx,
-                        )
-                        .await;
-                    }
-                }
+        loop {
+            if mailbox.recv_many(&mut buf, 64).await == 0 {
+                break;
             }
-        }
-    }
-
-    fn ensure_group(
-        node_id: &NodeId,
-        groups: &mut HashMap<ShardGroupId, Raft<crate::storage::MemoryLogStore>>,
-        group: ShardGroup,
-    ) {
-        if groups.contains_key(&group.id) {
-            return;
-        }
-        if !group.members.contains(node_id) {
-            return;
-        }
-
-        let peers: HashSet<NodeId> = group
-            .members
-            .iter()
-            .filter(|id| *id != node_id)
-            .cloned()
-            .collect();
-
-        let jitter = {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            node_id.hash(&mut hasher);
-            (hasher.finish() % 20) as u32
-        };
-        let raft = Raft::new(
-            node_id.clone(),
-            peers,
-            jitter,
-            crate::storage::MemoryLogStore::default(),
-            group.id,
-        );
-
-        tracing::info!(
-            "[{}] Created Raft group {:?} with {} peers",
-            node_id,
-            group.id,
-            raft.peers_count()
-        );
-
-        groups.insert(group.id, raft);
-    }
-
-    async fn remove_group(
-        node_id: &NodeId,
-        group_id: ShardGroupId,
-        groups: &mut HashMap<ShardGroupId, Raft<crate::storage::MemoryLogStore>>,
-        shard_tokens: &mut HashMap<ShardToken, u32>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
-    ) {
-        if groups.remove(&group_id).is_none() {
-            return;
-        }
-
-        for local_seq in [0, 1] {
-            if let Some(global_seq) = shard_tokens.remove(&group_id.token(local_seq)) {
-                let _ = scheduler_tx
-                    .send(TimerCommand::CancelSchedule { seq: global_seq }.into())
+            for cmd in buf.drain(..) {
+                state
+                    .process_command(cmd, &transport_tx, &scheduler_tx)
                     .await;
             }
+            state.flush_dirty(&transport_tx, &scheduler_tx).await;
         }
-
-        tracing::info!("[{}] Removed Raft group {:?}", node_id, group_id);
-    }
-
-    /// Flush outbound packets and timer commands for one shard group.
-    async fn flush(
-        shard_group_id: ShardGroupId,
-        groups: &mut HashMap<ShardGroupId, Raft<crate::storage::MemoryLogStore>>,
-        seq_counter: &mut u32,
-        shard_tokens: &mut HashMap<ShardToken, u32>,
-        transport_tx: &mpsc::Sender<RaftTransportCommand>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
-    ) {
-        let raft = match groups.get_mut(&shard_group_id) {
-            Some(r) => r,
-            None => return,
-        };
-
-        let timer_commands = raft.take_timer_commands();
-        let outbound_packets = raft.take_outbound();
-
-        let translated: Vec<_> = timer_commands
-            .into_iter()
-            .filter_map(|cmd| match cmd {
-                TimerCommand::SetSchedule {
-                    seq: local_seq,
-                    timer,
-                } => Some(TimerCommand::SetSchedule {
-                    seq: Self::get_or_alloc_seq(
-                        shard_group_id.token(local_seq),
-                        seq_counter,
-                        shard_tokens,
-                    ),
-                    timer,
-                }),
-                TimerCommand::CancelSchedule { seq: local_seq } => shard_tokens
-                    .get(&shard_group_id.token(local_seq))
-                    .map(|&global_seq| TimerCommand::CancelSchedule { seq: global_seq }),
-            })
-            .collect();
-
-        tokio::join!(
-            async {
-                for cmd in translated {
-                    let _ = scheduler_tx.send(cmd.into()).await;
-                }
-            },
-            async {
-                for pkt in outbound_packets {
-                    let _ = transport_tx.send(RaftTransportCommand::Send(pkt)).await;
-                }
-            }
-        );
-    }
-
-    fn get_or_alloc_seq(
-        token: ShardToken,
-        seq_counter: &mut u32,
-        shard_tokens: &mut HashMap<ShardToken, u32>,
-    ) -> u32 {
-        *shard_tokens.entry(token).or_insert_with(|| {
-            *seq_counter = seq_counter.wrapping_add(1);
-            *seq_counter
-        })
     }
 }

--- a/src/clusters/raft/messages.rs
+++ b/src/clusters/raft/messages.rs
@@ -120,8 +120,9 @@ impl OutboundRaftPacket {
 /// Commands sent from RaftActor to RaftTransportActor.
 #[derive(Debug)]
 pub enum RaftTransportCommand {
-    /// Send an RPC to a peer.
-    Send(OutboundRaftPacket),
+    /// Send RPCs to peers. Aggregated by RaftGroups across shard groups
+    /// to reduce channel sends — packets grouped by target NodeId.
+    Send(Vec<OutboundRaftPacket>),
     /// Drop connection and cached address for a dead peer.
     /// Prevents stale RPCs from flooding a restarted node at the same address.
     DisconnectPeer(NodeId),

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -52,99 +52,35 @@ impl RaftReader {
     }
 }
 
-struct RaftWriter(OwnedWriteHalf);
-
-impl RaftWriter {
-    async fn write_node_id(&mut self, node_id: &NodeId) -> std::io::Result<()> {
-        let bytes = bincode::encode_to_vec(node_id, BINCODE_CONFIG)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let len = bytes.len() as u32;
-        self.0.write_all(&len.to_be_bytes()).await?;
-        self.0.write_all(&bytes).await?;
-        Ok(())
-    }
-
-    async fn write_message(&mut self, msg: &WireRaftMessage) -> std::io::Result<()> {
-        let bytes = bincode::encode_to_vec(msg, BINCODE_CONFIG)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let len = bytes.len() as u32;
-        self.0.write_all(&len.to_be_bytes()).await?;
-        self.0.write_all(&bytes).await?;
-        Ok(())
-    }
-}
-
-/// TCP transport for Raft RPCs.
+/// Manages peer connections, address resolution, and dead-peer tracking.
 ///
-/// Either side can initiate a connection. On simultaneous connect, the
-/// connection initiated by the **lower `NodeId`** wins; the other is dropped.
+/// On simultaneous connect, the connection initiated by the **lower `NodeId`**
+/// wins; the other is dropped.
 ///
 /// Handshake: after connecting, the initiator sends its `NodeId`. The acceptor
 /// reads it, and if a connection to that peer already exists (from our own
 /// outbound connect), the tie is broken by NodeId ordering.
-pub struct RaftTransportActor;
+struct RaftWriters {
+    node_id: NodeId,
+    writers: HashMap<NodeId, OwnedWriteHalf>,
+    addr_cache: HashMap<NodeId, SocketAddr>,
+    /// Peers explicitly disconnected via DisconnectPeer. Outbound RPCs
+    /// to these peers are silently dropped until a new connection is
+    /// accepted (peer restart with new UUID won't hit this — different NodeId).
+    dead_peers: HashSet<NodeId>,
+}
 
-impl RaftTransportActor {
-    pub async fn run(
-        node_id: NodeId,
-        listener: TcpListener,
-        raft_tx: mpsc::Sender<RaftCommand>,
-        mut from_actor: mpsc::Receiver<RaftTransportCommand>,
-        swim_tx: mpsc::Sender<SwimCommand>,
-    ) {
-        let mut writers: HashMap<NodeId, RaftWriter> = HashMap::new();
-        let mut addr_cache: HashMap<NodeId, SocketAddr> = HashMap::new();
-        // Peers explicitly disconnected via DisconnectPeer. Outbound RPCs
-        // to these peers are silently dropped until a new connection is
-        // accepted (peer restart with new UUID won't hit this — different NodeId).
-        let mut dead_peers: HashSet<NodeId> = HashSet::new();
-        let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(300));
-        cleanup_interval.tick().await; // consume immediate first tick
-
-        loop {
-            tokio::select! {
-                Ok((stream, _)) = listener.accept() => {
-                    Self::handle_accepted(
-                        stream, &node_id, &raft_tx, &mut writers,
-                    ).await;
-                }
-                Some(cmd) = from_actor.recv() => {
-                    match cmd {
-                        RaftTransportCommand::Send(pkt) => {
-                            if dead_peers.contains(&pkt.target) {
-                                continue;
-                            }
-                            Self::handle_outbound(
-                                pkt, &node_id, &raft_tx, &swim_tx,
-                                &mut writers, &mut addr_cache,
-                            ).await;
-                        }
-                        RaftTransportCommand::DisconnectPeer(peer_id) => {
-                            writers.remove(&peer_id);
-                            addr_cache.remove(&peer_id);
-                            dead_peers.insert(peer_id.clone());
-                            tracing::info!(
-                                "[{}] Disconnected dead peer {:?}",
-                                node_id, peer_id
-                            );
-                        }
-                    }
-                }
-                _ = cleanup_interval.tick() => {
-                    if !dead_peers.is_empty() {
-                        dead_peers.clear();
-                    }
-                }
-            }
+impl RaftWriters {
+    fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            writers: HashMap::new(),
+            addr_cache: HashMap::new(),
+            dead_peers: HashSet::new(),
         }
     }
 
-    async fn handle_accepted(
-        stream: TcpStream,
-        node_id: &NodeId,
-        raft_tx: &mpsc::Sender<RaftCommand>,
-        writers: &mut HashMap<NodeId, RaftWriter>,
-    ) {
+    async fn accept(&mut self, stream: TcpStream, raft_tx: &mpsc::Sender<RaftCommand>) {
         let (read_half, write_half) = stream.into_split();
         let mut reader = RaftReader(read_half);
 
@@ -152,66 +88,94 @@ impl RaftTransportActor {
             return;
         };
 
-        if writers.contains_key(&peer_id) && peer_id > *node_id {
+        if self.writers.contains_key(&peer_id) && peer_id > self.node_id {
             return;
         }
 
-        writers.insert(peer_id, RaftWriter(write_half));
+        self.writers.insert(peer_id, write_half);
         tokio::spawn(reader.run(raft_tx.clone()));
     }
 
-    async fn handle_outbound(
-        pkt: OutboundRaftPacket,
-        node_id: &NodeId,
+    /// Send a batch of outbound packets, grouping by target NodeId.
+    /// Encodes all messages per target into a single buffer, writes once.
+    async fn send(
+        &mut self,
+        packets: Vec<OutboundRaftPacket>,
         raft_tx: &mpsc::Sender<RaftCommand>,
         swim_tx: &mpsc::Sender<SwimCommand>,
-        writers: &mut HashMap<NodeId, RaftWriter>,
-        addr_cache: &mut HashMap<NodeId, SocketAddr>,
     ) {
-        let target_id = pkt.target.clone();
-        let wire_msg = WireRaftMessage {
-            shard_group_id: pkt.shard_group_id,
-            sender: node_id.clone(),
-            rpc: pkt.rpc,
-        };
-
-        if let Some(writer) = writers.get_mut(&target_id) {
-            if writer.write_message(&wire_msg).await.is_ok() {
-                return;
+        // Group by target — flush_dirty already groups, but be defensive.
+        let mut by_target: HashMap<NodeId, Vec<WireRaftMessage>> = HashMap::new();
+        for pkt in packets {
+            if self.dead_peers.contains(&pkt.target) {
+                continue;
             }
-            writers.remove(&target_id);
+            by_target
+                .entry(pkt.target)
+                .or_default()
+                .push(WireRaftMessage {
+                    shard_group_id: pkt.shard_group_id,
+                    sender: self.node_id.clone(),
+                    rpc: pkt.rpc,
+                });
         }
 
-        let Some(target_addr) = Self::resolve_address(&target_id, swim_tx, addr_cache).await else {
-            tracing::warn!("Cannot resolve address for {:?}", target_id);
-            return;
-        };
+        for (target_id, msgs) in by_target {
+            // Try existing writer
+            if let Some(writer) = self.writers.get_mut(&target_id) {
+                if Self::write_messages(writer, &msgs).await.is_ok() {
+                    continue;
+                }
+                self.writers.remove(&target_id);
+            }
 
-        let Ok(stream) = TcpStream::connect(target_addr).await else {
-            tracing::warn!("Failed to connect to {} ({:?})", target_addr, target_id);
-            return;
-        };
+            // Establish new connection
+            let Some(target_addr) = self.resolve_address(&target_id, swim_tx).await else {
+                tracing::warn!("Cannot resolve address for {:?}", target_id);
+                continue;
+            };
 
-        let (read_half, write_half) = stream.into_split();
-        let mut writer = RaftWriter(write_half);
+            let Ok(stream) = TcpStream::connect(target_addr).await else {
+                tracing::warn!("Failed to connect to {} ({:?})", target_addr, target_id);
+                continue;
+            };
 
-        if writer.write_node_id(node_id).await.is_err() {
-            return;
+            let (read_half, write_half) = stream.into_split();
+            let mut writer = write_half;
+
+            if Self::write_node_id(&mut writer, &self.node_id)
+                .await
+                .is_err()
+            {
+                continue;
+            }
+
+            tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
+
+            if Self::write_messages(&mut writer, &msgs).await.is_err() {
+                continue;
+            }
+            self.writers.insert(target_id, writer);
         }
+    }
 
-        tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
-        if writer.write_message(&wire_msg).await.is_err() {
-            return;
-        }
-        writers.insert(target_id, writer);
+    fn disconnect(&mut self, peer_id: NodeId) {
+        self.writers.remove(&peer_id);
+        self.addr_cache.remove(&peer_id);
+        tracing::info!("[{}] Disconnected dead peer {:?}", self.node_id, peer_id);
+        self.dead_peers.insert(peer_id);
+    }
+
+    fn cleanup_dead_peers(&mut self) {
+        self.dead_peers.clear();
     }
 
     async fn resolve_address(
+        &mut self,
         node_id: &NodeId,
         swim_tx: &mpsc::Sender<SwimCommand>,
-        addr_cache: &mut HashMap<NodeId, SocketAddr>,
     ) -> Option<SocketAddr> {
-        if let Some(&addr) = addr_cache.get(node_id) {
+        if let Some(&addr) = self.addr_cache.get(node_id) {
             return Some(addr);
         }
 
@@ -226,10 +190,76 @@ impl RaftTransportActor {
         }
 
         if let Ok(Some(addr)) = rx.await {
-            addr_cache.insert(node_id.clone(), addr);
+            self.addr_cache.insert(node_id.clone(), addr);
             Some(addr)
         } else {
             None
+        }
+    }
+
+    // --- Wire helpers ---
+
+    async fn write_node_id(writer: &mut OwnedWriteHalf, node_id: &NodeId) -> std::io::Result<()> {
+        let bytes = bincode::encode_to_vec(node_id, BINCODE_CONFIG)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let len = bytes.len() as u32;
+        writer.write_all(&len.to_be_bytes()).await?;
+        writer.write_all(&bytes).await?;
+        Ok(())
+    }
+
+    /// Encode all messages into a single buffer, write once.
+    async fn write_messages(
+        writer: &mut OwnedWriteHalf,
+        msgs: &[WireRaftMessage],
+    ) -> std::io::Result<()> {
+        let mut buf = Vec::new();
+        for msg in msgs {
+            let bytes = bincode::encode_to_vec(msg, BINCODE_CONFIG)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            let len = bytes.len() as u32;
+            buf.extend_from_slice(&len.to_be_bytes());
+            buf.extend_from_slice(&bytes);
+        }
+        writer.write_all(&buf).await?;
+        Ok(())
+    }
+}
+
+/// Thin async boundary — select loop over listener and actor commands.
+pub struct RaftTransportActor;
+
+impl RaftTransportActor {
+    pub async fn run(
+        node_id: NodeId,
+        listener: TcpListener,
+        raft_tx: mpsc::Sender<RaftCommand>,
+        mut from_actor: mpsc::Receiver<RaftTransportCommand>,
+        swim_tx: mpsc::Sender<SwimCommand>,
+    ) {
+        let mut state = RaftWriters::new(node_id);
+        let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(300));
+        cleanup_interval.tick().await; // consume immediate first tick
+
+        loop {
+            tokio::select! {
+                Ok((stream, _)) = listener.accept() => {
+                    state.accept(stream, &raft_tx).await;
+                }
+                Some(cmd) = from_actor.recv() => {
+                    match cmd {
+                        RaftTransportCommand::Send(packets) => {
+                            state.send(packets, &raft_tx, &swim_tx).await;
+                        }
+                        RaftTransportCommand::DisconnectPeer(peer_id) => {
+                            state.disconnect(peer_id);
+                        }
+                    }
+                }
+                _ = cleanup_interval.tick() => {
+                    state.cleanup_dead_peers();
+                }
+            }
         }
     }
 }
@@ -262,10 +292,9 @@ mod tests {
         sim.host("client", || async {
             let addr = turmoil::lookup("server");
             let stream = TcpStream::connect((addr, 9000)).await?;
-            let (_, write_half) = stream.into_split();
-            let mut writer = RaftWriter(write_half);
+            let (_, mut write_half) = stream.into_split();
 
-            writer.write_node_id(&NodeId::new("node-abc")).await?;
+            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-abc")).await?;
             Ok(())
         });
 
@@ -300,11 +329,11 @@ mod tests {
         sim.host("client", || async {
             let addr = turmoil::lookup("server");
             let stream = TcpStream::connect((addr, 9000)).await?;
-            let (_, write_half) = stream.into_split();
-            let mut writer = RaftWriter(write_half);
+            let (_, mut write_half) = stream.into_split();
 
-            writer
-                .write_message(&WireRaftMessage {
+            RaftWriters::write_messages(
+                &mut write_half,
+                &[WireRaftMessage {
                     shard_group_id: ShardGroupId(42),
                     sender: NodeId::new("sender-1"),
                     rpc: RaftRpc::RequestVote(RequestVote {
@@ -313,8 +342,9 @@ mod tests {
                         last_log_index: 10,
                         last_log_term: 3,
                     }),
-                })
-                .await?;
+                }],
+            )
+            .await?;
             Ok(())
         });
 
@@ -330,14 +360,13 @@ mod tests {
         sim.host("acceptor", || async {
             let (raft_tx, _raft_rx) = mpsc::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
-            let mut writers: HashMap<NodeId, RaftWriter> = HashMap::new();
-            let node_id = NodeId::new("node-b");
+            let mut state = RaftWriters::new(NodeId::new("node-b"));
 
             let (stream, _) = listener.accept().await?;
-            RaftTransportActor::handle_accepted(stream, &node_id, &raft_tx, &mut writers).await;
+            state.accept(stream, &raft_tx).await;
 
             assert!(
-                writers.contains_key(&NodeId::new("node-a")),
+                state.writers.contains_key(&NodeId::new("node-a")),
                 "writer should be registered after handshake"
             );
             Ok(())
@@ -346,9 +375,8 @@ mod tests {
         sim.host("initiator", || async {
             let addr = turmoil::lookup("acceptor");
             let stream = TcpStream::connect((addr, 9000)).await?;
-            let (_, write_half) = stream.into_split();
-            let mut writer = RaftWriter(write_half);
-            writer.write_node_id(&NodeId::new("node-a")).await?;
+            let (_, mut write_half) = stream.into_split();
+            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-a")).await?;
             Ok(())
         });
 
@@ -369,13 +397,12 @@ mod tests {
             let (raft_tx, _raft_rx) = mpsc::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
             let dummy_listener = TcpListener::bind("0.0.0.0:9001").await?;
-            let mut writers: HashMap<NodeId, RaftWriter> = HashMap::new();
-            let node_id = NodeId::new("node-b");
+            let mut state = RaftWriters::new(NodeId::new("node-b"));
 
             // First connection from node-a
             let (stream, _) = listener.accept().await?;
-            RaftTransportActor::handle_accepted(stream, &node_id, &raft_tx, &mut writers).await;
-            assert!(writers.contains_key(&NodeId::new("node-a")));
+            state.accept(stream, &raft_tx).await;
+            assert!(state.writers.contains_key(&NodeId::new("node-a")));
 
             // Second connection from node-a (simulating simultaneous connect)
             let (stream2, _) = dummy_listener.accept().await?;
@@ -385,7 +412,8 @@ mod tests {
             assert_eq!(peer_id, NodeId::new("node-a"));
 
             // Conflict: node-a < node-b → incoming wins, replace
-            let should_drop = writers.contains_key(&peer_id) && peer_id > NodeId::new("node-b");
+            let should_drop =
+                state.writers.contains_key(&peer_id) && peer_id > NodeId::new("node-b");
             assert!(
                 !should_drop,
                 "lower NodeId's connection should NOT be dropped"
@@ -398,14 +426,12 @@ mod tests {
             let addr = turmoil::lookup("node-b");
 
             let stream1 = TcpStream::connect((addr, 9000)).await?;
-            let (_, write_half) = stream1.into_split();
-            let mut writer = RaftWriter(write_half);
-            writer.write_node_id(&NodeId::new("node-a")).await?;
+            let (_, mut write_half) = stream1.into_split();
+            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-a")).await?;
 
             let stream2 = TcpStream::connect((addr, 9001)).await?;
-            let (_, write_half2) = stream2.into_split();
-            let mut writer2 = RaftWriter(write_half2);
-            writer2.write_node_id(&NodeId::new("node-a")).await?;
+            let (_, mut write_half2) = stream2.into_split();
+            RaftWriters::write_node_id(&mut write_half2, &NodeId::new("node-a")).await?;
 
             Ok(())
         });

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -122,40 +122,55 @@ impl RaftWriters {
 
         for (target_id, msgs) in by_target {
             // Try existing writer
-            if let Some(writer) = self.writers.get_mut(&target_id) {
-                if Self::write_messages(writer, &msgs).await.is_ok() {
-                    continue;
-                }
-                self.writers.remove(&target_id);
-            }
-
-            // Establish new connection
-            let Some(target_addr) = self.resolve_address(&target_id, swim_tx).await else {
-                tracing::warn!("Cannot resolve address for {:?}", target_id);
-                continue;
-            };
-
-            let Ok(stream) = TcpStream::connect(target_addr).await else {
-                tracing::warn!("Failed to connect to {} ({:?})", target_addr, target_id);
-                continue;
-            };
-
-            let (read_half, write_half) = stream.into_split();
-            let mut writer = write_half;
-
-            if Self::write_node_id(&mut writer, &self.node_id)
-                .await
-                .is_err()
+            if self.writers.contains_key(&target_id)
+                && self.write_messages_to(&target_id, &msgs).await.is_ok()
             {
                 continue;
             }
 
-            tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
+            // Establish new connection
+            let Some(target_addr) = self.resolve_address(&target_id, swim_tx).await else {
+                tracing::warn!(
+                    "[{}] Cannot resolve address for {:?}",
+                    self.node_id,
+                    target_id
+                );
+                continue;
+            };
 
-            if Self::write_messages(&mut writer, &msgs).await.is_err() {
+            let Ok(stream) = TcpStream::connect(target_addr).await else {
+                tracing::warn!(
+                    "[{}] Failed to connect to {} ({:?})",
+                    self.node_id,
+                    target_addr,
+                    target_id
+                );
+                continue;
+            };
+
+            let (read_half, write_half) = stream.into_split();
+            self.writers.insert(target_id.clone(), write_half);
+
+            if let Err(e) = self.handshake(&target_id).await {
+                tracing::warn!(
+                    "[{}] Handshake with {:?} failed: {e}",
+                    self.node_id,
+                    target_id
+                );
                 continue;
             }
-            self.writers.insert(target_id, writer);
+
+            if let Err(e) = self.write_messages_to(&target_id, &msgs).await {
+                tracing::warn!(
+                    "[{}] Write {} msgs to {:?} failed: {e}",
+                    self.node_id,
+                    msgs.len(),
+                    target_id
+                );
+                continue;
+            }
+
+            tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
         }
     }
 
@@ -198,21 +213,37 @@ impl RaftWriters {
     }
 
     // --- Wire helpers ---
+    // On error, writer is removed from the map so subsequent calls reconnect.
 
-    async fn write_node_id(writer: &mut OwnedWriteHalf, node_id: &NodeId) -> std::io::Result<()> {
-        let bytes = bincode::encode_to_vec(node_id, BINCODE_CONFIG)
+    /// Send handshake (our NodeId) to a writer already in the map.
+    async fn handshake(&mut self, target: &NodeId) -> std::io::Result<()> {
+        let writer = self.writers.get_mut(target).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "no writer for target")
+        })?;
+        let bytes = bincode::encode_to_vec(&self.node_id, BINCODE_CONFIG)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
         let len = bytes.len() as u32;
-        writer.write_all(&len.to_be_bytes()).await?;
-        writer.write_all(&bytes).await?;
-        Ok(())
+        let result = async {
+            writer.write_all(&len.to_be_bytes()).await?;
+            writer.write_all(&bytes).await
+        }
+        .await;
+
+        if result.is_err() {
+            self.writers.remove(target);
+        }
+        result
     }
 
-    /// Encode all messages into a single buffer, write once.
-    async fn write_messages(
-        writer: &mut OwnedWriteHalf,
+    /// Encode all messages into a single buffer, write to target's connection.
+    async fn write_messages_to(
+        &mut self,
+        target: &NodeId,
         msgs: &[WireRaftMessage],
     ) -> std::io::Result<()> {
+        let writer = self.writers.get_mut(target).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotConnected, "no writer for target")
+        })?;
         let mut buf = Vec::new();
         for msg in msgs {
             let bytes = bincode::encode_to_vec(msg, BINCODE_CONFIG)
@@ -221,8 +252,11 @@ impl RaftWriters {
             buf.extend_from_slice(&len.to_be_bytes());
             buf.extend_from_slice(&bytes);
         }
-        writer.write_all(&buf).await?;
-        Ok(())
+        let result = writer.write_all(&buf).await;
+        if result.is_err() {
+            self.writers.remove(target);
+        }
+        result
     }
 }
 
@@ -272,6 +306,20 @@ mod tests {
     use std::time::Duration;
     use turmoil::Builder;
 
+    /// Write a length-prefixed bincode-encoded value to a raw write half.
+    /// Used by tests to simulate the peer side of the wire protocol.
+    async fn write_frame(
+        writer: &mut OwnedWriteHalf,
+        value: &impl bincode::Encode,
+    ) -> std::io::Result<()> {
+        let bytes = bincode::encode_to_vec(value, BINCODE_CONFIG)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let len = bytes.len() as u32;
+        writer.write_all(&len.to_be_bytes()).await?;
+        writer.write_all(&bytes).await?;
+        Ok(())
+    }
+
     #[test]
     fn handshake_write_then_read_node_id() -> turmoil::Result {
         let mut sim = Builder::new()
@@ -294,7 +342,7 @@ mod tests {
             let stream = TcpStream::connect((addr, 9000)).await?;
             let (_, mut write_half) = stream.into_split();
 
-            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-abc")).await?;
+            write_frame(&mut write_half, &NodeId::new("node-abc")).await?;
             Ok(())
         });
 
@@ -331,9 +379,9 @@ mod tests {
             let stream = TcpStream::connect((addr, 9000)).await?;
             let (_, mut write_half) = stream.into_split();
 
-            RaftWriters::write_messages(
+            write_frame(
                 &mut write_half,
-                &[WireRaftMessage {
+                &WireRaftMessage {
                     shard_group_id: ShardGroupId(42),
                     sender: NodeId::new("sender-1"),
                     rpc: RaftRpc::RequestVote(RequestVote {
@@ -342,7 +390,7 @@ mod tests {
                         last_log_index: 10,
                         last_log_term: 3,
                     }),
-                }],
+                },
             )
             .await?;
             Ok(())
@@ -376,7 +424,7 @@ mod tests {
             let addr = turmoil::lookup("acceptor");
             let stream = TcpStream::connect((addr, 9000)).await?;
             let (_, mut write_half) = stream.into_split();
-            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-a")).await?;
+            write_frame(&mut write_half, &NodeId::new("node-a")).await?;
             Ok(())
         });
 
@@ -427,11 +475,11 @@ mod tests {
 
             let stream1 = TcpStream::connect((addr, 9000)).await?;
             let (_, mut write_half) = stream1.into_split();
-            RaftWriters::write_node_id(&mut write_half, &NodeId::new("node-a")).await?;
+            write_frame(&mut write_half, &NodeId::new("node-a")).await?;
 
             let stream2 = TcpStream::connect((addr, 9001)).await?;
             let (_, mut write_half2) = stream2.into_split();
-            RaftWriters::write_node_id(&mut write_half2, &NodeId::new("node-a")).await?;
+            write_frame(&mut write_half2, &NodeId::new("node-a")).await?;
 
             Ok(())
         });

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -23,18 +23,14 @@ impl SwimActor {
         tracing::info!("[{}] SwimActor started.", state.node_id);
         Self::flush(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
 
-        while let Some(event) = mailbox.recv().await {
-            match event {
-                SwimCommand::PacketReceived { src, packet } => {
-                    state.step(src, packet);
-                }
-
-                SwimCommand::Timeout(tick_event) => {
-                    state.handle_timeout(tick_event);
-                }
-                SwimCommand::Query(command) => state.handle_query(command),
+        let mut buf = Vec::with_capacity(64);
+        loop {
+            if mailbox.recv_many(&mut buf, 64).await == 0 {
+                break;
             }
-
+            for event in buf.drain(..) {
+                state.process(event);
+            }
             Self::flush(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
         }
     }

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -144,7 +144,7 @@ impl Swim {
     // -----------------------------------------------------------------------
     // Core protocol logic
     // -----------------------------------------------------------------------
-    pub(crate) fn handle_timeout(&mut self, event: SwimTimeOutCallback) {
+    pub(super) fn handle_timeout(&mut self, event: SwimTimeOutCallback) {
         match event {
             SwimTimeOutCallback::ProtocolPeriodElapsed => self.start_probe(),
             SwimTimeOutCallback::TimedOut {
@@ -176,7 +176,7 @@ impl Swim {
         }
     }
 
-    pub(crate) fn handle_query(&self, command: SwimQueryCommand) {
+    pub(super) fn handle_query(&self, command: SwimQueryCommand) {
         match command {
             SwimQueryCommand::GetMembers { reply } => {
                 let _ = reply.send(self.members.values().cloned().collect());
@@ -300,8 +300,15 @@ impl Swim {
             );
         }
     }
+    pub fn process(&mut self, event: SwimCommand) {
+        match event {
+            SwimCommand::PacketReceived { src, packet } => self.step(src, packet),
+            SwimCommand::Timeout(tick_event) => self.handle_timeout(tick_event),
+            SwimCommand::Query(command) => self.handle_query(command),
+        }
+    }
 
-    pub fn step(&mut self, src: SocketAddr, packet: SwimPacket) {
+    pub(super) fn step(&mut self, src: SocketAddr, packet: SwimPacket) {
         // 1. Process Gossip (Piggybacked updates)
         for member in packet.gossip() {
             self.apply_membership_update(member.clone());


### PR DESCRIPTION
## Summary

Closes #48.

With 256 vnodes per physical node, each node participates in hundreds of shard groups. Before this change, every shard group flushed outbound RPCs independently — hundreds of channel sends and TCP syscalls per tick, all targeting the same 2 peer connections.

**Before (per heartbeat tick, 3-node cluster):**
- Hundreds of flush cycles (`tokio::join!`)
- Hundreds of channel sends (one per outbound packet)
- 2× that in TCP `write_all` syscalls (length prefix + payload)

**After:**
- 1 `recv_many` call, 1 `tokio::join!`
- 2 channel sends (one per physical peer)
- 2 TCP `write_all` syscalls (one batched buffer per peer)

## Changes

### `RaftGroups` struct (extracted from `RaftActor`)
Encapsulates group lifecycle, dirty tracking, timer seq namespacing. `flush_dirty` collects outbound across all dirty shard groups, aggregates by target `NodeId` — hundreds of groups collapse into 2 channel sends.

### `RaftWriters` struct (extracted from `RaftTransportActor`)
Encapsulates peer connections (`HashMap<NodeId, OwnedWriteHalf>`), address cache, dead-peer tracking. `write_messages_to` encodes all messages into a single buffer per peer — one `write_all` syscall instead of hundreds. Reader spawned only after successful handshake + write (no orphaned tasks). Eliminated `RaftWriter` newtype.

### `recv_many` batching (both actors)
SwimActor and RaftActor use `recv_many(&mut buf, 64)` instead of `recv()` + per-message flush. Under burst load, N messages = 1 flush.

### `Swim::process()` method
Sync command dispatch moved onto state machine. Actor calls `state.process(event)` directly.

### `RaftTransportCommand::Send` simplified
`Send(OutboundRaftPacket)` → `Send(Vec<OutboundRaftPacket>)`. Single variant, no redundant `SendBatch`.

### Skill docs updated
`build-actor` SKILL.md reflects drain-then-flush pattern, `Groups` struct pattern for multiplexing actors.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All 150 tests pass (unit + turmoil integration)
- [x] Manual verification with multi-node cluster

