### PR TITLE
feat: apply shard leader state from gossip to local topology

### DIFF
--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -11,12 +11,13 @@ use super::timer::SwimTimer;
 /// Internal Events (Actor Logic)
 #[derive(Debug)]
 pub enum SwimCommand {
-    // From Transport
+    // From Transport(External)
     PacketReceived { src: SocketAddr, packet: SwimPacket },
-    // From Ticker
+    // From Ticker(Internal)
     Timeout(SwimTimeOutCallback),
+    // From API (e.g., HTTP API)
     Query(SwimQueryCommand),
-    // From MultiRaftActor — leader election completed for a shard group
+    // From MultiRaftActor(Internal) — leader election completed for a shard group
     AnnounceShardLeader(LeaderChange),
 }
 

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -325,16 +325,13 @@ impl Swim {
                     event.term
                 );
 
-                // ? any possibility that members not found while shard leadership changed?
-                if let Some(addr) = self.members.get(&event.leader_node_id).map(|m| m.addr) {
-                    let info = ShardLeaderInfo {
-                        shard_group_id: event.shard_group_id,
-                        leader_node_id: event.leader_node_id.clone(),
-                        leader_addr: addr,
-                        term: event.term,
-                    };
-                    self.apply_shard_leader_update(&info);
-                }
+                let info = ShardLeaderInfo {
+                    shard_group_id: event.shard_group_id,
+                    leader_node_id: event.leader_node_id,
+                    leader_addr: self.advertise_addr,
+                    term: event.term,
+                };
+                self.apply_shard_leader_update(&info);
             }
         }
     }
@@ -1441,7 +1438,7 @@ mod tests {
             h.protocol
                 .process(SwimCommand::AnnounceShardLeader(LeaderChange {
                     shard_group_id: ShardGroupId(42),
-                    leader_node_id: NodeId::new("node-b"),
+                    leader_node_id: NodeId::new("node-local"),
                     term: 1,
                 }));
 
@@ -1635,13 +1632,12 @@ mod tests {
         #[test]
         fn announce_leader_updates_topology() {
             let mut h = TestHarness::new("node-local", 8000);
-            let b_addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-            add_node_harness(&mut h, "node-b", b_addr, 1);
+            let local_addr: SocketAddr = "127.0.0.1:8000".parse().unwrap();
 
             h.protocol
                 .process(SwimCommand::AnnounceShardLeader(LeaderChange {
                     shard_group_id: ShardGroupId(42),
-                    leader_node_id: NodeId::new("node-b"),
+                    leader_node_id: NodeId::new("node-local"),
                     term: 1,
                 }));
             let _ = h.protocol.take_events();
@@ -1649,8 +1645,8 @@ mod tests {
             let entry = h.protocol.topology.shard_leader(ShardGroupId(42));
             assert!(entry.is_some(), "topology should have shard leader entry");
             let entry = entry.unwrap();
-            assert_eq!(entry.leader_node_id, NodeId::new("node-b"));
-            assert_eq!(entry.leader_addr, b_addr);
+            assert_eq!(entry.leader_node_id, NodeId::new("node-local"));
+            assert_eq!(entry.leader_addr, local_addr);
             assert_eq!(entry.term, 1);
         }
 

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -344,8 +344,12 @@ impl Swim {
         for member in packet.gossip() {
             self.apply_membership_update(member.clone());
         }
+
+        // Piggybacked shard leader gossip — typically few entries per packet (often zero).
+        // Count bounded by remaining byte budget after membership gossip and
+        // dissemination counter (3 × ceil(log₂(N)) retransmissions per entry).
         for leader_info in packet.shard_leaders() {
-            self.apply_shard_leader_update(&leader_info);
+            self.apply_shard_leader_update(leader_info);
         }
 
         match packet {
@@ -609,7 +613,7 @@ impl Swim {
     }
 
     fn apply_shard_leader_update(&mut self, info: &ShardLeaderInfo) {
-        if !self.topology.update_shard_leader(&info) {
+        if !self.topology.update_shard_leader(info) {
             return;
         }
         self.shard_leader_buffer

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -63,7 +63,6 @@ pub struct Swim {
     live_node_tracker: LiveNodeTracker,
     gossip_buffer: SwimBuffer,
     shard_leader_buffer: ShardLeaderGossipBuffer,
-    shard_leaders: BTreeMap<ShardGroupId, (NodeId, u64)>,
     pub(crate) topology: Topology,
 
     // Sequence
@@ -91,7 +90,6 @@ impl Swim {
             live_node_tracker: LiveNodeTracker::new(rng_seed),
             gossip_buffer: SwimBuffer::default(),
             shard_leader_buffer: ShardLeaderGossipBuffer::default(),
-            shard_leaders: BTreeMap::new(),
             seq_counter: 0,
             last_suspected_seqs: BTreeMap::new(),
             pending_events: Vec::new(),
@@ -326,6 +324,8 @@ impl Swim {
                     event.leader_node_id,
                     event.term
                 );
+
+                // ? any possibility that members not found while shard leadership changed?
                 if let Some(addr) = self.members.get(&event.leader_node_id).map(|m| m.addr) {
                     let info = ShardLeaderInfo {
                         shard_group_id: event.shard_group_id,
@@ -333,9 +333,7 @@ impl Swim {
                         leader_addr: addr,
                         term: event.term,
                     };
-                    self.shard_leader_buffer.enqueue(info, self.members.len());
-                    self.shard_leaders
-                        .insert(event.shard_group_id, (event.leader_node_id, event.term));
+                    self.apply_shard_leader_update(&info);
                 }
             }
         }
@@ -347,7 +345,7 @@ impl Swim {
             self.apply_membership_update(member.clone());
         }
         for leader_info in packet.shard_leaders() {
-            self.apply_shard_leader_update(leader_info.clone());
+            self.apply_shard_leader_update(&leader_info);
         }
 
         match packet {
@@ -610,19 +608,12 @@ impl Swim {
         }
     }
 
-    fn apply_shard_leader_update(&mut self, info: ShardLeaderInfo) {
-        let dominated = match self.shard_leaders.get(&info.shard_group_id) {
-            Some(&(_, existing_term)) => info.term <= existing_term,
-            None => false,
-        };
-        if dominated {
+    fn apply_shard_leader_update(&mut self, info: &ShardLeaderInfo) {
+        if !self.topology.update_shard_leader(&info) {
             return;
         }
-        self.shard_leaders.insert(
-            info.shard_group_id,
-            (info.leader_node_id.clone(), info.term),
-        );
-        self.shard_leader_buffer.enqueue(info, self.members.len());
+        self.shard_leader_buffer
+            .enqueue(info.clone(), self.members.len());
     }
 
     fn next_seq(&mut self) -> u32 {
@@ -1497,14 +1488,11 @@ mod tests {
             h.step(b_addr, SwimPacket::Ping(header));
             let _ = h.protocol.take_packets();
 
-            let entry = h.protocol.shard_leaders.get(&ShardGroupId(42));
-            assert!(
-                entry.is_some(),
-                "Local shard_leaders table should have entry"
-            );
-            let (leader, term) = entry.unwrap();
-            assert_eq!(*leader, NodeId::new("node-b"));
-            assert_eq!(*term, 3);
+            let entry = h.protocol.topology.shard_leader(ShardGroupId(42));
+            assert!(entry.is_some(), "Topology should have shard leader entry");
+            let entry = entry.unwrap();
+            assert_eq!(entry.leader_node_id, NodeId::new("node-b"));
+            assert_eq!(entry.term, 3);
         }
 
         #[test]
@@ -1583,13 +1571,13 @@ mod tests {
             h.step(b_addr, SwimPacket::Ping(header2));
             let _ = h.protocol.take_packets();
 
-            let (leader, term) = h.protocol.shard_leaders.get(&ShardGroupId(42)).unwrap();
+            let entry = h.protocol.topology.shard_leader(ShardGroupId(42)).unwrap();
             assert_eq!(
-                *leader,
+                entry.leader_node_id,
                 NodeId::new("node-b"),
                 "Leader should not be overwritten by stale info"
             );
-            assert_eq!(*term, 5);
+            assert_eq!(entry.term, 5);
         }
 
         #[test]
@@ -1632,12 +1620,62 @@ mod tests {
                 b.step(a_addr, pkt.packet().clone());
                 let _ = b.take_events();
 
-                let entry = b.shard_leaders.get(&ShardGroupId(42));
+                let entry = b.topology.shard_leader(ShardGroupId(42));
                 assert!(entry.is_some(), "B should learn about group 42 leader");
-                let (leader, term) = entry.unwrap();
-                assert_eq!(*leader, NodeId::new("node-a"));
-                assert_eq!(*term, 1);
+                let entry = entry.unwrap();
+                assert_eq!(entry.leader_node_id, NodeId::new("node-a"));
+                assert_eq!(entry.term, 1);
             }
+        }
+
+        #[test]
+        fn announce_leader_updates_topology() {
+            let mut h = TestHarness::new("node-local", 8000);
+            let b_addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+            add_node_harness(&mut h, "node-b", b_addr, 1);
+
+            h.protocol
+                .process(SwimCommand::AnnounceShardLeader(LeaderChange {
+                    shard_group_id: ShardGroupId(42),
+                    leader_node_id: NodeId::new("node-b"),
+                    term: 1,
+                }));
+            let _ = h.protocol.take_events();
+
+            let entry = h.protocol.topology.shard_leader(ShardGroupId(42));
+            assert!(entry.is_some(), "topology should have shard leader entry");
+            let entry = entry.unwrap();
+            assert_eq!(entry.leader_node_id, NodeId::new("node-b"));
+            assert_eq!(entry.leader_addr, b_addr);
+            assert_eq!(entry.term, 1);
+        }
+
+        #[test]
+        fn receive_leader_gossip_updates_topology() {
+            let mut h = TestHarness::new("node-local", 8000);
+            let b_addr: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+            add_node_harness(&mut h, "node-b", b_addr, 1);
+
+            let header = SwimHeader {
+                seq: 1,
+                source_node_id: NodeId::new("node-b"),
+                source_incarnation: 1,
+                gossip: vec![],
+                shard_leaders: vec![ShardLeaderInfo {
+                    shard_group_id: ShardGroupId(99),
+                    leader_node_id: NodeId::new("node-b"),
+                    leader_addr: b_addr,
+                    term: 7,
+                }],
+            };
+            h.step(b_addr, SwimPacket::Ping(header));
+            let _ = h.protocol.take_events();
+
+            let entry = h.protocol.topology.shard_leader(ShardGroupId(99));
+            assert!(entry.is_some(), "topology should have received leader info");
+            let entry = entry.unwrap();
+            assert_eq!(entry.leader_node_id, NodeId::new("node-b"));
+            assert_eq!(entry.term, 7);
         }
     }
 }

--- a/src/clusters/swims/topology.rs
+++ b/src/clusters/swims/topology.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 
 use bincode::{Decode, Encode};
 
+use crate::clusters::swims::messages::dissemination_buffer::ShardLeaderInfo;
 use crate::clusters::{NodeId, SwimNodeState};
 
 /// Deterministic identifier for a shard group, derived from the hash of the first
@@ -43,6 +44,14 @@ pub struct VirtualNode {
     pnode_metadata: PhysicalNodeMetadata,
 }
 
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ShardLeaderEntry {
+    pub leader_node_id: NodeId,
+    pub leader_addr: SocketAddr,
+    pub term: u64,
+}
+
 #[derive(Clone, Debug)]
 pub struct Topology {
     config: TopologyConfig,
@@ -51,6 +60,9 @@ pub struct Topology {
     /// Reverse index: for each physical node, the set of shard groups it participates in.
     /// Rebuilt after every ring mutation. Makes `shard_groups_for_node()` O(1).
     node_groups: HashMap<NodeId, HashMap<ShardGroupId, ShardGroup>>,
+    /// Shard leader map: tracks current leader for each shard group.
+    /// NOT auto-cleared on node death — Raft re-election gossips new leader with higher term.
+    shard_leaders: HashMap<ShardGroupId, ShardLeaderEntry>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -135,6 +147,7 @@ impl Topology {
             config,
             ring: token_ring,
             node_groups: HashMap::new(),
+            shard_leaders: HashMap::new(),
         };
         topology.rebuild_reverse_index();
         topology
@@ -231,6 +244,33 @@ impl Topology {
     #[expect(dead_code)]
     pub fn num_nodes(&self) -> usize {
         self.ring.pnodes.len()
+    }
+
+    pub fn update_shard_leader(&mut self, info: &ShardLeaderInfo) -> bool {
+        if let Some(existing) = self.shard_leaders.get(&info.shard_group_id)
+            && info.term <= existing.term
+        {
+            return false;
+        }
+        self.shard_leaders.insert(
+            info.shard_group_id,
+            ShardLeaderEntry {
+                leader_node_id: info.leader_node_id.clone(),
+                leader_addr: info.leader_addr,
+                term: info.term,
+            },
+        );
+        true
+    }
+
+    #[allow(dead_code)]
+    pub fn shard_leader(&self, shard_group_id: ShardGroupId) -> Option<&ShardLeaderEntry> {
+        self.shard_leaders.get(&shard_group_id)
+    }
+
+    #[allow(dead_code)]
+    pub fn all_shard_leaders(&self) -> &HashMap<ShardGroupId, ShardLeaderEntry> {
+        &self.shard_leaders
     }
 }
 
@@ -648,5 +688,175 @@ mod tests {
         topology.remove_node(&NodeId::new("node-0"));
         let groups = topology.shard_groups_for_node(&NodeId::new("node-0"));
         assert!(groups.is_empty());
+    }
+
+    // --- shard leader map tests ---
+
+    #[test]
+    fn update_shard_leader_inserts_new_entry() {
+        let mut topology = topology_from(
+            &[("node-0", "127.0.0.1:8080")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 1,
+            },
+        );
+
+        let info = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 1,
+        };
+        assert!(topology.update_shard_leader(&info));
+
+        let entry = topology.shard_leader(ShardGroupId(42)).unwrap();
+        assert_eq!(entry.leader_node_id, NodeId::new("node-0"));
+        assert_eq!(entry.term, 1);
+    }
+
+    #[test]
+    fn update_shard_leader_higher_term_replaces() {
+        let mut topology = topology_from(
+            &[("node-0", "127.0.0.1:8080")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 1,
+            },
+        );
+
+        let info1 = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 1,
+        };
+        topology.update_shard_leader(&info1);
+
+        let info2 = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-1"),
+            leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            term: 3,
+        };
+        assert!(topology.update_shard_leader(&info2));
+
+        let entry = topology.shard_leader(ShardGroupId(42)).unwrap();
+        assert_eq!(entry.leader_node_id, NodeId::new("node-1"));
+        assert_eq!(entry.term, 3);
+    }
+
+    #[test]
+    fn update_shard_leader_stale_term_rejected() {
+        let mut topology = topology_from(
+            &[("node-0", "127.0.0.1:8080")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 1,
+            },
+        );
+
+        let info1 = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 5,
+        };
+        topology.update_shard_leader(&info1);
+
+        let stale = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-1"),
+            leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            term: 2,
+        };
+        assert!(!topology.update_shard_leader(&stale));
+
+        let equal = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-1"),
+            leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            term: 5,
+        };
+        assert!(!topology.update_shard_leader(&equal));
+
+        let entry = topology.shard_leader(ShardGroupId(42)).unwrap();
+        assert_eq!(entry.leader_node_id, NodeId::new("node-0"));
+        assert_eq!(entry.term, 5);
+    }
+
+    #[test]
+    fn shard_leader_survives_node_death() {
+        let mut topology = topology_from(
+            &[("node-0", "127.0.0.1:8080"), ("node-1", "127.0.0.1:8081")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 2,
+            },
+        );
+
+        let info = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(42),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 1,
+        };
+        topology.update_shard_leader(&info);
+
+        topology.update(
+            NodeId::new("node-0"),
+            "127.0.0.1:8080".parse().unwrap(),
+            &SwimNodeState::Dead,
+        );
+
+        let entry = topology.shard_leader(ShardGroupId(42));
+        assert!(
+            entry.is_some(),
+            "shard leader entry must survive node death"
+        );
+        assert_eq!(entry.unwrap().leader_node_id, NodeId::new("node-0"));
+    }
+
+    #[test]
+    fn shard_leader_returns_none_for_unknown_group() {
+        let topology = topology_from(
+            &[("node-0", "127.0.0.1:8080")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 1,
+            },
+        );
+        assert!(topology.shard_leader(ShardGroupId(999)).is_none());
+    }
+
+    #[test]
+    fn all_shard_leaders_returns_full_map() {
+        let mut topology = topology_from(
+            &[("node-0", "127.0.0.1:8080")],
+            TopologyConfig {
+                vnodes_per_pnode: 4,
+                replication_factor: 1,
+            },
+        );
+
+        let info1 = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(10),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 1,
+        };
+        let info2 = ShardLeaderInfo {
+            shard_group_id: ShardGroupId(20),
+            leader_node_id: NodeId::new("node-0"),
+            leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            term: 2,
+        };
+        topology.update_shard_leader(&info1);
+        topology.update_shard_leader(&info2);
+
+        let leaders = topology.all_shard_leaders();
+        assert_eq!(leaders.len(), 2);
+        assert!(leaders.contains_key(&ShardGroupId(10)));
+        assert!(leaders.contains_key(&ShardGroupId(20)));
     }
 }


### PR DESCRIPTION
## Summary
Closes #36

- Add `ShardLeaderEntry` and shard-leader map (`HashMap<ShardGroupId, ShardLeaderEntry>`) to `Topology`, with `update_shard_leader()` (term-gated) and `shard_leader()` query methods
- Wire `Swim::apply_shard_leader_update()` to update topology — topology is now the single source of truth for shard leader state
- Remove redundant `Swim.shard_leaders: BTreeMap` — stale rejection delegated to `Topology::update_shard_leader()`
- Simplify `AnnounceShardLeader` handler: use `advertise_addr` directly (leader is always local node)
- Document `SwimCommand` variant sources (External vs Internal)

## Design Decisions
- **No `GetShardLeader` query variant** — no production caller exists yet; topology is accessible internally when needed
- **No auto-removal on node death** — Raft re-election handles stale leaders by gossiping new `ShardLeaderEvent` with higher term
- **`SwimQueryCommand::GetShardLeader` deferred** — will add when an external component (e.g., proxy routing) needs it

## Files Changed
- `src/clusters/swims/topology.rs` — `ShardLeaderEntry`, shard-leader map, update/query methods, 6 new tests
- `src/clusters/swims/swim.rs` — wire topology update, simplify announce handler, 2 new integration tests
- `src/clusters/swims/messages/command.rs` — document variant sources

## Test Plan
- [x] `Topology::update_shard_leader` — insert, higher term replaces, stale/equal term rejected
- [x] Shard leader survives node death (not auto-removed)
- [x] `AnnounceShardLeader` updates topology with `advertise_addr`
- [x] Gossip-received leader info updates topology
- [x] Stale leader gossip rejected end-to-end
- [x] Two-node leader propagation via gossip
- [x] All 76 swims tests pass, clippy clean