### PR TITLE
Implement storage layer(4/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 .idea
 .serena
+.claude/worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +130,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +175,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -193,6 +253,7 @@ dependencies = [
  "clap",
  "murmur3",
  "rand 0.10.1",
+ "rocksdb",
  "serial_test",
  "tempfile",
  "thiserror",
@@ -202,6 +263,12 @@ dependencies = [
  "turmoil",
  "uuid",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -224,6 +291,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -293,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,10 +417,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -372,10 +470,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -399,6 +533,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +556,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -429,6 +579,16 @@ name = "murmur3"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -489,6 +649,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "ppv-lite86"
@@ -599,6 +765,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +792,22 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -743,6 +937,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -981,6 +1181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,3 +1423,13 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ murmur3 = "0.5"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 thiserror = "2.0.18"
+rocksdb = "0.24.0"
 
 
 [lints.rust]

--- a/diagrams/metadata-management/storage-key-layout.md
+++ b/diagrams/metadata-management/storage-key-layout.md
@@ -1,0 +1,94 @@
+# Storage Key Layout
+
+## Overview
+
+All shard groups share a single RocksDB default column family. Each key is prefixed with the shard group ID to isolate groups within the same keyspace.
+
+## Key Structure
+
+```
+[group_id: 8 bytes BE][key_type: 1 byte][optional index: 8 bytes BE]
+```
+
+| Key Type | Prefix | Suffix | Total Size | Description |
+|----------|--------|--------|------------|-------------|
+| LogEntry | 0x01 | u64 BE index | 17 bytes | Raft log entry at 1-based index |
+| HardState | 0x02 | none | 9 bytes | Durable Raft state (term, voted_for) |
+| SnapMeta | 0x03 | none | 9 bytes | Snapshot descriptor (reserved) |
+| SnapData | 0x04 | none | 9 bytes | State machine payload (reserved) |
+| AppliedIndex | 0x05 | none | 9 bytes | Last applied log index (reserved) |
+| Epoch | 0x06 | none | 9 bytes | Shard membership version (reserved) |
+
+Within each group, log entries (0x01) sort before metadata keys (0x02-0x06).
+
+## Concrete Example: 3 Shard Groups
+
+```
+Group 1 (0x0000000000000001):
+  00 00 00 00 00 00 00 01 | 01 | 00 00 00 00 00 00 00 01  -> LogEntry(1)
+  00 00 00 00 00 00 00 01 | 01 | 00 00 00 00 00 00 00 02  -> LogEntry(2)
+  00 00 00 00 00 00 00 01 | 01 | 00 00 00 00 00 00 00 03  -> LogEntry(3)
+  00 00 00 00 00 00 00 01 | 02 |                           -> HardState
+
+Group 7 (0x0000000000000007):
+  00 00 00 00 00 00 00 07 | 01 | 00 00 00 00 00 00 00 01  -> LogEntry(1)
+  00 00 00 00 00 00 00 07 | 02 |                           -> HardState
+
+Group 42 (0x000000000000002A):
+  00 00 00 00 00 00 00 2A | 01 | 00 00 00 00 00 00 00 01  -> LogEntry(1)
+  00 00 00 00 00 00 00 2A | 02 |                           -> HardState
+```
+
+## Why Big-Endian
+
+RocksDB sorts keys lexicographically (byte-by-byte). Big-endian encoding makes lexicographic order match numeric order:
+
+- All keys for group 1 cluster together
+- All keys for group 7 come after group 1
+- Within each group, log entries sort before metadata
+- Within log entries, index 1 sorts before index 2
+
+## Access Patterns
+
+### Fetch All Log Entries for a Group
+
+Prefix-bounded range scan:
+
+```
+start = [group_id][0x01][0x0000000000000000]
+end   = [group_id][0x02]                      (exclusive upper bound)
+```
+
+RocksDB iterator reads only that group's log entries sequentially. `set_iterate_upper_bound` tells RocksDB to skip SST blocks past the bound. No wasted I/O on other groups.
+
+### Point Lookup (e.g., HardState)
+
+```
+key = [group_id][0x02]
+```
+
+Direct `db.get(key)`. O(log N) in the SST block index.
+
+### Log Truncation (TruncateFrom)
+
+Delete entries from a given index onward:
+
+```
+start = [group_id][0x01][from_index]
+end   = [group_id][0x02]              (exclusive — preserves HardState)
+```
+
+### Delete Entire Group
+
+```
+start = [group_id]
+end   = [group_id + 1]               (exclusive — preserves next group)
+```
+
+Removes all keys (log entries + metadata) for that group.
+
+## Design Rationale
+
+Previous design used one RocksDB column family per shard group. With 768 groups (256 vnodes x 3 nodes), each `create_cf` call fsyncs the MANIFEST file (~230ms on macOS APFS), totaling ~177 seconds at startup.
+
+Single CF with composite keys eliminates CF creation entirely. Trade-off: iterator index is shared across groups, but block index lookup is O(log N) — negligible overhead.

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -3,9 +3,9 @@
 use std::collections::HashMap;
 
 use crate::clusters::NodeId;
-use crate::storage::Db;
 use crate::clusters::raft::messages::*;
 use crate::clusters::raft::multi_raft::MultiRaft;
+use crate::clusters::raft::storage::RaftStorage;
 use crate::clusters::swims::SwimCommand;
 use crate::schedulers::ticker_message::TickerCommand;
 
@@ -17,13 +17,13 @@ pub struct MultiRaftActor;
 impl MultiRaftActor {
     pub async fn run(
         node_id: NodeId,
-        db: Db,
+        storage: Box<dyn RaftStorage>,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
         swim_tx: mpsc::Sender<SwimCommand>,
     ) {
-        let mut store = MultiRaft::new(node_id, db);
+        let mut store = MultiRaft::new(node_id, storage);
         let mut buf = Vec::with_capacity(64);
         let mut deferred: Vec<Box<dyn FnOnce() + Send>> = Vec::with_capacity(64);
 

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::clusters::NodeId;
-use crate::storage::RaftDb;
+use crate::storage::Db;
 use crate::clusters::raft::messages::*;
 use crate::clusters::raft::multi_raft::MultiRaft;
 use crate::clusters::swims::SwimCommand;
@@ -17,7 +17,7 @@ pub struct MultiRaftActor;
 impl MultiRaftActor {
     pub async fn run(
         node_id: NodeId,
-        db: RaftDb,
+        db: Db,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use crate::clusters::NodeId;
+use crate::storage::RaftDb;
 use crate::clusters::raft::messages::*;
 use crate::clusters::raft::multi_raft::MultiRaft;
 use crate::clusters::swims::SwimCommand;
@@ -16,12 +17,13 @@ pub struct MultiRaftActor;
 impl MultiRaftActor {
     pub async fn run(
         node_id: NodeId,
+        db: RaftDb,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
         swim_tx: mpsc::Sender<SwimCommand>,
     ) {
-        let mut store = MultiRaft::new(node_id);
+        let mut store = MultiRaft::new(node_id, db);
         let mut buf = Vec::with_capacity(64);
         let mut deferred: Vec<Box<dyn FnOnce() + Send>> = Vec::with_capacity(64);
 

--- a/src/clusters/raft/messages/event.rs
+++ b/src/clusters/raft/messages/event.rs
@@ -18,7 +18,11 @@ pub struct LeaderChange {
 pub enum LogMutation {
     Append(LogEntry),
     TruncateFrom(u64),
-    HardState { term: u64, voted_for: Option<NodeId> },
+    // Raft state that MUST survive crashes.
+    HardState {
+        term: u64,
+        voted_for: Option<NodeId>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/clusters/raft/messages/event.rs
+++ b/src/clusters/raft/messages/event.rs
@@ -13,15 +13,25 @@ pub struct LeaderChange {
     pub term: u64,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RaftPersistentState {
+    pub(crate) term: u64,
+    pub(crate) voted_for: Option<NodeId>,
+    pub(crate) log: Vec<LogEntry>,
+}
+
+impl RaftPersistentState {
+    pub(crate) fn stabled_index(&self) -> u64 {
+        self.log.last().map_or(0, |e| e.index)
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum LogMutation {
     Append(LogEntry),
     TruncateFrom(u64),
-    HardState {
-        term: u64,
-        voted_for: Option<NodeId>,
-    },
+    HardState { term: u64, voted_for: Option<NodeId> },
 }
 
 #[derive(Debug)]

--- a/src/clusters/raft/messages/event.rs
+++ b/src/clusters/raft/messages/event.rs
@@ -13,19 +13,6 @@ pub struct LeaderChange {
     pub term: u64,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct RaftPersistentState {
-    pub(crate) term: u64,
-    pub(crate) voted_for: Option<NodeId>,
-    pub(crate) log: Vec<LogEntry>,
-}
-
-impl RaftPersistentState {
-    pub(crate) fn stabled_index(&self) -> u64 {
-        self.log.last().map_or(0, |e| e.index)
-    }
-}
-
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum LogMutation {

--- a/src/clusters/raft/mod.rs
+++ b/src/clusters/raft/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod messages;
 pub(crate) mod state;
 pub(crate) mod transport;
 pub(crate) mod multi_raft;
+pub(crate) mod storage;

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -7,14 +7,15 @@ use crate::clusters::raft::messages::{
     RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
+use crate::clusters::raft::storage::{delete_from, get_hard_state, put_hard_state, put_log_entry};
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
-use crate::storage::{RaftDb, WriteOperation, shard_cf_name};
+use crate::storage::{Db, DbOp, shard_cf_name};
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
     node_id: NodeId,
-    db: RaftDb,
+    db: Db,
     groups: HashMap<ShardGroupId, Raft>,
     seq_counter: RaftTimerTokenGenerator,
     dirty: HashSet<ShardGroupId>,
@@ -22,7 +23,7 @@ pub(crate) struct MultiRaft {
 }
 
 impl MultiRaft {
-    pub(crate) fn new(node_id: NodeId, db: RaftDb) -> Self {
+    pub(crate) fn new(node_id: NodeId, db: Db) -> Self {
         Self {
             node_id,
             db,
@@ -84,7 +85,8 @@ impl MultiRaft {
         }
 
         let cf_name = shard_cf_name(group.id.0);
-        if !self.db.has_cf(&cf_name) {
+        let cf_exist = self.db.has_cf(&cf_name);
+        if !cf_exist {
             self.db.create_cf(&cf_name);
         }
 
@@ -104,9 +106,18 @@ impl MultiRaft {
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
 
+        let (current_term, voted_for) =
+            if cf_exist && let Some(value) = get_hard_state(&self.db, &cf_name) {
+                value
+            } else {
+                (0, None)
+            };
+
         let raft = Raft::new(
             self.node_id.clone(),
             peers,
+            current_term,
+            voted_for,
             jitter,
             group.id,
             election_seq,
@@ -223,7 +234,7 @@ impl MultiRaft {
 
     pub(crate) fn flush(&mut self) -> Vec<RaftEvent> {
         let dirty: Vec<ShardGroupId> = std::mem::take(&mut self.dirty).into_iter().collect();
-        let mut batch: Vec<WriteOperation> = vec![];
+        let mut batch: Vec<DbOp> = vec![];
         let mut last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
 
         for id in &dirty {
@@ -235,13 +246,13 @@ impl MultiRaft {
             for log in raft.take_log_mutations() {
                 match log {
                     LogMutation::Append(entry) => {
-                        batch.push(WriteOperation::put_log_entry(&cf, &entry));
+                        batch.push(put_log_entry(&cf, &entry));
                     }
                     LogMutation::TruncateFrom(index) => {
-                        batch.push(WriteOperation::delete_from(&cf, index));
+                        batch.push(delete_from(&cf, index));
                     }
                     LogMutation::HardState { term, voted_for } => {
-                        batch.push(WriteOperation::put_hard_state(&cf, term, voted_for));
+                        batch.push(put_hard_state(&cf, term, voted_for));
                     }
                 }
             }
@@ -281,9 +292,9 @@ impl MultiRaft {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
     use crate::clusters::BINCODE_CONFIG;
     use crate::storage::ShardCfKey;
+    use std::collections::HashSet;
 
     fn node(id: &str) -> NodeId {
         NodeId::new(id)
@@ -306,13 +317,13 @@ mod tests {
             .collect()
     }
 
-    fn temp_db() -> (RaftDb, std::path::PathBuf) {
+    fn temp_db() -> (Db, std::path::PathBuf) {
         let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
-        let db = RaftDb::open(path.clone());
+        let db = Db::open(path.clone());
         (db, path)
     }
 
-    fn new_store(node_id: NodeId, db: RaftDb) -> MultiRaft {
+    fn new_store(node_id: NodeId, db: Db) -> MultiRaft {
         MultiRaft::new(node_id, db)
     }
 
@@ -372,14 +383,14 @@ mod tests {
         let me = node("n1");
 
         {
-            let db = RaftDb::open(path.clone());
+            let db = Db::open(path.clone());
             let mut store = new_store(me.clone(), db);
             store.add_group(shard(1, vec![me.clone(), node("n2")]));
             store.add_group(shard(2, vec![me.clone(), node("n2")]));
         }
 
         // Reopen — simulates a crash+restart.
-        let db = RaftDb::open(path);
+        let db = Db::open(path);
         let store = new_store(me.clone(), db);
         assert!(store.db.has_cf(&shard_cf_name(1)));
         assert!(store.db.has_cf(&shard_cf_name(2)));
@@ -390,7 +401,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use crate::clusters::raft::log::LogEntry;
-    use crate::clusters::raft::messages::{AppendEntries, RaftRpc};
+    use crate::clusters::raft::messages::{AppendEntries, RaftRpc, RequestVote};
 
     const TEST_GROUP_ID: ShardGroupId = ShardGroupId(42);
 
@@ -565,5 +576,25 @@ mod tests {
             read_entry(&store, 2).is_none(),
             "truncated entry 2 must be gone from RocksDB"
         );
+    }
+
+    #[test]
+    fn restart_restores_hard_state() {
+        let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
+        let me = node("n1");
+        {
+            let db = Db::open(path.clone());
+            let mut store = new_store(me.clone(), db);
+            store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+            elect_leader(&mut store);
+            store.flush();
+        }
+
+        let db = Db::open(path);
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
+        assert_eq!(raft.current_term(), 1);
+        assert_eq!(raft.voted_for(), Some(node("n1")));
     }
 }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -250,11 +250,11 @@ impl MultiRaft {
 
         if !batch.is_empty() {
             self.db.write_batch(&batch);
-        }
 
-        for (id, last_log_index) in last_indices {
-            if let Some(raft) = self.groups.get_mut(&id) {
-                raft.advance_stabled_index(last_log_index)
+            for (id, last_log_index) in last_indices {
+                if let Some(raft) = self.groups.get_mut(&id) {
+                    raft.advance_stabled_index(last_log_index)
+                }
             }
         }
 

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -4,10 +4,12 @@ use std::hash::{Hash, Hasher};
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
     LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
-    RaftTimeoutCallback,
+    RaftPersistentState, RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
-use crate::clusters::raft::storage::{delete_from, get_hard_state, put_hard_state, put_log_entry};
+use crate::clusters::raft::storage::{
+    delete_from, get_hard_state, get_log_entries, put_hard_state, put_log_entry,
+};
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
 use crate::storage::{Db, DbOp, shard_cf_name};
@@ -106,18 +108,21 @@ impl MultiRaft {
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
 
-        let (current_term, voted_for) =
-            if cf_exist && let Some(value) = get_hard_state(&self.db, &cf_name) {
-                value
-            } else {
-                (0, None)
-            };
+        let persistent = if cf_exist {
+            let (term, voted_for) = get_hard_state(&self.db, &cf_name).unwrap_or_default();
+            RaftPersistentState {
+                term,
+                voted_for,
+                log: get_log_entries(&self.db, &cf_name),
+            }
+        } else {
+            RaftPersistentState::default()
+        };
 
         let raft = Raft::new(
             self.node_id.clone(),
             peers,
-            current_term,
-            voted_for,
+            persistent,
             jitter,
             group.id,
             election_seq,
@@ -575,6 +580,40 @@ mod tests {
         assert!(
             read_entry(&store, 2).is_none(),
             "truncated entry 2 must be gone from RocksDB"
+        );
+    }
+
+    #[test]
+    fn restart_restores_log_entries_and_stabled_index() {
+        let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
+        let me = node("n1");
+
+        let expected_last_index;
+        {
+            let db = Db::open(path.clone());
+            let mut store = new_store(me.clone(), db);
+            store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+            elect_leader(&mut store);
+            store.flush();
+            propose_noop(&mut store);
+            store.flush();
+            expected_last_index = store.groups.get(&TEST_GROUP_ID).unwrap().log_last_index();
+        }
+
+        let db = Db::open(path);
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+
+        let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
+        assert_eq!(
+            raft.log_last_index(),
+            expected_last_index,
+            "log must be restored from RocksDB after restart"
+        );
+        assert_eq!(
+            raft.stabled_index(),
+            expected_last_index,
+            "stabled_index must equal last restored log entry"
         );
     }
 

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -273,7 +273,7 @@ mod tests {
     use super::*;
 
     use crate::clusters::raft::storage::RaftPersistentState;
-    use crate::storage::Db;
+    use crate::impls::metadata_storage::MetadataStorage;
     use std::collections::HashSet;
 
     fn node(id: &str) -> NodeId {
@@ -299,7 +299,7 @@ mod tests {
 
     fn temp_storage() -> (Box<dyn RaftStorage>, std::path::PathBuf) {
         let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
-        let db = Db::open(path.clone());
+        let db = MetadataStorage::open(path.clone());
         (Box::new(db), path)
     }
 
@@ -369,7 +369,7 @@ mod tests {
         let me = node("n1");
 
         {
-            let db = Db::open(path.clone());
+            let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(1, vec![me.clone()]));
             store.add_group(shard(2, vec![me.clone()]));
@@ -386,7 +386,7 @@ mod tests {
             store.flush();
         }
 
-        let db = Db::open(path);
+        let db = MetadataStorage::open(path);
         assert!(db.load_state(1) != Default::default());
         assert!(db.load_state(2) != Default::default());
     }
@@ -572,7 +572,7 @@ mod tests {
 
         let expected_last_index;
         {
-            let db = Db::open(path.clone());
+            let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
@@ -582,7 +582,7 @@ mod tests {
             expected_last_index = store.groups.get(&TEST_GROUP_ID).unwrap().log_last_index();
         }
 
-        let db = Db::open(path);
+        let db = MetadataStorage::open(path);
         let mut store = new_store(me.clone(), Box::new(db));
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
@@ -604,14 +604,14 @@ mod tests {
         let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
         let me = node("n1");
         {
-            let db = Db::open(path.clone());
+            let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
             store.flush();
         }
 
-        let db = Db::open(path);
+        let db = MetadataStorage::open(path);
         let mut store = new_store(me.clone(), Box::new(db));
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
         let raft = store.groups.get(&TEST_GROUP_ID).unwrap();

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -3,19 +3,19 @@ use std::hash::{Hash, Hasher};
 
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
-    MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
+    LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
     RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
 
+use crate::clusters::raft::storage::RaftStorage;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
-use crate::storage::{Db, DbOp};
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
     node_id: NodeId,
-    db: Db,
+    storage: Box<dyn RaftStorage>,
     groups: HashMap<ShardGroupId, Raft>,
     seq_counter: RaftTimerTokenGenerator,
     dirty: HashSet<ShardGroupId>,
@@ -23,10 +23,10 @@ pub(crate) struct MultiRaft {
 }
 
 impl MultiRaft {
-    pub(crate) fn new(node_id: NodeId, db: Db) -> Self {
+    pub(crate) fn new(node_id: NodeId, storage: Box<dyn RaftStorage>) -> Self {
         Self {
             node_id,
-            db,
+            storage,
             groups: HashMap::new(),
             seq_counter: RaftTimerTokenGenerator::default(),
             dirty: HashSet::new(),
@@ -101,7 +101,7 @@ impl MultiRaft {
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
 
-        let persistent = self.db.take_persistent_state_for(group.id.0);
+        let persistent = self.storage.load_state(group.id.0);
 
         let raft = Raft::new(
             self.node_id.clone(),
@@ -138,7 +138,7 @@ impl MultiRaft {
                 seq: raft.heartbeat_seq(),
             }));
 
-        self.db.delete_range(group_id);
+        self.storage.delete_group(group_id);
 
         tracing::info!("[{}] Removed Raft group {:?}", self.node_id, group_id);
     }
@@ -223,7 +223,7 @@ impl MultiRaft {
 
     pub(crate) fn flush(&mut self) -> Vec<RaftEvent> {
         let dirty: Vec<ShardGroupId> = std::mem::take(&mut self.dirty).into_iter().collect();
-        let mut batch: Vec<DbOp> = vec![];
+        let mut mutations: Vec<(ShardGroupId, LogMutation)> = vec![];
         let mut last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
 
         for id in &dirty {
@@ -233,13 +233,13 @@ impl MultiRaft {
 
             last_indices.insert(*id, raft.log_last_index());
             for log in raft.take_log_mutations() {
-                batch.push(DbOp::from_log(id, log));
+                mutations.push((*id, log));
             }
             self.pending_events.extend(raft.take_events());
         }
 
-        if !batch.is_empty() {
-            self.db.write_batch(&batch);
+        if !mutations.is_empty() {
+            self.storage.persist_mutations(mutations);
 
             for (id, last_log_index) in last_indices {
                 if let Some(raft) = self.groups.get_mut(&id) {
@@ -271,10 +271,9 @@ impl MultiRaft {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clusters::BINCODE_CONFIG;
 
     use crate::clusters::raft::storage::RaftPersistentState;
-    use crate::storage::ShardCfKey;
+    use crate::storage::Db;
     use std::collections::HashSet;
 
     fn node(id: &str) -> NodeId {
@@ -298,21 +297,21 @@ mod tests {
             .collect()
     }
 
-    fn temp_db() -> (Db, std::path::PathBuf) {
+    fn temp_storage() -> (Box<dyn RaftStorage>, std::path::PathBuf) {
         let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
         let db = Db::open(path.clone());
-        (db, path)
+        (Box::new(db), path)
     }
 
-    fn new_store(node_id: NodeId, db: Db) -> MultiRaft {
-        MultiRaft::new(node_id, db)
+    fn new_store(node_id: NodeId, storage: Box<dyn RaftStorage>) -> MultiRaft {
+        MultiRaft::new(node_id, storage)
     }
 
     #[test]
     fn timer_seqs_are_unique_across_groups() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
 
         store.add_group(shard(1, vec![me.clone(), node("n2")]));
         store.add_group(shard(2, vec![me.clone(), node("n2")]));
@@ -325,9 +324,9 @@ mod tests {
 
     #[test]
     fn add_group_registers_in_memory() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
 
         store.add_group(shard(42, vec![me.clone(), node("n2")]));
 
@@ -336,9 +335,9 @@ mod tests {
 
     #[test]
     fn remove_group_deletes_data() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
 
         store.add_group(shard(42, vec![me.clone()]));
         store.handle_command(MultiRaftCommand::Timeout(
@@ -347,17 +346,17 @@ mod tests {
             },
         ));
         store.flush();
-        assert!(store.db.take_persistent_state_for(42) != Default::default());
+        assert!(store.storage.load_state(42) != Default::default());
 
         store.remove_group(ShardGroupId(42));
-        assert!(store.db.take_persistent_state_for(42) == Default::default());
+        assert!(store.storage.load_state(42) == Default::default());
     }
 
     #[test]
     fn add_group_noop_when_not_member() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
 
         store.add_group(shard(42, vec![node("n2"), node("n3")]));
 
@@ -371,10 +370,9 @@ mod tests {
 
         {
             let db = Db::open(path.clone());
-            let mut store = new_store(me.clone(), db);
+            let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(1, vec![me.clone()]));
             store.add_group(shard(2, vec![me.clone()]));
-            // Trigger elections to produce HardState mutations
             store.handle_command(MultiRaftCommand::Timeout(
                 RaftTimeoutCallback::ElectionTimeout {
                     shard_group_id: ShardGroupId(1),
@@ -389,8 +387,8 @@ mod tests {
         }
 
         let db = Db::open(path);
-        assert!(db.take_persistent_state_for(1) != Default::default());
-        assert!(db.take_persistent_state_for(2) != Default::default());
+        assert!(db.load_state(1) != Default::default());
+        assert!(db.load_state(2) != Default::default());
     }
 
     // -----------------------------------------------------------------------
@@ -420,21 +418,19 @@ mod tests {
     }
 
     fn read_entry(store: &MultiRaft, index: u64) -> Option<LogEntry> {
-        let key = ShardCfKey::LogEntry(index).encode_for(TEST_GROUP_ID.0);
-        let bytes = store.db.get_key(&key)?;
-        let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG).ok()?;
-        Some(entry)
+        let state = store.storage.load_state(TEST_GROUP_ID.0);
+        state.log.into_iter().find(|e| e.index == index)
     }
 
     fn read_hard_state(store: &MultiRaft) -> RaftPersistentState {
-        store.db.take_persistent_state_for(TEST_GROUP_ID.0)
+        store.storage.load_state(TEST_GROUP_ID.0)
     }
 
     #[test]
     fn flush_persists_log_entry() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
@@ -450,9 +446,9 @@ mod tests {
 
     #[test]
     fn flush_persists_hard_state() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
@@ -464,9 +460,9 @@ mod tests {
 
     #[test]
     fn stabled_advances_after_flush() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         assert_eq!(store.stabled_for(TEST_GROUP_ID), 0);
@@ -487,9 +483,9 @@ mod tests {
 
     #[test]
     fn flush_noop_when_not_dirty() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
         store.flush(); // consume dirty from add_group
 
@@ -500,10 +496,10 @@ mod tests {
 
     #[test]
     fn flush_truncate_removes_entries_from_rocksdb() {
-        let (db, _) = temp_db();
+        let (storage, _) = temp_storage();
         let me = node("n1");
         let n2 = node("n2");
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), storage);
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone(), n2.clone()]));
         store.flush(); // consume add_group dirty
 
@@ -577,7 +573,7 @@ mod tests {
         let expected_last_index;
         {
             let db = Db::open(path.clone());
-            let mut store = new_store(me.clone(), db);
+            let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
             store.flush();
@@ -587,7 +583,7 @@ mod tests {
         }
 
         let db = Db::open(path);
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), Box::new(db));
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
@@ -609,14 +605,14 @@ mod tests {
         let me = node("n1");
         {
             let db = Db::open(path.clone());
-            let mut store = new_store(me.clone(), db);
+            let mut store = new_store(me.clone(), Box::new(db));
             store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
             store.flush();
         }
 
         let db = Db::open(path);
-        let mut store = new_store(me.clone(), db);
+        let mut store = new_store(me.clone(), Box::new(db));
         store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
         let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
         assert_eq!(raft.current_term(), 1);

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -9,10 +9,12 @@ use crate::clusters::raft::messages::{
 use crate::clusters::raft::state::Raft;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
+use crate::storage::{RaftDb, shard_cf_name};
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
     node_id: NodeId,
+    db: RaftDb,
     groups: HashMap<ShardGroupId, Raft>,
     seq_counter: RaftTimerTokenGenerator,
     dirty: HashSet<ShardGroupId>,
@@ -20,9 +22,10 @@ pub(crate) struct MultiRaft {
 }
 
 impl MultiRaft {
-    pub(crate) fn new(node_id: NodeId) -> Self {
+    pub(crate) fn new(node_id: NodeId, db: RaftDb) -> Self {
         Self {
             node_id,
+            db,
             groups: HashMap::new(),
             seq_counter: RaftTimerTokenGenerator::default(),
             dirty: HashSet::new(),
@@ -80,6 +83,11 @@ impl MultiRaft {
             return;
         }
 
+        let cf_name = shard_cf_name(group.id.0);
+        if !self.db.has_cf(&cf_name) {
+            self.db.create_cf(&cf_name);
+        }
+
         let peers: HashSet<NodeId> = group
             .members
             .iter()
@@ -129,6 +137,8 @@ impl MultiRaft {
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: raft.heartbeat_seq(),
             }));
+
+        self.db.drop_cf(&shard_cf_name(group_id.0));
 
         tracing::info!("[{}] Removed Raft group {:?}", self.node_id, group_id);
     }
@@ -265,10 +275,21 @@ mod tests {
             .collect()
     }
 
+    fn temp_db() -> (RaftDb, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
+        let db = RaftDb::open(path.clone());
+        (db, path)
+    }
+
+    fn new_store(node_id: NodeId, db: RaftDb) -> MultiRaft {
+        MultiRaft::new(node_id, db)
+    }
+
     #[test]
     fn timer_seqs_are_unique_across_groups() {
+        let (db, _) = temp_db();
         let me = node("n1");
-        let mut store = MultiRaft::new(me.clone());
+        let mut store = new_store(me.clone(), db);
 
         store.add_group(shard(1, vec![me.clone(), node("n2")]));
         store.add_group(shard(2, vec![me.clone(), node("n2")]));
@@ -277,5 +298,59 @@ mod tests {
         let seqs = timer_seqs(&events);
         let unique: HashSet<u32> = seqs.iter().cloned().collect();
         assert_eq!(seqs.len(), unique.len());
+    }
+
+    #[test]
+    fn add_group_creates_cf() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+
+        store.add_group(shard(42, vec![me.clone(), node("n2")]));
+
+        assert!(store.db.has_cf(&shard_cf_name(42)));
+    }
+
+    #[test]
+    fn remove_group_drops_cf() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+
+        store.add_group(shard(42, vec![me.clone(), node("n2")]));
+        store.remove_group(ShardGroupId(42));
+
+        assert!(!store.db.has_cf(&shard_cf_name(42)));
+    }
+
+    #[test]
+    fn add_group_noop_when_not_member() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+
+        store.add_group(shard(42, vec![node("n2"), node("n3")]));
+
+        assert!(!store.db.has_cf(&shard_cf_name(42)));
+        assert!(!store.groups.contains_key(&ShardGroupId(42)));
+    }
+
+    #[test]
+    fn restart_recovers_existing_cfs() {
+        let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
+        let me = node("n1");
+
+        {
+            let db = RaftDb::open(path.clone());
+            let mut store = new_store(me.clone(), db);
+            store.add_group(shard(1, vec![me.clone(), node("n2")]));
+            store.add_group(shard(2, vec![me.clone(), node("n2")]));
+        }
+
+        // Reopen — simulates a crash+restart.
+        let db = RaftDb::open(path);
+        let store = new_store(me.clone(), db);
+        assert!(store.db.has_cf(&shard_cf_name(1)));
+        assert!(store.db.has_cf(&shard_cf_name(2)));
     }
 }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -3,13 +3,13 @@ use std::hash::{Hash, Hasher};
 
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
-    MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
+    LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
     RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
-use crate::storage::{RaftDb, shard_cf_name};
+use crate::storage::{RaftDb, WriteOperation, shard_cf_name};
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
@@ -222,18 +222,40 @@ impl MultiRaft {
     }
 
     pub(crate) fn flush(&mut self) -> Vec<RaftEvent> {
-        for id in std::mem::take(&mut self.dirty) {
-            let Some(raft) = self.groups.get_mut(&id) else {
+        let dirty: Vec<ShardGroupId> = std::mem::take(&mut self.dirty).into_iter().collect();
+        let mut batch: Vec<WriteOperation> = vec![];
+        let mut last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
+
+        for id in &dirty {
+            let Some(raft) = self.groups.get_mut(id) else {
                 continue;
             };
-            // RocksDB integration point: replace the discard below with a batch write.
-            // take_log_mutations() returns Vec<LogMutation> — iterate and apply each variant:
-            //   LogMutation::Append(entry)        → cf_log.put((id, entry.index), bincode(entry))
-            //   LogMutation::TruncateFrom(index)  → delete_range cf_log (id, index)..(id, u64::MAX)
-            //   LogMutation::HardState { .. }     → cf_meta.put((id, "hard_state"), bincode(...))
-            // Batch all mutations for all dirty groups into one WriteBatch before db.write().
-            let _ = raft.take_log_mutations();
+            let cf = shard_cf_name(raft.shard_group_id.0);
+            last_indices.insert(*id, raft.log_last_index());
+            for log in raft.take_log_mutations() {
+                match log {
+                    LogMutation::Append(entry) => {
+                        batch.push(WriteOperation::put_log_entry(&cf, &entry));
+                    }
+                    LogMutation::TruncateFrom(index) => {
+                        batch.push(WriteOperation::delete_from(&cf, index));
+                    }
+                    LogMutation::HardState { term, voted_for } => {
+                        batch.push(WriteOperation::put_hard_state(&cf, term, voted_for));
+                    }
+                }
+            }
             self.pending_events.extend(raft.take_events());
+        }
+
+        if !batch.is_empty() {
+            self.db.write_batch(&batch);
+        }
+
+        for (id, last_log_index) in last_indices {
+            if let Some(raft) = self.groups.get_mut(&id) {
+                raft.advance_stabled_index(last_log_index)
+            }
         }
 
         std::mem::take(&mut self.pending_events)
@@ -250,9 +272,18 @@ impl RaftTimerTokenGenerator {
 }
 
 #[cfg(test)]
+impl MultiRaft {
+    fn stabled_for(&self, id: ShardGroupId) -> u64 {
+        self.groups.get(&id).map_or(0, |r| r.stabled_index())
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use crate::clusters::BINCODE_CONFIG;
+    use crate::storage::ShardCfKey;
 
     fn node(id: &str) -> NodeId {
         NodeId::new(id)
@@ -352,5 +383,187 @@ mod tests {
         let store = new_store(me.clone(), db);
         assert!(store.db.has_cf(&shard_cf_name(1)));
         assert!(store.db.has_cf(&shard_cf_name(2)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit 2 — flush() writes to RocksDB
+    // -----------------------------------------------------------------------
+
+    use crate::clusters::raft::log::LogEntry;
+    use crate::clusters::raft::messages::{AppendEntries, RaftRpc};
+
+    const TEST_GROUP_ID: ShardGroupId = ShardGroupId(42);
+
+    /// Elect n1 as leader of a single-node shard group. Single-node clusters
+    /// become leader immediately on ElectionTimeout (no peers to wait for).
+    fn elect_leader(store: &mut MultiRaft) {
+        store.handle_command(MultiRaftCommand::Timeout(
+            RaftTimeoutCallback::ElectionTimeout {
+                shard_group_id: TEST_GROUP_ID,
+            },
+        ));
+    }
+
+    fn propose_noop(store: &mut MultiRaft) -> MultiRaftReply {
+        store.handle_command(MultiRaftCommand::Propose {
+            shard_group_id: TEST_GROUP_ID,
+            command: RaftCommand::Noop,
+        })
+    }
+
+    fn read_entry(store: &MultiRaft, index: u64) -> Option<LogEntry> {
+        let cf = shard_cf_name(TEST_GROUP_ID.0);
+        let bytes = store
+            .db
+            .get_cf(&cf, &ShardCfKey::LogEntry(index).encode())?;
+        let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG).ok()?;
+        Some(entry)
+    }
+
+    fn read_hard_state(store: &MultiRaft) -> Option<(u64, Option<NodeId>)> {
+        let cf = shard_cf_name(TEST_GROUP_ID.0);
+        let bytes = store.db.get_cf(&cf, &ShardCfKey::HardState.encode())?;
+        let (hs, _) =
+            bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG).ok()?;
+        Some(hs)
+    }
+
+    #[test]
+    fn flush_persists_log_entry() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+
+        elect_leader(&mut store);
+        store.flush(); // persist election HardState
+
+        propose_noop(&mut store);
+        store.flush();
+
+        // The noop appended by become_leader is index 1; our proposal is index 2.
+        let entry = read_entry(&store, 2).expect("entry 2 must be in RocksDB after flush");
+        assert_eq!(entry.index, 2);
+    }
+
+    #[test]
+    fn flush_persists_hard_state() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+
+        elect_leader(&mut store);
+        store.flush();
+
+        let (term, _) = read_hard_state(&store).expect("HardState must be in RocksDB after flush");
+        assert_eq!(term, 1, "term must be 1 after first election");
+    }
+
+    #[test]
+    fn stabled_advances_after_flush() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+
+        assert_eq!(store.stabled_for(TEST_GROUP_ID), 0);
+
+        elect_leader(&mut store);
+        store.flush();
+        let after_election = store.stabled_for(TEST_GROUP_ID);
+
+        propose_noop(&mut store);
+        store.flush();
+        let after_propose = store.stabled_for(TEST_GROUP_ID);
+
+        assert!(
+            after_propose > after_election,
+            "stabled must advance after appending an entry"
+        );
+    }
+
+    #[test]
+    fn flush_noop_when_not_dirty() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.flush(); // consume dirty from add_group
+
+        // No state changes — flush should be a no-op and return no events.
+        let events = store.flush();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn flush_truncate_removes_entries_from_rocksdb() {
+        let (db, _) = temp_db();
+        let me = node("n1");
+        let n2 = node("n2");
+        let mut store = new_store(me.clone(), db);
+        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone(), n2.clone()]));
+        store.flush(); // consume add_group dirty
+
+        // n2 is acting as leader at term 1.  Send two entries to n1 (follower).
+        store.handle_command(MultiRaftCommand::PacketReceived {
+            shard_group_id: TEST_GROUP_ID,
+            from: n2.clone(),
+            rpc: RaftRpc::AppendEntries(AppendEntries {
+                term: 1,
+                leader_id: n2.clone(),
+                prev_log_index: 0,
+                prev_log_term: 0,
+                entries: vec![
+                    LogEntry {
+                        term: 1,
+                        index: 1,
+                        command: RaftCommand::Noop,
+                    },
+                    LogEntry {
+                        term: 1,
+                        index: 2,
+                        command: RaftCommand::Noop,
+                    },
+                ],
+                leader_commit: 0,
+            }),
+        });
+        store.flush();
+        assert!(
+            read_entry(&store, 1).is_some(),
+            "entry 1 must exist before truncation"
+        );
+        assert!(
+            read_entry(&store, 2).is_some(),
+            "entry 2 must exist before truncation"
+        );
+
+        // n2 re-sends from index 1 at term 2, conflicting with the existing term-1 entries.
+        // Raft truncates from index 1 and replaces with the new entry.
+        store.handle_command(MultiRaftCommand::PacketReceived {
+            shard_group_id: TEST_GROUP_ID,
+            from: n2.clone(),
+            rpc: RaftRpc::AppendEntries(AppendEntries {
+                term: 2,
+                leader_id: n2.clone(),
+                prev_log_index: 0,
+                prev_log_term: 0,
+                entries: vec![LogEntry {
+                    term: 2,
+                    index: 1,
+                    command: RaftCommand::Noop,
+                }],
+                leader_commit: 0,
+            }),
+        });
+        store.flush();
+
+        let new_entry = read_entry(&store, 1).expect("replacement entry 1 must be in RocksDB");
+        assert_eq!(new_entry.term, 2, "entry 1 must be the term-2 replacement");
+        assert!(
+            read_entry(&store, 2).is_none(),
+            "truncated entry 2 must be gone from RocksDB"
+        );
     }
 }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -401,7 +401,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use crate::clusters::raft::log::LogEntry;
-    use crate::clusters::raft::messages::{AppendEntries, RaftRpc, RequestVote};
+    use crate::clusters::raft::messages::{AppendEntries, RaftRpc};
 
     const TEST_GROUP_ID: ShardGroupId = ShardGroupId(42);
 

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -3,17 +3,14 @@ use std::hash::{Hash, Hasher};
 
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
-    LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
+    MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
     RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
-use crate::clusters::raft::storage::{
-    RaftPersistentState, delete_from, get_hard_state, get_log_entries, put_hard_state,
-    put_log_entry,
-};
+
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;
-use crate::storage::{Db, DbOp, shard_cf_name};
+use crate::storage::{Db, DbOp};
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
@@ -87,12 +84,6 @@ impl MultiRaft {
             return;
         }
 
-        let cf_name = shard_cf_name(group.id.0);
-        let cf_exist = self.db.has_cf(&cf_name);
-        if !cf_exist {
-            self.db.create_cf(&cf_name);
-        }
-
         let peers: HashSet<NodeId> = group
             .members
             .iter()
@@ -110,17 +101,7 @@ impl MultiRaft {
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
 
-        let persistent = if cf_exist {
-            let (term, voted_for) = get_hard_state(&self.db, &cf_name).unwrap_or_default();
-            let log = get_log_entries(&self.db, &cf_name);
-            RaftPersistentState {
-                term,
-                voted_for,
-                log
-            }
-        } else {
-            RaftPersistentState::default()
-        };
+        let persistent = self.db.take_persistent_state_for(group.id.0);
 
         let raft = Raft::new(
             self.node_id.clone(),
@@ -157,7 +138,7 @@ impl MultiRaft {
                 seq: raft.heartbeat_seq(),
             }));
 
-        self.db.drop_cf(&shard_cf_name(group_id.0));
+        self.db.delete_range(group_id);
 
         tracing::info!("[{}] Removed Raft group {:?}", self.node_id, group_id);
     }
@@ -249,20 +230,10 @@ impl MultiRaft {
             let Some(raft) = self.groups.get_mut(id) else {
                 continue;
             };
-            let cf = shard_cf_name(raft.shard_group_id.0);
+
             last_indices.insert(*id, raft.log_last_index());
             for log in raft.take_log_mutations() {
-                match log {
-                    LogMutation::Append(entry) => {
-                        batch.push(put_log_entry(&cf, &entry));
-                    }
-                    LogMutation::TruncateFrom(index) => {
-                        batch.push(delete_from(&cf, index));
-                    }
-                    LogMutation::HardState { term, voted_for } => {
-                        batch.push(put_hard_state(&cf, term, voted_for));
-                    }
-                }
+                batch.push(DbOp::from_log(id, log));
             }
             self.pending_events.extend(raft.take_events());
         }
@@ -301,6 +272,8 @@ impl MultiRaft {
 mod tests {
     use super::*;
     use crate::clusters::BINCODE_CONFIG;
+
+    use crate::clusters::raft::storage::RaftPersistentState;
     use crate::storage::ShardCfKey;
     use std::collections::HashSet;
 
@@ -351,26 +324,33 @@ mod tests {
     }
 
     #[test]
-    fn add_group_creates_cf() {
+    fn add_group_registers_in_memory() {
         let (db, _) = temp_db();
         let me = node("n1");
         let mut store = new_store(me.clone(), db);
 
         store.add_group(shard(42, vec![me.clone(), node("n2")]));
 
-        assert!(store.db.has_cf(&shard_cf_name(42)));
+        assert!(store.groups.contains_key(&ShardGroupId(42)));
     }
 
     #[test]
-    fn remove_group_drops_cf() {
+    fn remove_group_deletes_data() {
         let (db, _) = temp_db();
         let me = node("n1");
         let mut store = new_store(me.clone(), db);
 
-        store.add_group(shard(42, vec![me.clone(), node("n2")]));
-        store.remove_group(ShardGroupId(42));
+        store.add_group(shard(42, vec![me.clone()]));
+        store.handle_command(MultiRaftCommand::Timeout(
+            RaftTimeoutCallback::ElectionTimeout {
+                shard_group_id: ShardGroupId(42),
+            },
+        ));
+        store.flush();
+        assert!(store.db.take_persistent_state_for(42) != Default::default());
 
-        assert!(!store.db.has_cf(&shard_cf_name(42)));
+        store.remove_group(ShardGroupId(42));
+        assert!(store.db.take_persistent_state_for(42) == Default::default());
     }
 
     #[test]
@@ -381,27 +361,36 @@ mod tests {
 
         store.add_group(shard(42, vec![node("n2"), node("n3")]));
 
-        assert!(!store.db.has_cf(&shard_cf_name(42)));
         assert!(!store.groups.contains_key(&ShardGroupId(42)));
     }
 
     #[test]
-    fn restart_recovers_existing_cfs() {
+    fn restart_recovers_persisted_state() {
         let path = std::env::temp_dir().join(uuid::Uuid::new_v4().to_string());
         let me = node("n1");
 
         {
             let db = Db::open(path.clone());
             let mut store = new_store(me.clone(), db);
-            store.add_group(shard(1, vec![me.clone(), node("n2")]));
-            store.add_group(shard(2, vec![me.clone(), node("n2")]));
+            store.add_group(shard(1, vec![me.clone()]));
+            store.add_group(shard(2, vec![me.clone()]));
+            // Trigger elections to produce HardState mutations
+            store.handle_command(MultiRaftCommand::Timeout(
+                RaftTimeoutCallback::ElectionTimeout {
+                    shard_group_id: ShardGroupId(1),
+                },
+            ));
+            store.handle_command(MultiRaftCommand::Timeout(
+                RaftTimeoutCallback::ElectionTimeout {
+                    shard_group_id: ShardGroupId(2),
+                },
+            ));
+            store.flush();
         }
 
-        // Reopen — simulates a crash+restart.
         let db = Db::open(path);
-        let store = new_store(me.clone(), db);
-        assert!(store.db.has_cf(&shard_cf_name(1)));
-        assert!(store.db.has_cf(&shard_cf_name(2)));
+        assert!(db.take_persistent_state_for(1) != Default::default());
+        assert!(db.take_persistent_state_for(2) != Default::default());
     }
 
     // -----------------------------------------------------------------------
@@ -431,20 +420,14 @@ mod tests {
     }
 
     fn read_entry(store: &MultiRaft, index: u64) -> Option<LogEntry> {
-        let cf = shard_cf_name(TEST_GROUP_ID.0);
-        let bytes = store
-            .db
-            .get_cf(&cf, &ShardCfKey::LogEntry(index).encode())?;
+        let key = ShardCfKey::LogEntry(index).encode_for(TEST_GROUP_ID.0);
+        let bytes = store.db.get_key(&key)?;
         let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG).ok()?;
         Some(entry)
     }
 
-    fn read_hard_state(store: &MultiRaft) -> Option<(u64, Option<NodeId>)> {
-        let cf = shard_cf_name(TEST_GROUP_ID.0);
-        let bytes = store.db.get_cf(&cf, &ShardCfKey::HardState.encode())?;
-        let (hs, _) =
-            bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG).ok()?;
-        Some(hs)
+    fn read_hard_state(store: &MultiRaft) -> RaftPersistentState {
+        store.db.take_persistent_state_for(TEST_GROUP_ID.0)
     }
 
     #[test]
@@ -475,8 +458,8 @@ mod tests {
         elect_leader(&mut store);
         store.flush();
 
-        let (term, _) = read_hard_state(&store).expect("HardState must be in RocksDB after flush");
-        assert_eq!(term, 1, "term must be 1 after first election");
+        let state = read_hard_state(&store);
+        assert_eq!(state.term, 1, "term must be 1 after first election");
     }
 
     #[test]

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -4,11 +4,12 @@ use std::hash::{Hash, Hasher};
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
     LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
-    RaftPersistentState, RaftTimeoutCallback,
+    RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::Raft;
 use crate::clusters::raft::storage::{
-    delete_from, get_hard_state, get_log_entries, put_hard_state, put_log_entry,
+    RaftPersistentState, delete_from, get_hard_state, get_log_entries, put_hard_state,
+    put_log_entry,
 };
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::schedulers::ticker_message::TimerCommand;

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -112,10 +112,11 @@ impl MultiRaft {
 
         let persistent = if cf_exist {
             let (term, voted_for) = get_hard_state(&self.db, &cf_name).unwrap_or_default();
+            let log = get_log_entries(&self.db, &cf_name);
             RaftPersistentState {
                 term,
                 voted_for,
-                log: get_log_entries(&self.db, &cf_name),
+                log
             }
         } else {
             RaftPersistentState::default()

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -102,6 +102,7 @@ impl MultiRaft {
         let jitter = {
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             self.node_id.hash(&mut hasher);
+            group.id.0.hash(&mut hasher);
             (hasher.finish() % 20) as u32
         };
 

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -48,8 +48,9 @@ pub struct Raft {
     log: Vec<LogEntry>,
     pending_log_mutations: Vec<LogMutation>, // must persist
     pending_events: Vec<RaftEvent>,          // volatile side effects
-    commit_index: u64,
-    last_applied: u64,
+    commit_index: u64,                      // majority voted 
+    stabled_index: u64,                     // flushed to disk 
+    last_applied_index: u64,                // applied to state machine 
     role: Role,
     /// Tracks who the current leader is — set when this node becomes leader
     /// or when a valid `AppendEntries` is received from a leader.
@@ -80,7 +81,8 @@ impl Raft {
             pending_log_mutations: Vec::new(),
             pending_events: Vec::new(),
             commit_index: 0,
-            last_applied: 0,
+            stabled_index: 0,
+            last_applied_index: 0,
             role: Role::Follower,
             current_leader: None,
             peer_states: HashMap::new(),
@@ -112,7 +114,7 @@ impl Raft {
     // In-memory log helpers (1-based indexing; index 0 means "before log")
     // -------------------------------------------------------------------
 
-    fn log_last_index(&self) -> u64 {
+    pub(crate) fn log_last_index(&self) -> u64 {
         self.log.last().map_or(0, |e| e.index)
     }
 
@@ -185,6 +187,10 @@ impl Raft {
     fn quorum(&self) -> u32 {
         let total = self.peers.len() as u32 + 1; // +1 for self
         total / 2 + 1
+    }
+    
+    pub(crate) fn stabled_index(&self) -> u64 {
+        self.stabled_index
     }
 
     // -------------------------------------------------------------------
@@ -563,14 +569,24 @@ impl Raft {
             }
         }
     }
+    
+    pub(crate) fn advance_stabled_index(&mut self, value: u64) {
+        self.stabled_index = value;
+    }
 
-    /// Apply committed but unapplied log entries.
-    /// Currently handles Raft-internal ConfChanges (RemovePeer, AddPeer).
+    #[cfg(test)]
+    pub(crate) fn simulate_flush(&mut self) {
+        self.advance_stabled_index(self.log_last_index());
+        self.apply_committed_entries();
+    }
+
+    /// Apply committed (and persisted) but unapplied log entries.
+    /// Currently, handles Raft-internal ConfChanges (RemovePeer, AddPeer).
     /// Phase 4 will extend this with application state machine dispatch.
     fn apply_committed_entries(&mut self) {
-        while self.last_applied < self.commit_index {
-            self.last_applied += 1;
-            let entry = match self.log_get(self.last_applied) {
+        while self.last_applied_index < self.commit_index.min(self.stabled_index) {
+            self.last_applied_index += 1;
+            let entry = match self.log_get(self.last_applied_index) {
                 Some(e) => e.clone(),
                 None => continue,
             };
@@ -583,7 +599,7 @@ impl Raft {
                         "[{}] ConfChange applied: removed peer {} (index={})",
                         self.node_id,
                         node_id,
-                        self.last_applied
+                        self.last_applied_index
                     );
                 }
                 RaftCommand::AddPeer(ref node_id) => {
@@ -605,7 +621,7 @@ impl Raft {
                         "[{}] ConfChange applied: added peer {} (index={})",
                         self.node_id,
                         node_id,
-                        self.last_applied
+                        self.last_applied_index
                     );
                 }
             }
@@ -1472,8 +1488,9 @@ mod tests {
         // Single-node commits immediately on propose.
         let result = raft.propose(RaftCommand::RemovePeer(node("phantom")));
         assert!(result.is_ok());
+        raft.simulate_flush();
         // last_applied should have advanced
-        assert!(raft.last_applied > 0);
+        assert!(raft.last_applied_index > 0);
     }
 
     #[test]
@@ -1518,6 +1535,7 @@ mod tests {
         for pkt in acks {
             n1.step(node("node-2"), pkt.rpc);
         }
+        n1.simulate_flush();
 
         // After majority ack, commit_index advances and RemovePeer is applied
         assert!(!n1.has_peer(&node("node-3")));
@@ -1539,6 +1557,7 @@ mod tests {
 
         let result = raft.propose(RaftCommand::AddPeer(node("node-2")));
         assert!(result.is_ok());
+        raft.simulate_flush();
         assert!(raft.has_peer(&node("node-2")));
         assert_eq!(raft.peers_count(), 1);
     }
@@ -1596,6 +1615,7 @@ mod tests {
         for pkt in packets(&mut n2) {
             n1.step(node("node-2"), pkt.rpc);
         }
+        n1.simulate_flush();
 
         // After commit, node-4 is a peer
         assert!(n1.has_peer(&node("node-4")));

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -48,9 +48,9 @@ pub struct Raft {
     log: Vec<LogEntry>,
     pending_log_mutations: Vec<LogMutation>, // must persist
     pending_events: Vec<RaftEvent>,          // volatile side effects
-    commit_index: u64,                      // majority voted 
-    stabled_index: u64,                     // flushed to disk 
-    last_applied_index: u64,                // applied to state machine 
+    commit_index: u64,                       // majority voted
+    stabled_index: u64,                      // flushed to disk
+    last_applied_index: u64,                 // applied to state machine
     role: Role,
     /// Tracks who the current leader is — set when this node becomes leader
     /// or when a valid `AppendEntries` is received from a leader.
@@ -66,6 +66,8 @@ impl Raft {
     pub(crate) fn new(
         node_id: NodeId,
         peers: HashSet<NodeId>,
+        current_term: u64,
+        voted_for: Option<NodeId>,
         election_jitter: u32,
         shard_group_id: ShardGroupId,
         election_seq: u32,
@@ -75,8 +77,8 @@ impl Raft {
             node_id,
             shard_group_id,
             peers,
-            current_term: 0,
-            voted_for: None,
+            current_term,
+            voted_for,
             log: Vec::new(),
             pending_log_mutations: Vec::new(),
             pending_events: Vec::new(),
@@ -188,7 +190,7 @@ impl Raft {
         let total = self.peers.len() as u32 + 1; // +1 for self
         total / 2 + 1
     }
-    
+
     pub(crate) fn stabled_index(&self) -> u64 {
         self.stabled_index
     }
@@ -569,7 +571,7 @@ impl Raft {
             }
         }
     }
-    
+
     pub(crate) fn advance_stabled_index(&mut self, value: u64) {
         self.stabled_index = value;
     }
@@ -697,6 +699,16 @@ impl Raft {
                 seq: self.heartbeat_seq,
             }));
     }
+    
+    #[cfg(test)]
+    pub(crate) fn current_term(&self) -> u64 { 
+        return self.current_term
+    }
+
+    #[cfg(test)]
+    pub(crate) fn voted_for(&self) -> Option<NodeId> {
+        self.voted_for.clone()
+    }
 }
 
 #[cfg(test)]
@@ -734,13 +746,13 @@ mod tests {
     }
 
     fn single_node_raft() -> Raft {
-        Raft::new(node("node-1"), HashSet::new(), 0, TEST_SHARD, 0, 1)
+        Raft::new(node("node-1"), HashSet::new(), 0, None, 0, TEST_SHARD, 0, 1)
     }
 
     fn three_node_raft(id: &str) -> Raft {
         let all = ["node-1", "node-2", "node-3"];
         let peers: HashSet<NodeId> = all.iter().filter(|&&n| n != id).map(|&n| node(n)).collect();
-        Raft::new(node(id), peers, 0, TEST_SHARD, 0, 1)
+        Raft::new(node(id), peers, 0, None, 0, TEST_SHARD, 0, 1)
     }
 
     // -------------------------------------------------------------------
@@ -1433,7 +1445,7 @@ mod tests {
             let peers: HashSet<NodeId> = (0..peer_count)
                 .map(|i| NodeId::new(format!("peer-{i}")))
                 .collect();
-            let raft = Raft::new(NodeId::new("self"), peers, 0, TEST_SHARD, 0, 1);
+            let raft = Raft::new(NodeId::new("self"), peers, 0, None, 0, TEST_SHARD, 0, 1);
 
             assert_eq!(
                 raft.quorum(),

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -573,7 +573,7 @@ impl Raft {
     }
 
     pub(crate) fn advance_stabled_index(&mut self, value: u64) {
-        self.stabled_index = value;
+        self.stabled_index = self.stabled_index.max(value);
     }
 
     #[cfg(test)]

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -73,18 +73,17 @@ impl Raft {
         election_seq: u32,
         heartbeat_seq: u32,
     ) -> Self {
-        let stabled_index = persistent.stabled_index();
         let mut raft = Self {
             node_id,
             shard_group_id,
             peers,
+            stabled_index: persistent.stabled_index(),
             current_term: persistent.term,
             voted_for: persistent.voted_for,
             log: persistent.log,
             pending_log_mutations: Vec::new(),
             pending_events: Vec::new(),
             commit_index: 0,
-            stabled_index,
             last_applied_index: 0,
             role: Role::Follower,
             current_leader: None,
@@ -700,7 +699,7 @@ impl Raft {
                 seq: self.heartbeat_seq,
             }));
     }
-    
+
     #[cfg(test)]
     pub(crate) fn current_term(&self) -> u64 {
         self.current_term
@@ -747,13 +746,29 @@ mod tests {
     }
 
     fn single_node_raft() -> Raft {
-        Raft::new(node("node-1"), HashSet::new(), RaftPersistentState::default(), 0, TEST_SHARD, 0, 1)
+        Raft::new(
+            node("node-1"),
+            HashSet::new(),
+            RaftPersistentState::default(),
+            0,
+            TEST_SHARD,
+            0,
+            1,
+        )
     }
 
     fn three_node_raft(id: &str) -> Raft {
         let all = ["node-1", "node-2", "node-3"];
         let peers: HashSet<NodeId> = all.iter().filter(|&&n| n != id).map(|&n| node(n)).collect();
-        Raft::new(node(id), peers, RaftPersistentState::default(), 0, TEST_SHARD, 0, 1)
+        Raft::new(
+            node(id),
+            peers,
+            RaftPersistentState::default(),
+            0,
+            TEST_SHARD,
+            0,
+            1,
+        )
     }
 
     // -------------------------------------------------------------------
@@ -1446,7 +1461,15 @@ mod tests {
             let peers: HashSet<NodeId> = (0..peer_count)
                 .map(|i| NodeId::new(format!("peer-{i}")))
                 .collect();
-            let raft = Raft::new(NodeId::new("self"), peers, RaftPersistentState::default(), 0, TEST_SHARD, 0, 1);
+            let raft = Raft::new(
+                NodeId::new("self"),
+                peers,
+                RaftPersistentState::default(),
+                0,
+                TEST_SHARD,
+                0,
+                1,
+            );
 
             assert_eq!(
                 raft.quorum(),

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -701,8 +701,8 @@ impl Raft {
     }
     
     #[cfg(test)]
-    pub(crate) fn current_term(&self) -> u64 { 
-        return self.current_term
+    pub(crate) fn current_term(&self) -> u64 {
+        self.current_term
     }
 
     #[cfg(test)]

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -66,24 +66,24 @@ impl Raft {
     pub(crate) fn new(
         node_id: NodeId,
         peers: HashSet<NodeId>,
-        current_term: u64,
-        voted_for: Option<NodeId>,
+        persistent: RaftPersistentState,
         election_jitter: u32,
         shard_group_id: ShardGroupId,
         election_seq: u32,
         heartbeat_seq: u32,
     ) -> Self {
+        let stabled_index = persistent.stabled_index();
         let mut raft = Self {
             node_id,
             shard_group_id,
             peers,
-            current_term,
-            voted_for,
-            log: Vec::new(),
+            current_term: persistent.term,
+            voted_for: persistent.voted_for,
+            log: persistent.log,
             pending_log_mutations: Vec::new(),
             pending_events: Vec::new(),
             commit_index: 0,
-            stabled_index: 0,
+            stabled_index,
             last_applied_index: 0,
             role: Role::Follower,
             current_leader: None,
@@ -746,13 +746,13 @@ mod tests {
     }
 
     fn single_node_raft() -> Raft {
-        Raft::new(node("node-1"), HashSet::new(), 0, None, 0, TEST_SHARD, 0, 1)
+        Raft::new(node("node-1"), HashSet::new(), RaftPersistentState::default(), 0, TEST_SHARD, 0, 1)
     }
 
     fn three_node_raft(id: &str) -> Raft {
         let all = ["node-1", "node-2", "node-3"];
         let peers: HashSet<NodeId> = all.iter().filter(|&&n| n != id).map(|&n| node(n)).collect();
-        Raft::new(node(id), peers, 0, None, 0, TEST_SHARD, 0, 1)
+        Raft::new(node(id), peers, RaftPersistentState::default(), 0, TEST_SHARD, 0, 1)
     }
 
     // -------------------------------------------------------------------
@@ -1445,7 +1445,7 @@ mod tests {
             let peers: HashSet<NodeId> = (0..peer_count)
                 .map(|i| NodeId::new(format!("peer-{i}")))
                 .collect();
-            let raft = Raft::new(NodeId::new("self"), peers, 0, None, 0, TEST_SHARD, 0, 1);
+            let raft = Raft::new(NodeId::new("self"), peers, RaftPersistentState::default(), 0, TEST_SHARD, 0, 1);
 
             assert_eq!(
                 raft.quorum(),

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use crate::clusters::NodeId;
 use crate::clusters::raft::log::LogEntry;
 use crate::clusters::raft::messages::*;
+use crate::clusters::raft::storage::RaftPersistentState;
 use crate::clusters::swims::ShardGroupId;
 use crate::schedulers::ticker_message::TimerCommand;
 

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -26,7 +26,8 @@ pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> 
 pub(crate) fn get_hard_state(db: &Db, cf: &str) -> Option<(u64, Option<NodeId>)> {
     let bytes = db.get_value(cf, &ShardCfKey::HardState.encode())?;
     let (hard_state, _) =
-        bincode::decode_from_slice(&bytes, BINCODE_CONFIG).expect("corrupt HardState");
+        bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG)
+            .expect("corrupt HardState");
     Some(hard_state)
 }
 
@@ -36,4 +37,19 @@ pub(crate) fn delete_from(cf: &str, from_index: u64) -> DbOp {
         cf: cf.to_owned(),
         index,
     }
+}
+
+/// Reads all persisted log entries from the column family in index order.
+///
+/// TODO: When snapshots are implemented, update this to start from
+/// `snapshot.last_applied_index + 1` — entries before that point are compacted.
+pub(crate) fn get_log_entries(db: &Db, cf: &str) -> Vec<LogEntry> {
+    db.scan_range(cf, &[0x01], &[0x02])
+        .into_iter()
+        .map(|bytes| {
+            let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG)
+                .expect("corrupt LogEntry in RocksDB");
+            entry
+        })
+        .collect()
 }

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -1,5 +1,7 @@
 use crate::clusters::NodeId;
 use crate::clusters::raft::log::LogEntry;
+use crate::clusters::raft::messages::LogMutation;
+use crate::clusters::swims::ShardGroupId;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RaftPersistentState {
@@ -12,4 +14,10 @@ impl RaftPersistentState {
     pub(crate) fn stabled_index(&self) -> u64 {
         self.log.last().map_or(0, |e| e.index)
     }
+}
+
+pub(crate) trait RaftStorage: Send {
+    fn load_state(&self, group_id: u64) -> RaftPersistentState;
+    fn persist_mutations(&self, mutations: Vec<(ShardGroupId, LogMutation)>);
+    fn delete_group(&self, group_id: ShardGroupId);
 }

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -1,8 +1,7 @@
+use crate::clusters::NodeId;
 use crate::clusters::raft::log::LogEntry;
-use crate::clusters::{BINCODE_CONFIG, NodeId};
-use crate::storage::{Db, DbOp, ShardCfKey};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RaftPersistentState {
     pub(crate) term: u64,
     pub(crate) voted_for: Option<NodeId>,
@@ -13,56 +12,4 @@ impl RaftPersistentState {
     pub(crate) fn stabled_index(&self) -> u64 {
         self.log.last().map_or(0, |e| e.index)
     }
-}
-
-pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> DbOp {
-    let key = ShardCfKey::LogEntry(entry.index).encode();
-    let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
-    DbOp::Put {
-        cf: cf.to_owned(),
-        key,
-        value,
-    }
-}
-
-pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> DbOp {
-    let key = ShardCfKey::HardState.encode();
-    let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
-        .expect("encode HardState failed");
-    DbOp::Put {
-        cf: cf.to_owned(),
-        key,
-        value,
-    }
-}
-
-pub(crate) fn get_hard_state(db: &Db, cf: &str) -> Option<(u64, Option<NodeId>)> {
-    let bytes = db.get_value(cf, &ShardCfKey::HardState.encode())?;
-    let (hard_state, _) =
-        bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG)
-            .expect("corrupt HardState");
-    Some(hard_state)
-}
-
-pub(crate) fn delete_from(cf: &str, from_index: u64) -> DbOp {
-    let index = ShardCfKey::LogEntry(from_index).encode();
-    DbOp::DeleteFrom {
-        cf: cf.to_owned(),
-        index,
-    }
-}
-
-/// Reads all persisted log entries from the column family in index order.
-///
-/// TODO: When snapshots are implemented, update this to start from
-/// `snapshot.last_applied_index + 1` — entries before that point are compacted.
-pub(crate) fn get_log_entries(db: &Db, cf: &str) -> Vec<LogEntry> {
-    db.scan_range(cf, &[0x01], &[0x02])
-        .into_iter()
-        .map(|bytes| {
-            let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG)
-                .expect("corrupt LogEntry in RocksDB");
-            entry
-        })
-        .collect()
 }

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -1,0 +1,23 @@
+use crate::clusters::{NodeId, BINCODE_CONFIG};
+use crate::clusters::raft::log::LogEntry;
+use crate::storage::{DbOp, ShardCfKey};
+
+impl DbOp {
+    pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> Self {
+        let key = ShardCfKey::LogEntry(entry.index).encode();
+        let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
+        DbOp::Put { cf: cf.to_owned(), key, value }
+    }
+
+    pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> Self {
+        let key = ShardCfKey::HardState.encode();
+        let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
+            .expect("encode HardState failed");
+        DbOp::Put { cf: cf.to_owned(), key, value }
+    }
+
+    pub(crate) fn delete_from(cf: &str, from_index: u64) -> Self {
+        let index = ShardCfKey::LogEntry(from_index).encode();
+        DbOp::DeleteFrom { cf: cf.to_owned(), index }
+    }
+}

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -1,23 +1,39 @@
-use crate::clusters::{NodeId, BINCODE_CONFIG};
 use crate::clusters::raft::log::LogEntry;
-use crate::storage::{DbOp, ShardCfKey};
+use crate::clusters::{BINCODE_CONFIG, NodeId};
+use crate::storage::{Db, DbOp, ShardCfKey};
 
-impl DbOp {
-    pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> Self {
-        let key = ShardCfKey::LogEntry(entry.index).encode();
-        let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
-        DbOp::Put { cf: cf.to_owned(), key, value }
+pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> DbOp {
+    let key = ShardCfKey::LogEntry(entry.index).encode();
+    let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
+    DbOp::Put {
+        cf: cf.to_owned(),
+        key,
+        value,
     }
+}
 
-    pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> Self {
-        let key = ShardCfKey::HardState.encode();
-        let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
-            .expect("encode HardState failed");
-        DbOp::Put { cf: cf.to_owned(), key, value }
+pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> DbOp {
+    let key = ShardCfKey::HardState.encode();
+    let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
+        .expect("encode HardState failed");
+    DbOp::Put {
+        cf: cf.to_owned(),
+        key,
+        value,
     }
+}
 
-    pub(crate) fn delete_from(cf: &str, from_index: u64) -> Self {
-        let index = ShardCfKey::LogEntry(from_index).encode();
-        DbOp::DeleteFrom { cf: cf.to_owned(), index }
+pub(crate) fn get_hard_state(db: &Db, cf: &str) -> Option<(u64, Option<NodeId>)> {
+    let bytes = db.get_value(cf, &ShardCfKey::HardState.encode())?;
+    let (hard_state, _) =
+        bincode::decode_from_slice(&bytes, BINCODE_CONFIG).expect("corrupt HardState");
+    Some(hard_state)
+}
+
+pub(crate) fn delete_from(cf: &str, from_index: u64) -> DbOp {
+    let index = ShardCfKey::LogEntry(from_index).encode();
+    DbOp::DeleteFrom {
+        cf: cf.to_owned(),
+        index,
     }
 }

--- a/src/clusters/raft/storage.rs
+++ b/src/clusters/raft/storage.rs
@@ -2,6 +2,19 @@ use crate::clusters::raft::log::LogEntry;
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::storage::{Db, DbOp, ShardCfKey};
 
+#[derive(Debug, Clone, Default)]
+pub struct RaftPersistentState {
+    pub(crate) term: u64,
+    pub(crate) voted_for: Option<NodeId>,
+    pub(crate) log: Vec<LogEntry>,
+}
+
+impl RaftPersistentState {
+    pub(crate) fn stabled_index(&self) -> u64 {
+        self.log.last().map_or(0, |e| e.index)
+    }
+}
+
 pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> DbOp {
     let key = ShardCfKey::LogEntry(entry.index).encode();
     let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,9 @@ pub struct Environment {
     #[arg(long, env = "EASTGUARD_DATA_DIR", default_value = "./eastguard/data")]
     pub data_dir: String,
 
+    #[arg(long, env = "EASTGUARD_META_DIR", default_value = "./eastguard/meta")]
+    pub meta_dir: String,
+
     #[arg(long = "node-id-prefix", env = "EASTGUARD_NODE_ID_PREFIX")]
     pub node_id_prefix: Option<String>,
 
@@ -85,35 +88,33 @@ impl Environment {
         // 1. Parse arguments from CLI and/or ENV vars
         let env = Environment::parse();
 
-        // 2. Ensure data directory exists
-        if let Err(e) = fs::create_dir_all(&env.data_dir) {
-            panic!(
-                "Warning: Could not create directory '{}': {}",
-                env.data_dir, e
-            );
-        }
-
-        // Validate write permissions
-        let test_file = format!("{}/.write_test", env.data_dir);
-        if OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&test_file)
-            .is_ok()
-        {
-            let _ = fs::remove_file(test_file);
-        } else {
-            panic!(
-                "Warning: Server directory '{}' may not be writable.",
-                env.data_dir
-            );
+        // 2. Ensure data and meta directories exist and are writable
+        for dir in [&env.data_dir, &env.meta_dir] {
+            if let Err(e) = fs::create_dir_all(dir) {
+                panic!("Warning: Could not create directory '{}': {}", dir, e);
+            }
+            let test_file = format!("{}/.write_test", dir);
+            if OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&test_file)
+                .is_ok()
+            {
+                let _ = fs::remove_file(test_file);
+            } else {
+                panic!("Warning: Server directory '{}' may not be writable.", dir);
+            }
         }
 
         env
     }
     pub(crate) fn bind_addr(&self) -> String {
         format!("{}:{}", self.host, self.port)
+    }
+
+    pub(crate) fn raft_db_path(&self) -> std::path::PathBuf {
+        std::path::PathBuf::from(&self.meta_dir).join("raft")
     }
 
     pub(crate) fn peer_bind_addr(&self) -> std::net::SocketAddr {
@@ -203,6 +204,7 @@ mod tests {
         Environment {
             config_dir: "./eastguard/config".into(),
             data_dir: "./eastguard/data".into(),
+            meta_dir: "./eastguard/meta".into(),
             node_id_prefix: None,
             port: 2921,
             cluster_port: 2922,
@@ -239,6 +241,7 @@ mod tests {
 
         assert_eq!(env.config_dir, "./eastguard/config");
         assert_eq!(env.data_dir, "./eastguard/data");
+        assert_eq!(env.meta_dir, "./eastguard/meta");
         assert_eq!(env.node_id_prefix, None);
         assert_eq!(env.port, 2921);
         assert_eq!(env.cluster_port, 2922);

--- a/src/impls/metadata_storage.rs
+++ b/src/impls/metadata_storage.rs
@@ -82,12 +82,12 @@ impl DbOp {
 
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
-pub(crate) struct Db {
+pub(crate) struct MetadataStorage {
     db: rocksdb::DB,
     sync_opts: rocksdb::WriteOptions,
 }
 
-impl Db {
+impl MetadataStorage {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
@@ -175,7 +175,7 @@ impl Db {
     }
 }
 
-impl RaftStorage for Db {
+impl RaftStorage for MetadataStorage {
     fn load_state(&self, group_id: u64) -> RaftPersistentState {
         self.take_persistent_state_for(group_id)
     }

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod metadata_storage;

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -10,8 +10,8 @@ use turmoil::Builder;
 
 fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
     Environment {
-        config_dir: format!("./eastguard/config/{}", idx),
-        data_dir: format!("./eastguard/data/{}", idx),
+        config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
         port,
         cluster_port,

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -18,7 +18,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
         cluster_port,
         host: "0.0.0.0".into(),
         advertise_host: None,
-        vnodes_per_node: 16, // TODO: 256 hangs when using turmoil. Let's fix it in the future
+        vnodes_per_node: 256,
         join_seed_nodes: vec![],
         join_initial_delay_ms: 1000,
         join_interval_ms: 1000,
@@ -68,6 +68,7 @@ async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
 ///   SWIM failure detection → MembershipEvent::NodeDead → HandleNodeDeath → MultiRaftActor RemovePeer
 ///   Node restart → SWIM rejoin → HandleNodeJoin again
 #[test]
+#[serial_test::serial]
 fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(100))

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -1,11 +1,13 @@
+use crate::StartUp;
 use crate::clusters::{SwimNode, SwimNodeState};
 use crate::config::Environment;
 use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
 use crate::connections::request::ConnectionRequests;
 use crate::connections::request::QueryCommand::GetMembers;
 use crate::net::TcpStream;
+use std::time::Duration;
+use turmoil::Builder;
 
-#[allow(dead_code)]
 fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
@@ -16,7 +18,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
         cluster_port,
         host: "0.0.0.0".into(),
         advertise_host: None,
-        vnodes_per_node: 256,
+        vnodes_per_node: 16, // TODO: 256 hangs when using turmoil. Let's fix it in the future
         join_seed_nodes: vec![],
         join_initial_delay_ms: 1000,
         join_interval_ms: 1000,
@@ -25,7 +27,6 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
     }
 }
 
-#[allow(dead_code)]
 async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
     let stream = TcpStream::connect((host, port)).await?;
     let (read_half, write_half) = stream.into_split();
@@ -35,7 +36,6 @@ async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
     Ok(reader.read_request().await?)
 }
 
-#[allow(dead_code)]
 async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
     let members = get_members(host, port).await?;
     let alive_count = members
@@ -50,7 +50,6 @@ async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::R
     Ok(())
 }
 
-#[allow(dead_code)]
 async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
     let Ok(members) = get_members(host, port).await else {
         return false;
@@ -62,106 +61,105 @@ async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
     }
 }
 
-// RocksDB makes simulator hang. Fix it in the future
-// /// Full-stack E2E: SWIM cluster formation with MultiRaftActor wired in.
-// ///
-// /// Proves the complete pipeline works without panic:
-// ///   SWIM discover → MembershipEvent::NodeAlive → HandleNodeJoin → MultiRaftActor EnsureGroup/AddPeer
-// ///   SWIM failure detection → MembershipEvent::NodeDead → HandleNodeDeath → MultiRaftActor RemovePeer
-// ///   Node restart → SWIM rejoin → HandleNodeJoin again
-// #[test]
-// fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
-//     let mut sim = Builder::new()
-//         .tick_duration(Duration::from_millis(100))
-//         .simulation_duration(Duration::from_secs(120))
-//         .tcp_capacity(4096)
-//         .build();
-//
-//     let _ = tracing_subscriber::fmt()
-//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-//         .try_init();
-//
-//     sim.host("node-1", || async {
-//         let me = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-2", || async {
-//         let me = turmoil::lookup("node-2");
-//         let n1 = turmoil::lookup("node-1");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-3", || async {
-//         let me = turmoil::lookup("node-3");
-//         let n1 = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.client("checker", async {
-//         // Phase 1: Cluster formation — all 3 nodes alive
-//         tracing::info!("[E2E] Phase 1: waiting for cluster formation...");
-//         tokio::time::sleep(Duration::from_secs(10)).await;
-//         check_alive_count("node-1", 8081, 3).await?;
-//         check_alive_count("node-2", 8082, 3).await?;
-//         check_alive_count("node-3", 8083, 3).await?;
-//         tracing::info!("[E2E] Phase 1 OK: all 3 nodes alive");
-//
-//         // Phase 2: Crash node-3, verify SWIM detects death
-//         // (SWIM→Raft HandleNodeDeath fires internally — no panic = pipeline works)
-//         tracing::info!("[E2E] Phase 2: waiting for node-3 death detection...");
-//         tokio::time::sleep(Duration::from_secs(20)).await;
-//         assert!(
-//             check_dead_or_not_exist("node-1", 8081, "node-3").await,
-//             "node-1 should see node-3 as Dead"
-//         );
-//         assert!(
-//             check_dead_or_not_exist("node-2", 8082, "node-3").await,
-//             "node-2 should see node-3 as Dead"
-//         );
-//         tracing::info!("[E2E] Phase 2 OK: node-3 confirmed dead");
-//
-//         // Phase 3: Restart node-3 (fresh UUID), verify rejoin
-//         // (SWIM→Raft HandleNodeJoin fires internally — no panic = pipeline works)
-//         tracing::info!("[E2E] Phase 3: waiting for node-3 to rejoin...");
-//         tokio::time::sleep(Duration::from_secs(50)).await;
-//         check_alive_count("node-1", 8081, 3).await?;
-//         check_alive_count("node-2", 8082, 3).await?;
-//         check_alive_count("node-3", 8083, 3).await?;
-//         tracing::info!("[E2E] Phase 3 OK: node-3 rejoined, all 3 alive");
-//
-//         Ok(())
-//     });
-//
-//     // Crash node-3 after Phase 1 (~10s)
-//     while sim.elapsed() < Duration::from_secs(15) {
-//         sim.step()?;
-//     }
-//     tracing::info!("[E2E] Crashing node-3 at {}s", sim.elapsed().as_secs());
-//     sim.crash("node-3");
-//
-//     // Restart node-3 after Phase 2 (~40s)
-//     while sim.elapsed() < Duration::from_secs(40) {
-//         sim.step()?;
-//     }
-//     tracing::info!("[E2E] Restarting node-3 at {}s", sim.elapsed().as_secs());
-//     sim.bounce("node-3");
-//
-//     sim.run()
-// }
+/// Full-stack E2E: SWIM cluster formation with MultiRaftActor wired in.
+///
+/// Proves the complete pipeline works without panic:
+///   SWIM discover → MembershipEvent::NodeAlive → HandleNodeJoin → MultiRaftActor EnsureGroup/AddPeer
+///   SWIM failure detection → MembershipEvent::NodeDead → HandleNodeDeath → MultiRaftActor RemovePeer
+///   Node restart → SWIM rejoin → HandleNodeJoin again
+#[test]
+fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(120))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    sim.host("node-1", || async {
+        let me = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-2", || async {
+        let me = turmoil::lookup("node-2");
+        let n1 = turmoil::lookup("node-1");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-3", || async {
+        let me = turmoil::lookup("node-3");
+        let n1 = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.client("checker", async {
+        // Phase 1: Cluster formation — all 3 nodes alive
+        tracing::info!("[E2E] Phase 1: waiting for cluster formation...");
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        check_alive_count("node-1", 8081, 3).await?;
+        check_alive_count("node-2", 8082, 3).await?;
+        check_alive_count("node-3", 8083, 3).await?;
+        tracing::info!("[E2E] Phase 1 OK: all 3 nodes alive");
+
+        // Phase 2: Crash node-3, verify SWIM detects death
+        // (SWIM→Raft HandleNodeDeath fires internally — no panic = pipeline works)
+        tracing::info!("[E2E] Phase 2: waiting for node-3 death detection...");
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        assert!(
+            check_dead_or_not_exist("node-1", 8081, "node-3").await,
+            "node-1 should see node-3 as Dead"
+        );
+        assert!(
+            check_dead_or_not_exist("node-2", 8082, "node-3").await,
+            "node-2 should see node-3 as Dead"
+        );
+        tracing::info!("[E2E] Phase 2 OK: node-3 confirmed dead");
+
+        // Phase 3: Restart node-3 (fresh UUID), verify rejoin
+        // (SWIM→Raft HandleNodeJoin fires internally — no panic = pipeline works)
+        tracing::info!("[E2E] Phase 3: waiting for node-3 to rejoin...");
+        tokio::time::sleep(Duration::from_secs(50)).await;
+        check_alive_count("node-1", 8081, 3).await?;
+        check_alive_count("node-2", 8082, 3).await?;
+        check_alive_count("node-3", 8083, 3).await?;
+        tracing::info!("[E2E] Phase 3 OK: node-3 rejoined, all 3 alive");
+
+        Ok(())
+    });
+
+    // Crash node-3 after Phase 1 (~10s)
+    while sim.elapsed() < Duration::from_secs(15) {
+        sim.step()?;
+    }
+    tracing::info!("[E2E] Crashing node-3 at {}s", sim.elapsed().as_secs());
+    sim.crash("node-3");
+
+    // Restart node-3 after Phase 2 (~40s)
+    while sim.elapsed() < Duration::from_secs(40) {
+        sim.step()?;
+    }
+    tracing::info!("[E2E] Restarting node-3 at {}s", sim.elapsed().as_secs());
+    sim.bounce("node-3");
+
+    sim.run()
+}

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -61,105 +61,106 @@ async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
     }
 }
 
-/// Full-stack E2E: SWIM cluster formation with MultiRaftActor wired in.
-///
-/// Proves the complete pipeline works without panic:
-///   SWIM discover → MembershipEvent::NodeAlive → HandleNodeJoin → MultiRaftActor EnsureGroup/AddPeer
-///   SWIM failure detection → MembershipEvent::NodeDead → HandleNodeDeath → MultiRaftActor RemovePeer
-///   Node restart → SWIM rejoin → HandleNodeJoin again
-#[test]
-fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
-    let mut sim = Builder::new()
-        .tick_duration(Duration::from_millis(100))
-        .simulation_duration(Duration::from_secs(120))
-        .tcp_capacity(4096)
-        .build();
-
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
-
-    sim.host("node-1", || async {
-        let me = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-2", || async {
-        let me = turmoil::lookup("node-2");
-        let n1 = turmoil::lookup("node-1");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-3", || async {
-        let me = turmoil::lookup("node-3");
-        let n1 = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.client("checker", async {
-        // Phase 1: Cluster formation — all 3 nodes alive
-        tracing::info!("[E2E] Phase 1: waiting for cluster formation...");
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        check_alive_count("node-1", 8081, 3).await?;
-        check_alive_count("node-2", 8082, 3).await?;
-        check_alive_count("node-3", 8083, 3).await?;
-        tracing::info!("[E2E] Phase 1 OK: all 3 nodes alive");
-
-        // Phase 2: Crash node-3, verify SWIM detects death
-        // (SWIM→Raft HandleNodeDeath fires internally — no panic = pipeline works)
-        tracing::info!("[E2E] Phase 2: waiting for node-3 death detection...");
-        tokio::time::sleep(Duration::from_secs(20)).await;
-        assert!(
-            check_dead_or_not_exist("node-1", 8081, "node-3").await,
-            "node-1 should see node-3 as Dead"
-        );
-        assert!(
-            check_dead_or_not_exist("node-2", 8082, "node-3").await,
-            "node-2 should see node-3 as Dead"
-        );
-        tracing::info!("[E2E] Phase 2 OK: node-3 confirmed dead");
-
-        // Phase 3: Restart node-3 (fresh UUID), verify rejoin
-        // (SWIM→Raft HandleNodeJoin fires internally — no panic = pipeline works)
-        tracing::info!("[E2E] Phase 3: waiting for node-3 to rejoin...");
-        tokio::time::sleep(Duration::from_secs(50)).await;
-        check_alive_count("node-1", 8081, 3).await?;
-        check_alive_count("node-2", 8082, 3).await?;
-        check_alive_count("node-3", 8083, 3).await?;
-        tracing::info!("[E2E] Phase 3 OK: node-3 rejoined, all 3 alive");
-
-        Ok(())
-    });
-
-    // Crash node-3 after Phase 1 (~10s)
-    while sim.elapsed() < Duration::from_secs(15) {
-        sim.step()?;
-    }
-    tracing::info!("[E2E] Crashing node-3 at {}s", sim.elapsed().as_secs());
-    sim.crash("node-3");
-
-    // Restart node-3 after Phase 2 (~40s)
-    while sim.elapsed() < Duration::from_secs(40) {
-        sim.step()?;
-    }
-    tracing::info!("[E2E] Restarting node-3 at {}s", sim.elapsed().as_secs());
-    sim.bounce("node-3");
-
-    sim.run()
-}
+// RocksDB makes simulator hang. Fix it in the future
+// /// Full-stack E2E: SWIM cluster formation with MultiRaftActor wired in.
+// ///
+// /// Proves the complete pipeline works without panic:
+// ///   SWIM discover → MembershipEvent::NodeAlive → HandleNodeJoin → MultiRaftActor EnsureGroup/AddPeer
+// ///   SWIM failure detection → MembershipEvent::NodeDead → HandleNodeDeath → MultiRaftActor RemovePeer
+// ///   Node restart → SWIM rejoin → HandleNodeJoin again
+// #[test]
+// fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
+//     let mut sim = Builder::new()
+//         .tick_duration(Duration::from_millis(100))
+//         .simulation_duration(Duration::from_secs(120))
+//         .tcp_capacity(4096)
+//         .build();
+//
+//     let _ = tracing_subscriber::fmt()
+//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+//         .try_init();
+//
+//     sim.host("node-1", || async {
+//         let me = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-2", || async {
+//         let me = turmoil::lookup("node-2");
+//         let n1 = turmoil::lookup("node-1");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-3", || async {
+//         let me = turmoil::lookup("node-3");
+//         let n1 = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.client("checker", async {
+//         // Phase 1: Cluster formation — all 3 nodes alive
+//         tracing::info!("[E2E] Phase 1: waiting for cluster formation...");
+//         tokio::time::sleep(Duration::from_secs(10)).await;
+//         check_alive_count("node-1", 8081, 3).await?;
+//         check_alive_count("node-2", 8082, 3).await?;
+//         check_alive_count("node-3", 8083, 3).await?;
+//         tracing::info!("[E2E] Phase 1 OK: all 3 nodes alive");
+//
+//         // Phase 2: Crash node-3, verify SWIM detects death
+//         // (SWIM→Raft HandleNodeDeath fires internally — no panic = pipeline works)
+//         tracing::info!("[E2E] Phase 2: waiting for node-3 death detection...");
+//         tokio::time::sleep(Duration::from_secs(20)).await;
+//         assert!(
+//             check_dead_or_not_exist("node-1", 8081, "node-3").await,
+//             "node-1 should see node-3 as Dead"
+//         );
+//         assert!(
+//             check_dead_or_not_exist("node-2", 8082, "node-3").await,
+//             "node-2 should see node-3 as Dead"
+//         );
+//         tracing::info!("[E2E] Phase 2 OK: node-3 confirmed dead");
+//
+//         // Phase 3: Restart node-3 (fresh UUID), verify rejoin
+//         // (SWIM→Raft HandleNodeJoin fires internally — no panic = pipeline works)
+//         tracing::info!("[E2E] Phase 3: waiting for node-3 to rejoin...");
+//         tokio::time::sleep(Duration::from_secs(50)).await;
+//         check_alive_count("node-1", 8081, 3).await?;
+//         check_alive_count("node-2", 8082, 3).await?;
+//         check_alive_count("node-3", 8083, 3).await?;
+//         tracing::info!("[E2E] Phase 3 OK: node-3 rejoined, all 3 alive");
+//
+//         Ok(())
+//     });
+//
+//     // Crash node-3 after Phase 1 (~10s)
+//     while sim.elapsed() < Duration::from_secs(15) {
+//         sim.step()?;
+//     }
+//     tracing::info!("[E2E] Crashing node-3 at {}s", sim.elapsed().as_secs());
+//     sim.crash("node-3");
+//
+//     // Restart node-3 after Phase 2 (~40s)
+//     while sim.elapsed() < Duration::from_secs(40) {
+//         sim.step()?;
+//     }
+//     tracing::info!("[E2E] Restarting node-3 at {}s", sim.elapsed().as_secs());
+//     sim.bounce("node-3");
+//
+//     sim.run()
+// }

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -12,6 +12,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
         port,
         cluster_port,

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -1,13 +1,11 @@
-use crate::StartUp;
 use crate::clusters::{SwimNode, SwimNodeState};
 use crate::config::Environment;
 use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
 use crate::connections::request::ConnectionRequests;
 use crate::connections::request::QueryCommand::GetMembers;
 use crate::net::TcpStream;
-use std::time::Duration;
-use turmoil::Builder;
 
+#[allow(dead_code)]
 fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
@@ -27,6 +25,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
     }
 }
 
+#[allow(dead_code)]
 async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
     let stream = TcpStream::connect((host, port)).await?;
     let (read_half, write_half) = stream.into_split();
@@ -36,6 +35,7 @@ async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
     Ok(reader.read_request().await?)
 }
 
+#[allow(dead_code)]
 async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
     let members = get_members(host, port).await?;
     let alive_count = members
@@ -50,6 +50,7 @@ async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::R
     Ok(())
 }
 
+#[allow(dead_code)]
 async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
     let Ok(members) = get_members(host, port).await else {
         return false;

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -165,6 +165,7 @@ async fn read_leader(host: &str, port: u16) -> Option<NodeId> {
 /// 3-node cluster: after election, inject HandleNodeDeath for node-3.
 /// Leader proposes RemovePeer. Group continues with 2 members.
 #[test]
+#[serial_test::serial]
 fn node_death_triggers_remove_peer() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(1))
@@ -234,6 +235,7 @@ fn node_death_triggers_remove_peer() -> turmoil::Result {
 /// 2-node cluster: after election, inject HandleNodeJoin for node-3.
 /// Leader proposes AddPeer. Group expands to include node-3.
 #[test]
+#[serial_test::serial]
 fn node_join_triggers_add_peer() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(1))

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -11,10 +11,10 @@ use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
+use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -79,7 +79,7 @@ async fn start_raft_node(
         swim_tx.clone(),
     ));
 
-    let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let db = MetadataStorage::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
         Box::new(db),

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -14,6 +14,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
+use crate::storage::RaftDb;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -78,8 +79,10 @@ async fn start_raft_node(
         swim_tx.clone(),
     ));
 
+    let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
+        db,
         raft_mailbox,
         transport_tx,
         ticker_tx,

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -14,7 +14,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::RaftDb;
+use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -79,7 +79,7 @@ async fn start_raft_node(
         swim_tx.clone(),
     ));
 
-    let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
         db,

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -82,7 +82,7 @@ async fn start_raft_node(
     let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
-        db,
+        Box::new(db),
         raft_mailbox,
         transport_tx,
         ticker_tx,

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -14,6 +14,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
+use crate::storage::RaftDb;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -81,8 +82,10 @@ async fn run_raft_node(
         swim_tx.clone(),
     ));
 
+    let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
+        db,
         raft_mailbox,
         transport_tx,
         ticker_tx,

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -85,7 +85,7 @@ async fn run_raft_node(
     let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
-        db,
+        Box::new(db),
         raft_mailbox,
         transport_tx,
         ticker_tx,

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -162,6 +162,7 @@ async fn read_leader(host: &str, port: u16) -> Option<NodeId> {
 /// the checker connects to each node and verifies that all agree on the same
 /// elected leader.
 #[test]
+#[serial_test::serial]
 fn three_node_raft_elects_leader() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(1))

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -14,7 +14,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::RaftDb;
+use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -82,7 +82,7 @@ async fn run_raft_node(
         swim_tx.clone(),
     ));
 
-    let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
         db,

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -11,10 +11,10 @@ use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
+use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const QUERY_PORT: u16 = 29000;
@@ -82,7 +82,7 @@ async fn run_raft_node(
         swim_tx.clone(),
     ));
 
-    let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let db = MetadataStorage::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
         Box::new(db),
@@ -94,7 +94,12 @@ async fn run_raft_node(
 
     // Ensure the shard group
     raft_tx
-        .send(MultiRaftCommand::EnsureGroup { group: group.clone() }.into())
+        .send(
+            MultiRaftCommand::EnsureGroup {
+                group: group.clone(),
+            }
+            .into(),
+        )
         .await
         .unwrap();
 

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -15,7 +15,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::RaftDb;
+use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const RESULT_PORT: u16 = 39000;
@@ -113,7 +113,7 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                         swim_tx,
                     ));
                 }
-                let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+                let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
                 tokio::spawn(MultiRaftActor::run(
                     node_id,
                     db,

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -15,6 +15,7 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
+use crate::storage::RaftDb;
 
 const CLUSTER_PORT: u16 = 19000;
 const RESULT_PORT: u16 = 39000;
@@ -112,8 +113,10 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                         swim_tx,
                     ));
                 }
+                let db = RaftDb::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
                 tokio::spawn(MultiRaftActor::run(
                     node_id,
+                    db,
                     raft_mailbox,
                     transport_tx,
                     ticker_tx,

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -43,6 +43,7 @@ async fn swim_handler_with_leader_capture(
 /// 3-node cluster: after election, verify that exactly one node emits a
 /// LeaderChangeEvent with term=1 and correct shard_group_id.
 #[test]
+#[serial_test::serial]
 fn leader_election_emits_leader_change_event() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(1))

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -117,7 +117,7 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                 let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
                 tokio::spawn(MultiRaftActor::run(
                     node_id,
-                    db,
+                    Box::new(db),
                     raft_mailbox,
                     transport_tx,
                     ticker_tx,

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -7,15 +7,15 @@ use tokio::sync::mpsc;
 use turmoil::Builder;
 
 use crate::clusters::raft::actor::MultiRaftActor;
-use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::messages::LeaderChange;
+use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
+use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker_message::TickerCommand;
-use crate::storage::Db;
 
 const CLUSTER_PORT: u16 = 19000;
 const RESULT_PORT: u16 = 39000;
@@ -114,7 +114,9 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                         swim_tx,
                     ));
                 }
-                let db = Db::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+                let db = MetadataStorage::open(
+                    std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()),
+                );
                 tokio::spawn(MultiRaftActor::run(
                     node_id,
                     Box::new(db),

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -20,7 +20,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
         cluster_port,
         host: "0.0.0.0".into(),
         advertise_host: None,
-        vnodes_per_node: 16, // TODO: when set to 256, it hangs. Let's fix it
+        vnodes_per_node: 256,
         join_seed_nodes: vec![],
         join_initial_delay_ms: 1000,
         join_interval_ms: 1000,
@@ -89,6 +89,7 @@ async fn check_node_is_all_alive(host: &str, port: u16) -> turmoil::Result {
 }
 
 #[test]
+#[serial_test::serial]
 fn cluster_setup() -> turmoil::Result {
     let mut sim = Builder::new()
         .simulation_duration(Duration::from_secs(30))
@@ -158,6 +159,7 @@ fn cluster_setup() -> turmoil::Result {
 /// node-1 and node-3 are partitioned from each other.
 /// They must learn about each other exclusively through node-2's gossip.
 #[test]
+#[serial_test::serial]
 fn partition_gossip() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(100))
@@ -229,6 +231,7 @@ fn partition_gossip() -> turmoil::Result {
 
 /// node-3 process is killed and restarted.
 #[test]
+#[serial_test::serial]
 fn dead_node_rejoin_after_process_restart() -> turmoil::Result {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(100))

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -11,8 +11,8 @@ use turmoil::Builder;
 
 fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
     Environment {
-        config_dir: format!("./eastguard/config/{}", idx),
-        data_dir: format!("./eastguard/data/{}", idx),
+        config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
         port,
         cluster_port,

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -13,6 +13,7 @@ fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Envir
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
         port,
         cluster_port,

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -1,342 +1,340 @@
-// TODO: Fix. After integrating RocksDB, simulator hangs.
 
+/// Make sure to run the test using RUST_LOG=debug cargo test -- --nocapture
+use crate::StartUp;
+use crate::clusters::{SwimNode, SwimNodeState};
+use crate::config::Environment;
+use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
+use crate::connections::request::ConnectionRequests;
+use crate::connections::request::QueryCommand::GetMembers;
+use crate::net::TcpStream;
+use std::time::Duration;
+use turmoil::Builder;
 
-// /// Make sure to run the test using RUST_LOG=debug cargo test -- --nocapture
-// use crate::StartUp;
-// use crate::clusters::{SwimNode, SwimNodeState};
-// use crate::config::Environment;
-// use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
-// use crate::connections::request::ConnectionRequests;
-// use crate::connections::request::QueryCommand::GetMembers;
-// use crate::net::TcpStream;
-// use std::time::Duration;
-// use turmoil::Builder;
-//
-// fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
-//     Environment {
-//         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-//         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-//         meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-//         node_id_prefix: Some(node_id),
-//         port,
-//         cluster_port,
-//         host: "0.0.0.0".into(),
-//         advertise_host: None,
-//         vnodes_per_node: 256,
-//         join_seed_nodes: vec![],
-//         join_initial_delay_ms: 1000,
-//         join_interval_ms: 1000,
-//         join_multiplier: 2,
-//         join_max_attempts: 5,
-//     }
-// }
-//
-// async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
-//     let stream = TcpStream::connect((host, port)).await?;
-//     let (read_half, write_half) = stream.into_split();
-//     let mut writer = ClientStreamWriter::new(write_half);
-//     let mut reader = ClientStreamReader::new(read_half);
-//     writer.write(&ConnectionRequests::Query(GetMembers)).await?;
-//     Ok(reader.read_request().await?)
-// }
-//
-// async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
-//     let members = get_members(host, port).await?;
-//     tracing::info!("INSPECTING host: {}", host);
-//     let alive_count = members
-//         .iter()
-//         .filter(|m| m.state == SwimNodeState::Alive)
-//         .count();
-//     assert_eq!(
-//         alive_count, expected,
-//         "{host} should have {expected} alive nodes, got {:?}",
-//         members
-//     );
-//     Ok(())
-// }
-//
-// /// Returns `true` if the node whose id starts with `target` is Dead or absent
-// /// from the member list reported by `host`. Returns `false` on connection error
-// /// or if the node is still Alive/Suspect.
-// async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
-//     let Ok(members) = get_members(host, port).await else {
-//         tracing::warn!("[TEST] check_dead_or_not_exist: could not reach {host}");
-//         return false;
-//     };
-//     match members.iter().find(|m| m.node_id.starts_with(target)) {
-//         None => {
-//             tracing::info!("[TEST] {host} has no entry for '{target}' — fully removed");
-//             true
-//         }
-//         Some(n) if n.state == SwimNodeState::Dead => {
-//             tracing::info!(
-//                 "[TEST] {host} sees '{target}' as Dead (incarnation={})",
-//                 n.incarnation
-//             );
-//             true
-//         }
-//         Some(n) => {
-//             tracing::info!(
-//                 "[TEST] {host} sees '{target}' as {:?} — not dead yet (incarnation={})",
-//                 n.state,
-//                 n.incarnation
-//             );
-//             false
-//         }
-//     }
-// }
-//
-// async fn check_node_is_all_alive(host: &str, port: u16) -> turmoil::Result {
-//     check_alive_count(host, port, 3).await
-// }
-//
-// #[test]
-// fn cluster_setup() -> turmoil::Result {
-//     let mut sim = Builder::new()
-//         .simulation_duration(Duration::from_secs(30))
-//         .tcp_capacity(4096)
-//         .build();
-//
-//     let _ = tracing_subscriber::fmt()
-//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-//         .try_init();
-//
-//     sim.host("node-1", || async {
-//         let me = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let n3 = turmoil::lookup("node-3");
-//
-//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         tracing::info!("NODE-1 is running");
-//         Ok(())
-//     });
-//
-//     sim.host("node-2", || async {
-//         let me = turmoil::lookup("node-2");
-//         let n1 = turmoil::lookup("node-1");
-//         let n3 = turmoil::lookup("node-3");
-//
-//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         tracing::info!("NODE-2 is running");
-//         Ok(())
-//     });
-//
-//     sim.host("node-3", || async {
-//         let me = turmoil::lookup("node-3");
-//         let n1 = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//
-//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-//         StartUp::with_env(env, 0).run().await?;
-//         tracing::info!("NODE-3 is running");
-//         Ok(())
-//     });
-//
-//     sim.client("checker", async {
-//         // wait for cluster to form
-//         tokio::time::sleep(Duration::from_secs(10)).await;
-//
-//         check_node_is_all_alive("node-1", 8081).await?;
-//         check_node_is_all_alive("node-2", 8082).await?;
-//         check_node_is_all_alive("node-3", 8083).await?;
-//
-//         Ok(())
-//     });
-//
-//     sim.run()
-// }
-//
-// /// node-1 and node-3 are partitioned from each other.
-// /// They must learn about each other exclusively through node-2's gossip.
-// #[test]
-// fn partition_gossip() -> turmoil::Result {
-//     let mut sim = Builder::new()
-//         .tick_duration(Duration::from_millis(100))
-//         .simulation_duration(Duration::from_secs(120))
-//         .tcp_capacity(4096)
-//         .build();
-//     let _ = tracing_subscriber::fmt()
-//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-//         .try_init();
-//
-//     sim.host("node-1", || async {
-//         let me = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-2", || async {
-//         let me = turmoil::lookup("node-2");
-//         let n1 = turmoil::lookup("node-1");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-3", || async {
-//         let me = turmoil::lookup("node-3");
-//         let n1 = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-//         env.advertise_host = Some(me.to_string());
-//
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.client("checker", async {
-//         // wait for nodes to form cluster
-//         tracing::info!("[TEST] WAIT FOR NODES TO FORM CLUSTER");
-//         tokio::time::sleep(Duration::from_secs(30)).await;
-//
-//         // block all direct traffic between node-1 and node-3
-//         tracing::info!("[TEST] BLOCK ALL TRAFFIC BETWEEN node-1 and  node-3 !!");
-//         turmoil::partition("node-1", "node-3");
-//
-//         // wait for gossip through node-2 to propagate membership
-//         tokio::time::sleep(Duration::from_secs(60)).await;
-//         tracing::info!("[TEST] WAKEUP!!");
-//
-//         check_node_is_all_alive("node-1", 8081).await?;
-//         check_node_is_all_alive("node-2", 8082).await?;
-//         check_node_is_all_alive("node-3", 8083).await?;
-//
-//         Ok(())
-//     });
-//
-//     sim.run()
-// }
-//
-// /// node-3 process is killed and restarted.
-// #[test]
-// fn dead_node_rejoin_after_process_restart() -> turmoil::Result {
-//     let mut sim = Builder::new()
-//         .tick_duration(Duration::from_millis(100))
-//         .simulation_duration(Duration::from_secs(120))
-//         .tcp_capacity(4096)
-//         .build();
-//
-//     let _ = tracing_subscriber::fmt()
-//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-//         .try_init();
-//
-//     sim.host("node-1", || async {
-//         let me = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-2", || async {
-//         let me = turmoil::lookup("node-2");
-//         let n1 = turmoil::lookup("node-1");
-//         let n3 = turmoil::lookup("node-3");
-//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.host("node-3", || async {
-//         let me = turmoil::lookup("node-3");
-//         let n1 = turmoil::lookup("node-1");
-//         let n2 = turmoil::lookup("node-2");
-//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-//         env.advertise_host = Some(me.to_string());
-//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-//         StartUp::with_env(env, 0).run().await?;
-//         Ok(())
-//     });
-//
-//     sim.client("checker", async {
-//         // Phase 1: Wait for the cluster to form, then verify all 3 nodes are alive.
-//         tracing::info!("[TEST] Phase 1: waiting 10s for initial cluster formation...");
-//         tokio::time::sleep(Duration::from_secs(10)).await;
-//         tracing::info!("[TEST] Phase 1: verifying all 3 nodes are alive before crash");
-//         check_node_is_all_alive("node-1", 8081).await?;
-//         check_node_is_all_alive("node-2", 8082).await?;
-//         check_node_is_all_alive("node-3", 8083).await?;
-//         tracing::info!("[TEST] Phase 1: OK — all 3 nodes alive");
-//
-//         // Phase 2: node-3 is crashed at ~15s sim time.
-//         // Wait 20s for the SWIM failure detector to mark it Dead
-//         // (suspect window ~5s + probe round-trips → Dead within ~10-15s of the crash).
-//         tracing::info!("[TEST] Phase 2: waiting 20s for SWIM to detect node-3 as dead...");
-//         tokio::time::sleep(Duration::from_secs(20)).await; // ~30s total sim time
-//         tracing::info!("[TEST] Phase 2: verifying node-3 is dead or absent on all surviving nodes");
-//         assert!(
-//             check_dead_or_not_exist("node-1", 8081, "node-3").await,
-//             "node-1 should see node-3 as Dead or absent"
-//         );
-//         assert!(
-//             check_dead_or_not_exist("node-2", 8082, "node-3").await,
-//             "node-2 should see node-3 as Dead or absent"
-//         );
-//         tracing::info!(
-//             "[TEST] Phase 2: OK — node-3 confirmed dead or removed on all surviving nodes"
-//         );
-//
-//         // Phase 3: node-3 is restarted at ~40s sim time with a fresh UUID.
-//         // Wait 50s for its join pings to reach the cluster and gossip to converge.
-//         tracing::info!("[TEST] Phase 3: waiting 50s for node-3 to rejoin the cluster...");
-//         tokio::time::sleep(Duration::from_secs(50)).await; // ~80s total sim time
-//         tracing::info!("[TEST] Phase 3: verifying node-3 has rejoined");
-//         check_node_is_all_alive("node-1", 8081).await?;
-//         check_node_is_all_alive("node-2", 8082).await?;
-//         check_node_is_all_alive("node-3", 8083).await?;
-//         tracing::info!("[TEST] Phase 3: OK — all 3 nodes alive, node-3 successfully rejoined");
-//
-//         Ok(())
-//     });
-//
-//     // Crash node-3 after Phase 1 check has completed (~10s).
-//     while sim.elapsed() < Duration::from_secs(15) {
-//         sim.step()?;
-//     }
-//     tracing::info!(
-//         "[TEST] Crashing node-3 at {}s sim time",
-//         sim.elapsed().as_secs()
-//     );
-//     sim.crash("node-3");
-//
-//     // Step to ~40s — Phase 2 check completes by ~30s, giving a 10s gap before restart.
-//     while sim.elapsed() < Duration::from_secs(40) {
-//         sim.step()?;
-//     }
-//     // Restart node-3 — the host factory runs again with a fresh UUID.
-//     tracing::info!(
-//         "[TEST] Restarting node-3 with fresh UUID at {}s sim time",
-//         sim.elapsed().as_secs()
-//     );
-//     sim.bounce("node-3");
-//
-//     // Run remaining simulation until the checker client completes (~80s).
-//     sim.run()
-// }
+fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
+    Environment {
+        config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        node_id_prefix: Some(node_id),
+        port,
+        cluster_port,
+        host: "0.0.0.0".into(),
+        advertise_host: None,
+        vnodes_per_node: 16, // TODO: when set to 256, it hangs. Let's fix it
+        join_seed_nodes: vec![],
+        join_initial_delay_ms: 1000,
+        join_interval_ms: 1000,
+        join_multiplier: 2,
+        join_max_attempts: 5,
+    }
+}
+
+async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
+    let stream = TcpStream::connect((host, port)).await?;
+    let (read_half, write_half) = stream.into_split();
+    let mut writer = ClientStreamWriter::new(write_half);
+    let mut reader = ClientStreamReader::new(read_half);
+    writer.write(&ConnectionRequests::Query(GetMembers)).await?;
+    Ok(reader.read_request().await?)
+}
+
+async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
+    let members = get_members(host, port).await?;
+    tracing::info!("INSPECTING host: {}", host);
+    let alive_count = members
+        .iter()
+        .filter(|m| m.state == SwimNodeState::Alive)
+        .count();
+    assert_eq!(
+        alive_count, expected,
+        "{host} should have {expected} alive nodes, got {:?}",
+        members
+    );
+    Ok(())
+}
+
+/// Returns `true` if the node whose id starts with `target` is Dead or absent
+/// from the member list reported by `host`. Returns `false` on connection error
+/// or if the node is still Alive/Suspect.
+async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
+    let Ok(members) = get_members(host, port).await else {
+        tracing::warn!("[TEST] check_dead_or_not_exist: could not reach {host}");
+        return false;
+    };
+    match members.iter().find(|m| m.node_id.starts_with(target)) {
+        None => {
+            tracing::info!("[TEST] {host} has no entry for '{target}' — fully removed");
+            true
+        }
+        Some(n) if n.state == SwimNodeState::Dead => {
+            tracing::info!(
+                "[TEST] {host} sees '{target}' as Dead (incarnation={})",
+                n.incarnation
+            );
+            true
+        }
+        Some(n) => {
+            tracing::info!(
+                "[TEST] {host} sees '{target}' as {:?} — not dead yet (incarnation={})",
+                n.state,
+                n.incarnation
+            );
+            false
+        }
+    }
+}
+
+async fn check_node_is_all_alive(host: &str, port: u16) -> turmoil::Result {
+    check_alive_count(host, port, 3).await
+}
+
+#[test]
+fn cluster_setup() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(30))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    sim.host("node-1", || async {
+        let me = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let n3 = turmoil::lookup("node-3");
+
+        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        tracing::info!("NODE-1 is running");
+        Ok(())
+    });
+
+    sim.host("node-2", || async {
+        let me = turmoil::lookup("node-2");
+        let n1 = turmoil::lookup("node-1");
+        let n3 = turmoil::lookup("node-3");
+
+        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        tracing::info!("NODE-2 is running");
+        Ok(())
+    });
+
+    sim.host("node-3", || async {
+        let me = turmoil::lookup("node-3");
+        let n1 = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+
+        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+        StartUp::with_env(env, 0).run().await?;
+        tracing::info!("NODE-3 is running");
+        Ok(())
+    });
+
+    sim.client("checker", async {
+        // wait for cluster to form
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        check_node_is_all_alive("node-1", 8081).await?;
+        check_node_is_all_alive("node-2", 8082).await?;
+        check_node_is_all_alive("node-3", 8083).await?;
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// node-1 and node-3 are partitioned from each other.
+/// They must learn about each other exclusively through node-2's gossip.
+#[test]
+fn partition_gossip() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(120))
+        .tcp_capacity(4096)
+        .build();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    sim.host("node-1", || async {
+        let me = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-2", || async {
+        let me = turmoil::lookup("node-2");
+        let n1 = turmoil::lookup("node-1");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-3", || async {
+        let me = turmoil::lookup("node-3");
+        let n1 = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+        env.advertise_host = Some(me.to_string());
+
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.client("checker", async {
+        // wait for nodes to form cluster
+        tracing::info!("[TEST] WAIT FOR NODES TO FORM CLUSTER");
+        tokio::time::sleep(Duration::from_secs(30)).await;
+
+        // block all direct traffic between node-1 and node-3
+        tracing::info!("[TEST] BLOCK ALL TRAFFIC BETWEEN node-1 and  node-3 !!");
+        turmoil::partition("node-1", "node-3");
+
+        // wait for gossip through node-2 to propagate membership
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        tracing::info!("[TEST] WAKEUP!!");
+
+        check_node_is_all_alive("node-1", 8081).await?;
+        check_node_is_all_alive("node-2", 8082).await?;
+        check_node_is_all_alive("node-3", 8083).await?;
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// node-3 process is killed and restarted.
+#[test]
+fn dead_node_rejoin_after_process_restart() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(120))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    sim.host("node-1", || async {
+        let me = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-2", || async {
+        let me = turmoil::lookup("node-2");
+        let n1 = turmoil::lookup("node-1");
+        let n3 = turmoil::lookup("node-3");
+        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.host("node-3", || async {
+        let me = turmoil::lookup("node-3");
+        let n1 = turmoil::lookup("node-1");
+        let n2 = turmoil::lookup("node-2");
+        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+        env.advertise_host = Some(me.to_string());
+        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+        StartUp::with_env(env, 0).run().await?;
+        Ok(())
+    });
+
+    sim.client("checker", async {
+        // Phase 1: Wait for the cluster to form, then verify all 3 nodes are alive.
+        tracing::info!("[TEST] Phase 1: waiting 10s for initial cluster formation...");
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        tracing::info!("[TEST] Phase 1: verifying all 3 nodes are alive before crash");
+        check_node_is_all_alive("node-1", 8081).await?;
+        check_node_is_all_alive("node-2", 8082).await?;
+        check_node_is_all_alive("node-3", 8083).await?;
+        tracing::info!("[TEST] Phase 1: OK — all 3 nodes alive");
+
+        // Phase 2: node-3 is crashed at ~15s sim time.
+        // Wait 20s for the SWIM failure detector to mark it Dead
+        // (suspect window ~5s + probe round-trips → Dead within ~10-15s of the crash).
+        tracing::info!("[TEST] Phase 2: waiting 20s for SWIM to detect node-3 as dead...");
+        tokio::time::sleep(Duration::from_secs(20)).await; // ~30s total sim time
+        tracing::info!("[TEST] Phase 2: verifying node-3 is dead or absent on all surviving nodes");
+        assert!(
+            check_dead_or_not_exist("node-1", 8081, "node-3").await,
+            "node-1 should see node-3 as Dead or absent"
+        );
+        assert!(
+            check_dead_or_not_exist("node-2", 8082, "node-3").await,
+            "node-2 should see node-3 as Dead or absent"
+        );
+        tracing::info!(
+            "[TEST] Phase 2: OK — node-3 confirmed dead or removed on all surviving nodes"
+        );
+
+        // Phase 3: node-3 is restarted at ~40s sim time with a fresh UUID.
+        // Wait 50s for its join pings to reach the cluster and gossip to converge.
+        tracing::info!("[TEST] Phase 3: waiting 50s for node-3 to rejoin the cluster...");
+        tokio::time::sleep(Duration::from_secs(50)).await; // ~80s total sim time
+        tracing::info!("[TEST] Phase 3: verifying node-3 has rejoined");
+        check_node_is_all_alive("node-1", 8081).await?;
+        check_node_is_all_alive("node-2", 8082).await?;
+        check_node_is_all_alive("node-3", 8083).await?;
+        tracing::info!("[TEST] Phase 3: OK — all 3 nodes alive, node-3 successfully rejoined");
+
+        Ok(())
+    });
+
+    // Crash node-3 after Phase 1 check has completed (~10s).
+    while sim.elapsed() < Duration::from_secs(15) {
+        sim.step()?;
+    }
+    tracing::info!(
+        "[TEST] Crashing node-3 at {}s sim time",
+        sim.elapsed().as_secs()
+    );
+    sim.crash("node-3");
+
+    // Step to ~40s — Phase 2 check completes by ~30s, giving a 10s gap before restart.
+    while sim.elapsed() < Duration::from_secs(40) {
+        sim.step()?;
+    }
+    // Restart node-3 — the host factory runs again with a fresh UUID.
+    tracing::info!(
+        "[TEST] Restarting node-3 with fresh UUID at {}s sim time",
+        sim.elapsed().as_secs()
+    );
+    sim.bounce("node-3");
+
+    // Run remaining simulation until the checker client completes (~80s).
+    sim.run()
+}

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -1,339 +1,342 @@
-/// Make sure to run the test using RUST_LOG=debug cargo test -- --nocapture
-use crate::StartUp;
-use crate::clusters::{SwimNode, SwimNodeState};
-use crate::config::Environment;
-use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
-use crate::connections::request::ConnectionRequests;
-use crate::connections::request::QueryCommand::GetMembers;
-use crate::net::TcpStream;
-use std::time::Duration;
-use turmoil::Builder;
+// TODO: Fix. After integrating RocksDB, simulator hangs.
 
-fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
-    Environment {
-        config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-        data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-        meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-        node_id_prefix: Some(node_id),
-        port,
-        cluster_port,
-        host: "0.0.0.0".into(),
-        advertise_host: None,
-        vnodes_per_node: 256,
-        join_seed_nodes: vec![],
-        join_initial_delay_ms: 1000,
-        join_interval_ms: 1000,
-        join_multiplier: 2,
-        join_max_attempts: 5,
-    }
-}
 
-async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
-    let stream = TcpStream::connect((host, port)).await?;
-    let (read_half, write_half) = stream.into_split();
-    let mut writer = ClientStreamWriter::new(write_half);
-    let mut reader = ClientStreamReader::new(read_half);
-    writer.write(&ConnectionRequests::Query(GetMembers)).await?;
-    Ok(reader.read_request().await?)
-}
-
-async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
-    let members = get_members(host, port).await?;
-    tracing::info!("INSPECTING host: {}", host);
-    let alive_count = members
-        .iter()
-        .filter(|m| m.state == SwimNodeState::Alive)
-        .count();
-    assert_eq!(
-        alive_count, expected,
-        "{host} should have {expected} alive nodes, got {:?}",
-        members
-    );
-    Ok(())
-}
-
-/// Returns `true` if the node whose id starts with `target` is Dead or absent
-/// from the member list reported by `host`. Returns `false` on connection error
-/// or if the node is still Alive/Suspect.
-async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
-    let Ok(members) = get_members(host, port).await else {
-        tracing::warn!("[TEST] check_dead_or_not_exist: could not reach {host}");
-        return false;
-    };
-    match members.iter().find(|m| m.node_id.starts_with(target)) {
-        None => {
-            tracing::info!("[TEST] {host} has no entry for '{target}' — fully removed");
-            true
-        }
-        Some(n) if n.state == SwimNodeState::Dead => {
-            tracing::info!(
-                "[TEST] {host} sees '{target}' as Dead (incarnation={})",
-                n.incarnation
-            );
-            true
-        }
-        Some(n) => {
-            tracing::info!(
-                "[TEST] {host} sees '{target}' as {:?} — not dead yet (incarnation={})",
-                n.state,
-                n.incarnation
-            );
-            false
-        }
-    }
-}
-
-async fn check_node_is_all_alive(host: &str, port: u16) -> turmoil::Result {
-    check_alive_count(host, port, 3).await
-}
-
-#[test]
-fn cluster_setup() -> turmoil::Result {
-    let mut sim = Builder::new()
-        .simulation_duration(Duration::from_secs(30))
-        .tcp_capacity(4096)
-        .build();
-
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
-
-    sim.host("node-1", || async {
-        let me = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let n3 = turmoil::lookup("node-3");
-
-        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        tracing::info!("NODE-1 is running");
-        Ok(())
-    });
-
-    sim.host("node-2", || async {
-        let me = turmoil::lookup("node-2");
-        let n1 = turmoil::lookup("node-1");
-        let n3 = turmoil::lookup("node-3");
-
-        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        tracing::info!("NODE-2 is running");
-        Ok(())
-    });
-
-    sim.host("node-3", || async {
-        let me = turmoil::lookup("node-3");
-        let n1 = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-
-        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-        StartUp::with_env(env, 0).run().await?;
-        tracing::info!("NODE-3 is running");
-        Ok(())
-    });
-
-    sim.client("checker", async {
-        // wait for cluster to form
-        tokio::time::sleep(Duration::from_secs(10)).await;
-
-        check_node_is_all_alive("node-1", 8081).await?;
-        check_node_is_all_alive("node-2", 8082).await?;
-        check_node_is_all_alive("node-3", 8083).await?;
-
-        Ok(())
-    });
-
-    sim.run()
-}
-
-/// node-1 and node-3 are partitioned from each other.
-/// They must learn about each other exclusively through node-2's gossip.
-#[test]
-fn partition_gossip() -> turmoil::Result {
-    let mut sim = Builder::new()
-        .tick_duration(Duration::from_millis(100))
-        .simulation_duration(Duration::from_secs(120))
-        .tcp_capacity(4096)
-        .build();
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
-
-    sim.host("node-1", || async {
-        let me = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-2", || async {
-        let me = turmoil::lookup("node-2");
-        let n1 = turmoil::lookup("node-1");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-3", || async {
-        let me = turmoil::lookup("node-3");
-        let n1 = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-        env.advertise_host = Some(me.to_string());
-
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.client("checker", async {
-        // wait for nodes to form cluster
-        tracing::info!("[TEST] WAIT FOR NODES TO FORM CLUSTER");
-        tokio::time::sleep(Duration::from_secs(30)).await;
-
-        // block all direct traffic between node-1 and node-3
-        tracing::info!("[TEST] BLOCK ALL TRAFFIC BETWEEN node-1 and  node-3 !!");
-        turmoil::partition("node-1", "node-3");
-
-        // wait for gossip through node-2 to propagate membership
-        tokio::time::sleep(Duration::from_secs(60)).await;
-        tracing::info!("[TEST] WAKEUP!!");
-
-        check_node_is_all_alive("node-1", 8081).await?;
-        check_node_is_all_alive("node-2", 8082).await?;
-        check_node_is_all_alive("node-3", 8083).await?;
-
-        Ok(())
-    });
-
-    sim.run()
-}
-
-/// node-3 process is killed and restarted.
-#[test]
-fn dead_node_rejoin_after_process_restart() -> turmoil::Result {
-    let mut sim = Builder::new()
-        .tick_duration(Duration::from_millis(100))
-        .simulation_duration(Duration::from_secs(120))
-        .tcp_capacity(4096)
-        .build();
-
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
-
-    sim.host("node-1", || async {
-        let me = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-2", || async {
-        let me = turmoil::lookup("node-2");
-        let n1 = turmoil::lookup("node-1");
-        let n3 = turmoil::lookup("node-3");
-        let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.host("node-3", || async {
-        let me = turmoil::lookup("node-3");
-        let n1 = turmoil::lookup("node-1");
-        let n2 = turmoil::lookup("node-2");
-        let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
-        StartUp::with_env(env, 0).run().await?;
-        Ok(())
-    });
-
-    sim.client("checker", async {
-        // Phase 1: Wait for the cluster to form, then verify all 3 nodes are alive.
-        tracing::info!("[TEST] Phase 1: waiting 10s for initial cluster formation...");
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        tracing::info!("[TEST] Phase 1: verifying all 3 nodes are alive before crash");
-        check_node_is_all_alive("node-1", 8081).await?;
-        check_node_is_all_alive("node-2", 8082).await?;
-        check_node_is_all_alive("node-3", 8083).await?;
-        tracing::info!("[TEST] Phase 1: OK — all 3 nodes alive");
-
-        // Phase 2: node-3 is crashed at ~15s sim time.
-        // Wait 20s for the SWIM failure detector to mark it Dead
-        // (suspect window ~5s + probe round-trips → Dead within ~10-15s of the crash).
-        tracing::info!("[TEST] Phase 2: waiting 20s for SWIM to detect node-3 as dead...");
-        tokio::time::sleep(Duration::from_secs(20)).await; // ~30s total sim time
-        tracing::info!("[TEST] Phase 2: verifying node-3 is dead or absent on all surviving nodes");
-        assert!(
-            check_dead_or_not_exist("node-1", 8081, "node-3").await,
-            "node-1 should see node-3 as Dead or absent"
-        );
-        assert!(
-            check_dead_or_not_exist("node-2", 8082, "node-3").await,
-            "node-2 should see node-3 as Dead or absent"
-        );
-        tracing::info!(
-            "[TEST] Phase 2: OK — node-3 confirmed dead or removed on all surviving nodes"
-        );
-
-        // Phase 3: node-3 is restarted at ~40s sim time with a fresh UUID.
-        // Wait 50s for its join pings to reach the cluster and gossip to converge.
-        tracing::info!("[TEST] Phase 3: waiting 50s for node-3 to rejoin the cluster...");
-        tokio::time::sleep(Duration::from_secs(50)).await; // ~80s total sim time
-        tracing::info!("[TEST] Phase 3: verifying node-3 has rejoined");
-        check_node_is_all_alive("node-1", 8081).await?;
-        check_node_is_all_alive("node-2", 8082).await?;
-        check_node_is_all_alive("node-3", 8083).await?;
-        tracing::info!("[TEST] Phase 3: OK — all 3 nodes alive, node-3 successfully rejoined");
-
-        Ok(())
-    });
-
-    // Crash node-3 after Phase 1 check has completed (~10s).
-    while sim.elapsed() < Duration::from_secs(15) {
-        sim.step()?;
-    }
-    tracing::info!(
-        "[TEST] Crashing node-3 at {}s sim time",
-        sim.elapsed().as_secs()
-    );
-    sim.crash("node-3");
-
-    // Step to ~40s — Phase 2 check completes by ~30s, giving a 10s gap before restart.
-    while sim.elapsed() < Duration::from_secs(40) {
-        sim.step()?;
-    }
-    // Restart node-3 — the host factory runs again with a fresh UUID.
-    tracing::info!(
-        "[TEST] Restarting node-3 with fresh UUID at {}s sim time",
-        sim.elapsed().as_secs()
-    );
-    sim.bounce("node-3");
-
-    // Run remaining simulation until the checker client completes (~80s).
-    sim.run()
-}
+// /// Make sure to run the test using RUST_LOG=debug cargo test -- --nocapture
+// use crate::StartUp;
+// use crate::clusters::{SwimNode, SwimNodeState};
+// use crate::config::Environment;
+// use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
+// use crate::connections::request::ConnectionRequests;
+// use crate::connections::request::QueryCommand::GetMembers;
+// use crate::net::TcpStream;
+// use std::time::Duration;
+// use turmoil::Builder;
+//
+// fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
+//     Environment {
+//         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+//         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+//         meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+//         node_id_prefix: Some(node_id),
+//         port,
+//         cluster_port,
+//         host: "0.0.0.0".into(),
+//         advertise_host: None,
+//         vnodes_per_node: 256,
+//         join_seed_nodes: vec![],
+//         join_initial_delay_ms: 1000,
+//         join_interval_ms: 1000,
+//         join_multiplier: 2,
+//         join_max_attempts: 5,
+//     }
+// }
+//
+// async fn get_members(host: &str, port: u16) -> turmoil::Result<Vec<SwimNode>> {
+//     let stream = TcpStream::connect((host, port)).await?;
+//     let (read_half, write_half) = stream.into_split();
+//     let mut writer = ClientStreamWriter::new(write_half);
+//     let mut reader = ClientStreamReader::new(read_half);
+//     writer.write(&ConnectionRequests::Query(GetMembers)).await?;
+//     Ok(reader.read_request().await?)
+// }
+//
+// async fn check_alive_count(host: &str, port: u16, expected: usize) -> turmoil::Result {
+//     let members = get_members(host, port).await?;
+//     tracing::info!("INSPECTING host: {}", host);
+//     let alive_count = members
+//         .iter()
+//         .filter(|m| m.state == SwimNodeState::Alive)
+//         .count();
+//     assert_eq!(
+//         alive_count, expected,
+//         "{host} should have {expected} alive nodes, got {:?}",
+//         members
+//     );
+//     Ok(())
+// }
+//
+// /// Returns `true` if the node whose id starts with `target` is Dead or absent
+// /// from the member list reported by `host`. Returns `false` on connection error
+// /// or if the node is still Alive/Suspect.
+// async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> bool {
+//     let Ok(members) = get_members(host, port).await else {
+//         tracing::warn!("[TEST] check_dead_or_not_exist: could not reach {host}");
+//         return false;
+//     };
+//     match members.iter().find(|m| m.node_id.starts_with(target)) {
+//         None => {
+//             tracing::info!("[TEST] {host} has no entry for '{target}' — fully removed");
+//             true
+//         }
+//         Some(n) if n.state == SwimNodeState::Dead => {
+//             tracing::info!(
+//                 "[TEST] {host} sees '{target}' as Dead (incarnation={})",
+//                 n.incarnation
+//             );
+//             true
+//         }
+//         Some(n) => {
+//             tracing::info!(
+//                 "[TEST] {host} sees '{target}' as {:?} — not dead yet (incarnation={})",
+//                 n.state,
+//                 n.incarnation
+//             );
+//             false
+//         }
+//     }
+// }
+//
+// async fn check_node_is_all_alive(host: &str, port: u16) -> turmoil::Result {
+//     check_alive_count(host, port, 3).await
+// }
+//
+// #[test]
+// fn cluster_setup() -> turmoil::Result {
+//     let mut sim = Builder::new()
+//         .simulation_duration(Duration::from_secs(30))
+//         .tcp_capacity(4096)
+//         .build();
+//
+//     let _ = tracing_subscriber::fmt()
+//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+//         .try_init();
+//
+//     sim.host("node-1", || async {
+//         let me = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let n3 = turmoil::lookup("node-3");
+//
+//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         tracing::info!("NODE-1 is running");
+//         Ok(())
+//     });
+//
+//     sim.host("node-2", || async {
+//         let me = turmoil::lookup("node-2");
+//         let n1 = turmoil::lookup("node-1");
+//         let n3 = turmoil::lookup("node-3");
+//
+//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         tracing::info!("NODE-2 is running");
+//         Ok(())
+//     });
+//
+//     sim.host("node-3", || async {
+//         let me = turmoil::lookup("node-3");
+//         let n1 = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//
+//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+//         StartUp::with_env(env, 0).run().await?;
+//         tracing::info!("NODE-3 is running");
+//         Ok(())
+//     });
+//
+//     sim.client("checker", async {
+//         // wait for cluster to form
+//         tokio::time::sleep(Duration::from_secs(10)).await;
+//
+//         check_node_is_all_alive("node-1", 8081).await?;
+//         check_node_is_all_alive("node-2", 8082).await?;
+//         check_node_is_all_alive("node-3", 8083).await?;
+//
+//         Ok(())
+//     });
+//
+//     sim.run()
+// }
+//
+// /// node-1 and node-3 are partitioned from each other.
+// /// They must learn about each other exclusively through node-2's gossip.
+// #[test]
+// fn partition_gossip() -> turmoil::Result {
+//     let mut sim = Builder::new()
+//         .tick_duration(Duration::from_millis(100))
+//         .simulation_duration(Duration::from_secs(120))
+//         .tcp_capacity(4096)
+//         .build();
+//     let _ = tracing_subscriber::fmt()
+//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+//         .try_init();
+//
+//     sim.host("node-1", || async {
+//         let me = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-2", || async {
+//         let me = turmoil::lookup("node-2");
+//         let n1 = turmoil::lookup("node-1");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-3", || async {
+//         let me = turmoil::lookup("node-3");
+//         let n1 = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+//         env.advertise_host = Some(me.to_string());
+//
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.client("checker", async {
+//         // wait for nodes to form cluster
+//         tracing::info!("[TEST] WAIT FOR NODES TO FORM CLUSTER");
+//         tokio::time::sleep(Duration::from_secs(30)).await;
+//
+//         // block all direct traffic between node-1 and node-3
+//         tracing::info!("[TEST] BLOCK ALL TRAFFIC BETWEEN node-1 and  node-3 !!");
+//         turmoil::partition("node-1", "node-3");
+//
+//         // wait for gossip through node-2 to propagate membership
+//         tokio::time::sleep(Duration::from_secs(60)).await;
+//         tracing::info!("[TEST] WAKEUP!!");
+//
+//         check_node_is_all_alive("node-1", 8081).await?;
+//         check_node_is_all_alive("node-2", 8082).await?;
+//         check_node_is_all_alive("node-3", 8083).await?;
+//
+//         Ok(())
+//     });
+//
+//     sim.run()
+// }
+//
+// /// node-3 process is killed and restarted.
+// #[test]
+// fn dead_node_rejoin_after_process_restart() -> turmoil::Result {
+//     let mut sim = Builder::new()
+//         .tick_duration(Duration::from_millis(100))
+//         .simulation_duration(Duration::from_secs(120))
+//         .tcp_capacity(4096)
+//         .build();
+//
+//     let _ = tracing_subscriber::fmt()
+//         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+//         .try_init();
+//
+//     sim.host("node-1", || async {
+//         let me = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(1, "node-1".to_string(), 8081, 18001);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n2}:18002"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-2", || async {
+//         let me = turmoil::lookup("node-2");
+//         let n1 = turmoil::lookup("node-1");
+//         let n3 = turmoil::lookup("node-3");
+//         let mut env = default_env(2, "node-2".to_string(), 8082, 18002);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n3}:18003")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.host("node-3", || async {
+//         let me = turmoil::lookup("node-3");
+//         let n1 = turmoil::lookup("node-1");
+//         let n2 = turmoil::lookup("node-2");
+//         let mut env = default_env(3, "node-3".to_string(), 8083, 18003);
+//         env.advertise_host = Some(me.to_string());
+//         env.join_seed_nodes = vec![format!("{n1}:18001"), format!("{n2}:18002")];
+//         StartUp::with_env(env, 0).run().await?;
+//         Ok(())
+//     });
+//
+//     sim.client("checker", async {
+//         // Phase 1: Wait for the cluster to form, then verify all 3 nodes are alive.
+//         tracing::info!("[TEST] Phase 1: waiting 10s for initial cluster formation...");
+//         tokio::time::sleep(Duration::from_secs(10)).await;
+//         tracing::info!("[TEST] Phase 1: verifying all 3 nodes are alive before crash");
+//         check_node_is_all_alive("node-1", 8081).await?;
+//         check_node_is_all_alive("node-2", 8082).await?;
+//         check_node_is_all_alive("node-3", 8083).await?;
+//         tracing::info!("[TEST] Phase 1: OK — all 3 nodes alive");
+//
+//         // Phase 2: node-3 is crashed at ~15s sim time.
+//         // Wait 20s for the SWIM failure detector to mark it Dead
+//         // (suspect window ~5s + probe round-trips → Dead within ~10-15s of the crash).
+//         tracing::info!("[TEST] Phase 2: waiting 20s for SWIM to detect node-3 as dead...");
+//         tokio::time::sleep(Duration::from_secs(20)).await; // ~30s total sim time
+//         tracing::info!("[TEST] Phase 2: verifying node-3 is dead or absent on all surviving nodes");
+//         assert!(
+//             check_dead_or_not_exist("node-1", 8081, "node-3").await,
+//             "node-1 should see node-3 as Dead or absent"
+//         );
+//         assert!(
+//             check_dead_or_not_exist("node-2", 8082, "node-3").await,
+//             "node-2 should see node-3 as Dead or absent"
+//         );
+//         tracing::info!(
+//             "[TEST] Phase 2: OK — node-3 confirmed dead or removed on all surviving nodes"
+//         );
+//
+//         // Phase 3: node-3 is restarted at ~40s sim time with a fresh UUID.
+//         // Wait 50s for its join pings to reach the cluster and gossip to converge.
+//         tracing::info!("[TEST] Phase 3: waiting 50s for node-3 to rejoin the cluster...");
+//         tokio::time::sleep(Duration::from_secs(50)).await; // ~80s total sim time
+//         tracing::info!("[TEST] Phase 3: verifying node-3 has rejoined");
+//         check_node_is_all_alive("node-1", 8081).await?;
+//         check_node_is_all_alive("node-2", 8082).await?;
+//         check_node_is_all_alive("node-3", 8083).await?;
+//         tracing::info!("[TEST] Phase 3: OK — all 3 nodes alive, node-3 successfully rejoined");
+//
+//         Ok(())
+//     });
+//
+//     // Crash node-3 after Phase 1 check has completed (~10s).
+//     while sim.elapsed() < Duration::from_secs(15) {
+//         sim.step()?;
+//     }
+//     tracing::info!(
+//         "[TEST] Crashing node-3 at {}s sim time",
+//         sim.elapsed().as_secs()
+//     );
+//     sim.crash("node-3");
+//
+//     // Step to ~40s — Phase 2 check completes by ~30s, giving a 10s gap before restart.
+//     while sim.elapsed() < Duration::from_secs(40) {
+//         sim.step()?;
+//     }
+//     // Restart node-3 — the host factory runs again with a fresh UUID.
+//     tracing::info!(
+//         "[TEST] Restarting node-3 with fresh UUID at {}s sim time",
+//         sim.elapsed().as_secs()
+//     );
+//     sim.bounce("node-3");
+//
+//     // Run remaining simulation until the checker client completes (~80s).
+//     sim.run()
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@ mod config;
 mod connections;
 
 mod clusters;
-pub(crate) mod storage;
 
 mod net;
 pub(crate) mod schedulers;
 
+pub(crate) mod impls;
 #[cfg(test)]
 mod it;
 pub(crate) mod macros;
@@ -19,6 +19,7 @@ use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::{SwimCommand, SwimQueryCommand};
 use crate::config::Environment;
 use crate::connections::request::QueryCommand;
+use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
 use crate::{
@@ -95,7 +96,7 @@ impl StartUp {
             swim_ticker_tx,
             raft_tx,
         ));
-        let raft_db = crate::storage::Db::open(self.env.raft_db_path());
+        let raft_db = MetadataStorage::open(self.env.raft_db_path());
         tokio::spawn(MultiRaftActor::run(
             node_id,
             Box::new(raft_db),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl StartUp {
             swim_ticker_tx,
             raft_tx,
         ));
-        let raft_db = crate::storage::RaftDb::open(self.env.raft_db_path());
+        let raft_db = crate::storage::Db::open(self.env.raft_db_path());
         tokio::spawn(MultiRaftActor::run(
             node_id,
             raft_db,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod connections;
 
 mod clusters;
+pub(crate) mod storage;
 
 mod net;
 pub(crate) mod schedulers;
@@ -94,8 +95,10 @@ impl StartUp {
             swim_ticker_tx,
             raft_tx,
         ));
+        let raft_db = crate::storage::RaftDb::open(self.env.raft_db_path());
         tokio::spawn(MultiRaftActor::run(
             node_id,
+            raft_db,
             raft_mailbox,
             raft_transport_tx,
             raft_ticker_tx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ impl StartUp {
         // Raft channels
         let (raft_tx, raft_mailbox) = mpsc::channel(4096);
         let (raft_transport_tx, raft_transport_rx) = mpsc::channel(100);
-        let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel(64);
+        let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel(self.env.vnodes_per_node as usize * 4);
 
         // Build SWIM state and extract node_id before handing state to the actor
         let state = self.env.swim(self.rng_seed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl StartUp {
         let raft_db = crate::storage::Db::open(self.env.raft_db_path());
         tokio::spawn(MultiRaftActor::run(
             node_id,
-            raft_db,
+            Box::new(raft_db),
             raft_mailbox,
             raft_transport_tx,
             raft_ticker_tx,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -129,7 +129,12 @@ impl Db {
             }
         }
 
-        self.db.write(batch).expect("failed to write batch");
+        // ! SAFETY: without the following sync option, Raft's safety is not guaranteed
+        let mut write_opts = rocksdb::WriteOptions::default();
+        write_opts.set_sync(true);
+        self.db
+            .write_opt(batch, &write_opts)
+            .expect("failed to write batch");
     }
 
     pub(crate) fn scan_range(&self, cf_name: &str, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,35 +1,18 @@
-#[allow(dead_code)]
-pub(crate) const CF_META: &str = "meta";
-pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
+use crate::clusters::{
+    BINCODE_CONFIG, NodeId,
+    raft::{log::LogEntry, messages::LogMutation, storage::RaftPersistentState},
+    swims::ShardGroupId,
+};
 
-/// Per-shard column family key space.
-///
-/// Layout (one CF per shard group):
-///   0x01 + u64 BE  →  LogEntry        (9 bytes; lexicographic = numeric order)
-///   0x02           →  HardState       (1 byte)
-///   0x03           →  SnapMeta        (1 byte)
-///   0x04           →  SnapData        (1 byte)
-///   0x05           →  AppliedIndex    (1 byte)
-///   0x06           →  Epoch           (1 byte)
-///
-/// Log entries (0x01…) sort strictly before metadata keys (0x02–0x06).
-/// delete_range on 0x01..0x02 safely compacts only log entries.
+/// Per-shard key space within the default column family.
+/// read storage-key-layout.md for more information
 #[allow(dead_code)]
 pub(crate) enum ShardCfKey {
-    /// Raft log entry at the given 1-based index.
     LogEntry(u64),
-    /// Durable Raft state (current_term, voted_for) — must survive restarts.
     HardState,
-    /// Snapshot descriptor (last_included_index/term, peers, epoch).
-    /// Leader writes on checkpoint; follower writes on InstallSnapshot RPC arrival.
-    /// Survives crashes mid-transfer — missing SnapData means transfer must restart.
     SnapMeta,
-    /// Full state machine payload (topics, ranges, segments) — only sent to followers too far behind for log replication.
-    /// Written after full out-of-band stream is received and checksum-verified.
     SnapData,
-    /// Highest log index applied to the state machine — determines replay boundary on restart.
     AppliedIndex,
-    /// Shard membership + topology version — incremented on AddPeer/RemovePeer to detect stale routing.
     Epoch,
 }
 
@@ -49,24 +32,48 @@ impl ShardCfKey {
             ShardCfKey::Epoch => vec![0x06],
         }
     }
-}
 
-const LOG_ENTRY_RANGE_END: &[u8] = &[0x02];
-
-pub(crate) fn shard_cf_name(id: u64) -> String {
-    format!("{CF_SHARD_PREFIX}{id:016x}")
+    pub(crate) fn encode_for(&self, group_id: u64) -> Vec<u8> {
+        let suffix = self.encode();
+        let mut key = Vec::with_capacity(8 + suffix.len());
+        key.extend_from_slice(&group_id.to_be_bytes());
+        key.extend_from_slice(&suffix);
+        key
+    }
 }
 
 pub(crate) enum DbOp {
-    Put {
-        cf: String,
-        key: Vec<u8>,
-        value: Vec<u8>,
-    },
-    DeleteFrom {
-        cf: String,
-        index: Vec<u8>,
-    },
+    Put { key: Vec<u8>, value: Vec<u8> },
+    DeleteRange { start: Vec<u8>, end: Vec<u8> },
+}
+impl DbOp {
+    pub(crate) fn from_log(id: &ShardGroupId, log: LogMutation) -> Self {
+        fn put_log_entry(group_id: u64, entry: &LogEntry) -> DbOp {
+            let key = ShardCfKey::LogEntry(entry.index).encode_for(group_id);
+            let value =
+                bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
+            DbOp::Put { key, value }
+        }
+
+        fn put_hard_state(group_id: u64, term: u64, voted_for: Option<NodeId>) -> DbOp {
+            let key = ShardCfKey::HardState.encode_for(group_id);
+            let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
+                .expect("encode HardState failed");
+            DbOp::Put { key, value }
+        }
+
+        fn delete_from(group_id: u64, from_index: u64) -> DbOp {
+            let start = ShardCfKey::LogEntry(from_index).encode_for(group_id);
+            let end = ShardCfKey::HardState.encode_for(group_id);
+            DbOp::DeleteRange { start, end }
+        }
+
+        match log {
+            LogMutation::Append(entry) => put_log_entry(id.0, &entry),
+            LogMutation::TruncateFrom(index) => delete_from(id.0, index),
+            LogMutation::HardState { term, voted_for } => put_hard_state(id.0, term, voted_for),
+        }
+    }
 }
 
 /// Opaque handle to the node's RocksDB instance.
@@ -79,31 +86,13 @@ impl Db {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
-        opts.create_missing_column_families(true);
-
-        let cf_names = rocksdb::DB::list_cf(&opts, &path).unwrap_or_default();
-        let db = rocksdb::DB::open_cf(&opts, &path, &cf_names).expect("failed to open RocksDB");
+        let db = rocksdb::DB::open(&opts, &path).expect("failed to open RocksDB");
         Self { db }
     }
 
-    pub(crate) fn create_cf(&mut self, name: &str) {
-        self.db
-            .create_cf(name, &rocksdb::Options::default())
-            .expect("failed to create column family");
-    }
-
-    pub(crate) fn drop_cf(&mut self, name: &str) {
-        let _ = self.db.drop_cf(name);
-    }
-
-    pub(crate) fn has_cf(&self, name: &str) -> bool {
-        self.db.cf_handle(name).is_some()
-    }
-
-    pub(crate) fn get_value(&self, cf_name: &str, key: &[u8]) -> Option<Vec<u8>> {
-        let cf = self.db.cf_handle(cf_name)?;
-        self.db.get_cf(cf, key).unwrap_or_else(|e| {
-            tracing::error!("Error retrieving: {}", e);
+    pub(crate) fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.db.get(key).unwrap_or_else(|e| {
+            tracing::error!("RocksDB get error: {}", e);
             None
         })
     }
@@ -112,24 +101,16 @@ impl Db {
         let mut batch = rocksdb::WriteBatch::default();
         for operation in operations {
             match operation {
-                DbOp::Put { cf, key, value } => {
-                    let cf = self
-                        .db
-                        .cf_handle(cf)
-                        .unwrap_or_else(|| panic!("CF {cf} not found"));
-                    batch.put_cf(cf, key, value)
+                DbOp::Put { key, value } => {
+                    batch.put(key, value);
                 }
-                DbOp::DeleteFrom { cf, index: start } => {
-                    let cf = self
-                        .db
-                        .cf_handle(cf)
-                        .unwrap_or_else(|| panic!("CF {cf} not found"));
-                    batch.delete_range_cf(&cf, start.as_slice(), LOG_ENTRY_RANGE_END);
+                DbOp::DeleteRange { start, end } => {
+                    batch.delete_range(start, end);
                 }
             }
         }
 
-        // ! SAFETY: without the following sync option, Raft's safety is not guaranteed
+        // Raft safety requires WAL sync before acknowledging writes
         let mut write_opts = rocksdb::WriteOptions::default();
         write_opts.set_sync(true);
         self.db
@@ -137,26 +118,60 @@ impl Db {
             .expect("failed to write batch");
     }
 
-    pub(crate) fn scan_range(&self, cf_name: &str, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
-        let Some(cf) = self.db.cf_handle(cf_name) else {
-            return vec![];
-        };
+    pub(crate) fn scan_range(&self, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_upper_bound(end.to_vec());
         self.db
-            .iterator_cf_opt(
-                &cf,
-                opts,
+            .iterator_opt(
                 rocksdb::IteratorMode::From(start, rocksdb::Direction::Forward),
+                opts,
             )
             .flatten()
             .map(|(_, v)| v.to_vec())
             .collect()
     }
 
+    pub(crate) fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
+        let Some(bytes) = self.get(&ShardCfKey::HardState.encode_for(group_id)) else {
+            return RaftPersistentState::default();
+        };
+
+        let ((term, voted_for), _) =
+            bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG)
+                .expect("corrupt HardState");
+
+        let log = self.get_log_entries(group_id);
+        RaftPersistentState {
+            term,
+            voted_for,
+            log,
+        }
+    }
+
+    pub(crate) fn get_log_entries(&self, group_id: u64) -> Vec<LogEntry> {
+        let start = ShardCfKey::LogEntry(0).encode_for(group_id);
+        let end = ShardCfKey::HardState.encode_for(group_id);
+        self.scan_range(&start, &end)
+            .into_iter()
+            .map(|bytes| {
+                let (entry, _) = bincode::decode_from_slice::<LogEntry, _>(&bytes, BINCODE_CONFIG)
+                    .expect("corrupt LogEntry in RocksDB");
+                entry
+            })
+            .collect()
+    }
+
+    pub(crate) fn delete_range(&self, group_id: ShardGroupId) {
+        let start: &[u8] = &group_id.0.to_be_bytes();
+        let end: &[u8] = &(group_id.0 + 1).to_be_bytes();
+
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.delete_range(start, end);
+        self.db.write(batch).expect("failed to delete range");
+    }
+
     #[cfg(test)]
-    pub(crate) fn get_cf(&self, cf_name: &str, key: &[u8]) -> Option<Vec<u8>> {
-        let cf = self.db.cf_handle(cf_name)?;
-        self.db.get_cf(cf, key).ok().flatten()
+    pub(crate) fn get_key(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.db.get(key).ok().flatten()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,8 +12,8 @@ pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
 ///   0x05           →  AppliedIndex    (1 byte)
 ///   0x06           →  Epoch           (1 byte)
 ///
-/// Metadata keys (0x02–0x06) sort strictly before all log entries (0x01…).
-/// delete_range on 0x01..0x01+MAX safely compacts only log entries.
+/// Log entries (0x01…) sort strictly before metadata keys (0x02–0x06).
+/// delete_range on 0x01..0x02 safely compacts only log entries.
 #[allow(dead_code)]
 pub(crate) enum ShardCfKey {
     /// Raft log entry at the given 1-based index.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -72,27 +72,6 @@ pub(crate) enum DbOp {
     },
 }
 
-/// we place the following functions under WriteOperation so that Raft details don't leak into Storage layer
-impl DbOp {
-    pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> Self {
-        let key = ShardCfKey::LogEntry(entry.index).encode();
-        let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
-        DbOp::Put { cf: cf.to_owned(), key, value }
-    }
-
-    pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> Self {
-        let key = ShardCfKey::HardState.encode();
-        let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
-            .expect("encode HardState failed");
-        DbOp::Put { cf: cf.to_owned(), key, value }
-    }
-
-    pub(crate) fn delete_from(cf: &str, from_index: u64) -> Self {
-        let index = ShardCfKey::LogEntry(from_index).encode();
-        DbOp::DeleteFrom { cf: cf.to_owned(), index }
-    }
-}
-
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
 pub(crate) struct Db {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -132,6 +132,23 @@ impl Db {
         self.db.write(batch).expect("failed to write batch");
     }
 
+    pub(crate) fn scan_range(&self, cf_name: &str, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
+        let Some(cf) = self.db.cf_handle(cf_name) else {
+            return vec![];
+        };
+        let mut opts = rocksdb::ReadOptions::default();
+        opts.set_iterate_upper_bound(end.to_vec());
+        self.db
+            .iterator_cf_opt(
+                &cf,
+                opts,
+                rocksdb::IteratorMode::From(start, rocksdb::Direction::Forward),
+            )
+            .flatten()
+            .map(|(_, v)| v.to_vec())
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn get_cf(&self, cf_name: &str, key: &[u8]) -> Option<Vec<u8>> {
         let cf = self.db.cf_handle(cf_name)?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -82,14 +82,19 @@ impl DbOp {
 
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
-pub(crate) struct Db(rocksdb::DB);
+pub(crate) struct Db {
+    db: rocksdb::DB,
+    sync_opts: rocksdb::WriteOptions,
+}
 
 impl Db {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, &path).expect("failed to open RocksDB");
-        Self(db)
+        let mut sync_opts = rocksdb::WriteOptions::default();
+        sync_opts.set_sync(true);
+        Self { db, sync_opts }
     }
 
     fn write_batch(&self, operations: &[DbOp]) {
@@ -105,18 +110,15 @@ impl Db {
             }
         }
 
-        // Raft safety requires WAL sync before acknowledging writes
-        let mut write_opts = rocksdb::WriteOptions::default();
-        write_opts.set_sync(true);
-        self.0
-            .write_opt(batch, &write_opts)
+        self.db
+            .write_opt(batch, &self.sync_opts)
             .expect("failed to write batch");
     }
 
     fn scan_range(&self, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_upper_bound(end.to_vec());
-        self.0
+        self.db
             .iterator_opt(
                 rocksdb::IteratorMode::From(start, rocksdb::Direction::Forward),
                 opts,
@@ -128,7 +130,7 @@ impl Db {
 
     fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
         let Some(bytes) = self
-            .0
+            .db
             .get(ShardCfKey::HardState.encode_for(group_id))
             .unwrap_or_else(|e| {
                 tracing::error!("RocksDB get error: {}", e);
@@ -169,7 +171,9 @@ impl Db {
 
         let mut batch = rocksdb::WriteBatch::default();
         batch.delete_range(start, end);
-        self.0.write(batch).expect("failed to delete range");
+        self.db
+            .write_opt(batch, &self.sync_opts)
+            .expect("failed to delete range");
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -129,7 +129,7 @@ impl Db {
     pub(crate) fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
         let Some(bytes) = self
             .0
-            .get(&ShardCfKey::HardState.encode_for(group_id))
+            .get(ShardCfKey::HardState.encode_for(group_id))
             .unwrap_or_else(|e| {
                 tracing::error!("RocksDB get error: {}", e);
                 None

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -58,7 +58,9 @@ pub(crate) fn shard_cf_name(id: u64) -> String {
 
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
-pub(crate) struct RaftDb(rocksdb::DB);
+pub(crate) struct RaftDb {
+    db: rocksdb::DB
+}
 
 impl RaftDb {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
@@ -69,20 +71,20 @@ impl RaftDb {
         let cf_names = rocksdb::DB::list_cf(&opts, &path).unwrap_or_default();
         let db = rocksdb::DB::open_cf(&opts, &path, &cf_names)
             .expect("failed to open RocksDB");
-        Self(db)
+        Self { db }
     }
 
     pub(crate) fn create_cf(&mut self, name: &str) {
-        self.0
+        self.db
             .create_cf(name, &rocksdb::Options::default())
             .expect("failed to create column family");
     }
 
     pub(crate) fn drop_cf(&mut self, name: &str) {
-        let _ = self.0.drop_cf(name);
+        let _ = self.db.drop_cf(name);
     }
 
     pub(crate) fn has_cf(&self, name: &str) -> bool {
-        self.0.cf_handle(name).is_some()
+        self.db.cf_handle(name).is_some()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -116,7 +116,9 @@ impl Db {
     }
 
     fn scan_range(&self, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
+        //ReadOptions mutated per-call — set_iterate_upper_bound(end.to_vec()) changes each time. Can't reuse.
         let mut opts = rocksdb::ReadOptions::default();
+
         opts.set_iterate_upper_bound(end.to_vec());
         self.db
             .iterator_opt(
@@ -132,10 +134,7 @@ impl Db {
         let Some(bytes) = self
             .db
             .get(ShardCfKey::HardState.encode_for(group_id))
-            .unwrap_or_else(|e| {
-                tracing::error!("RocksDB get error: {}", e);
-                None
-            })
+            .unwrap_or_default()
         else {
             return RaftPersistentState::default();
         };
@@ -144,15 +143,14 @@ impl Db {
             bincode::decode_from_slice::<(u64, Option<NodeId>), _>(&bytes, BINCODE_CONFIG)
                 .expect("corrupt HardState");
 
-        let log = self.get_log_entries(group_id);
         RaftPersistentState {
             term,
             voted_for,
-            log,
+            log: self.list_log_entires(group_id),
         }
     }
 
-    fn get_log_entries(&self, group_id: u64) -> Vec<LogEntry> {
+    fn list_log_entires(&self, group_id: u64) -> Vec<LogEntry> {
         let start = ShardCfKey::LogEntry(0).encode_for(group_id);
         let end = ShardCfKey::HardState.encode_for(group_id);
         self.scan_range(&start, &end)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,56 @@
+#[allow(dead_code)]
+pub(crate) const CF_META: &str = "meta";
+pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
+
+/// Per-shard column family key space.
+///
+/// Layout (one CF per shard group):
+///   0x01 + u64 BE  →  LogEntry        (9 bytes; lexicographic = numeric order)
+///   0x02           →  HardState       (1 byte)
+///   0x03           →  SnapMeta        (1 byte)
+///   0x04           →  SnapData        (1 byte)
+///   0x05           →  AppliedIndex    (1 byte)
+///   0x06           →  Epoch           (1 byte)
+///
+/// Metadata keys (0x02–0x06) sort strictly before all log entries (0x01…).
+/// delete_range on 0x01..0x01+MAX safely compacts only log entries.
+#[allow(dead_code)]
+pub(crate) enum ShardCfKey {
+    /// Raft log entry at the given 1-based index.
+    LogEntry(u64),
+    /// Durable Raft state (current_term, voted_for) — must survive restarts.
+    HardState,
+    /// Snapshot descriptor (last_included_index/term, peers, epoch).
+    /// Leader writes on checkpoint; follower writes on InstallSnapshot RPC arrival.
+    /// Survives crashes mid-transfer — missing SnapData means transfer must restart.
+    SnapMeta,
+    /// Full state machine payload (topics, ranges, segments) — only sent to followers too far behind for log replication.
+    /// Written after full out-of-band stream is received and checksum-verified.
+    SnapData,
+    /// Highest log index applied to the state machine — determines replay boundary on restart.
+    AppliedIndex,
+    /// Shard membership + topology version — incremented on AddPeer/RemovePeer to detect stale routing.
+    Epoch,
+}
+
+impl ShardCfKey {
+    pub(crate) fn encode(&self) -> Vec<u8> {
+        match self {
+            ShardCfKey::LogEntry(index) => {
+                let mut key = Vec::with_capacity(9);
+                key.push(0x01);
+                key.extend_from_slice(&index.to_be_bytes());
+                key
+            }
+            ShardCfKey::HardState   => vec![0x02],
+            ShardCfKey::SnapMeta    => vec![0x03],
+            ShardCfKey::SnapData    => vec![0x04],
+            ShardCfKey::AppliedIndex => vec![0x05],
+            ShardCfKey::Epoch       => vec![0x06],
+        }
+    }
+}
+
+pub(crate) fn shard_cf_name(id: u64) -> String {
+    format!("{CF_SHARD_PREFIX}{id:016x}")
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,3 @@
-use crate::clusters::raft::log::LogEntry;
-use crate::clusters::{BINCODE_CONFIG, NodeId};
-
-#[allow(dead_code)]
 pub(crate) const CF_META: &str = "meta";
 pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
 
@@ -101,6 +97,14 @@ impl Db {
 
     pub(crate) fn has_cf(&self, name: &str) -> bool {
         self.db.cf_handle(name).is_some()
+    }
+
+    pub(crate) fn get_value(&self, cf_name: &str, key: &[u8]) -> Option<Vec<u8>> {
+        let cf = self.db.cf_handle(cf_name)?;
+        self.db.get_cf(cf, key).unwrap_or_else(|e| {
+            tracing::error!("Error retrieving: {}", e);
+            None
+        })
     }
 
     pub(crate) fn write_batch(&self, operations: &[DbOp]) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ pub(crate) enum ShardCfKey {
 }
 
 impl ShardCfKey {
-    pub(crate) fn encode(&self) -> Vec<u8> {
+    fn encode(&self) -> Vec<u8> {
         match self {
             ShardCfKey::LogEntry(index) => {
                 let mut key = Vec::with_capacity(9);
@@ -37,7 +37,7 @@ impl ShardCfKey {
         }
     }
 
-    pub(crate) fn encode_for(&self, group_id: u64) -> Vec<u8> {
+    fn encode_for(&self, group_id: u64) -> Vec<u8> {
         let suffix = self.encode();
         let mut key = Vec::with_capacity(8 + suffix.len());
         key.extend_from_slice(&group_id.to_be_bytes());
@@ -126,7 +126,7 @@ impl Db {
             .collect()
     }
 
-    pub(crate) fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
+    fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
         let Some(bytes) = self
             .0
             .get(ShardCfKey::HardState.encode_for(group_id))

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,10 @@
 use crate::clusters::{
     BINCODE_CONFIG, NodeId,
-    raft::{log::LogEntry, messages::LogMutation, storage::RaftPersistentState},
+    raft::{
+        log::LogEntry,
+        messages::LogMutation,
+        storage::{RaftPersistentState, RaftStorage},
+    },
     swims::ShardGroupId,
 };
 
@@ -78,26 +82,17 @@ impl DbOp {
 
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
-pub(crate) struct Db {
-    db: rocksdb::DB,
-}
+pub(crate) struct Db(rocksdb::DB);
 
 impl Db {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
         let db = rocksdb::DB::open(&opts, &path).expect("failed to open RocksDB");
-        Self { db }
+        Self(db)
     }
 
-    pub(crate) fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.db.get(key).unwrap_or_else(|e| {
-            tracing::error!("RocksDB get error: {}", e);
-            None
-        })
-    }
-
-    pub(crate) fn write_batch(&self, operations: &[DbOp]) {
+    fn write_batch(&self, operations: &[DbOp]) {
         let mut batch = rocksdb::WriteBatch::default();
         for operation in operations {
             match operation {
@@ -113,15 +108,15 @@ impl Db {
         // Raft safety requires WAL sync before acknowledging writes
         let mut write_opts = rocksdb::WriteOptions::default();
         write_opts.set_sync(true);
-        self.db
+        self.0
             .write_opt(batch, &write_opts)
             .expect("failed to write batch");
     }
 
-    pub(crate) fn scan_range(&self, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
+    fn scan_range(&self, start: &[u8], end: &[u8]) -> Vec<Vec<u8>> {
         let mut opts = rocksdb::ReadOptions::default();
         opts.set_iterate_upper_bound(end.to_vec());
-        self.db
+        self.0
             .iterator_opt(
                 rocksdb::IteratorMode::From(start, rocksdb::Direction::Forward),
                 opts,
@@ -132,7 +127,14 @@ impl Db {
     }
 
     pub(crate) fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
-        let Some(bytes) = self.get(&ShardCfKey::HardState.encode_for(group_id)) else {
+        let Some(bytes) = self
+            .0
+            .get(&ShardCfKey::HardState.encode_for(group_id))
+            .unwrap_or_else(|e| {
+                tracing::error!("RocksDB get error: {}", e);
+                None
+            })
+        else {
             return RaftPersistentState::default();
         };
 
@@ -148,7 +150,7 @@ impl Db {
         }
     }
 
-    pub(crate) fn get_log_entries(&self, group_id: u64) -> Vec<LogEntry> {
+    fn get_log_entries(&self, group_id: u64) -> Vec<LogEntry> {
         let start = ShardCfKey::LogEntry(0).encode_for(group_id);
         let end = ShardCfKey::HardState.encode_for(group_id);
         self.scan_range(&start, &end)
@@ -161,17 +163,30 @@ impl Db {
             .collect()
     }
 
-    pub(crate) fn delete_range(&self, group_id: ShardGroupId) {
+    fn delete_range(&self, group_id: ShardGroupId) {
         let start: &[u8] = &group_id.0.to_be_bytes();
         let end: &[u8] = &(group_id.0 + 1).to_be_bytes();
 
         let mut batch = rocksdb::WriteBatch::default();
         batch.delete_range(start, end);
-        self.db.write(batch).expect("failed to delete range");
+        self.0.write(batch).expect("failed to delete range");
+    }
+}
+
+impl RaftStorage for Db {
+    fn load_state(&self, group_id: u64) -> RaftPersistentState {
+        self.take_persistent_state_for(group_id)
     }
 
-    #[cfg(test)]
-    pub(crate) fn get_key(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.db.get(key).ok().flatten()
+    fn persist_mutations(&self, mutations: Vec<(ShardGroupId, LogMutation)>) {
+        let batch: Vec<DbOp> = mutations
+            .into_iter()
+            .map(|(id, log)| DbOp::from_log(&id, log))
+            .collect();
+        self.write_batch(&batch);
+    }
+
+    fn delete_group(&self, group_id: ShardGroupId) {
+        self.delete_range(group_id);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,6 +34,7 @@ pub(crate) enum ShardCfKey {
 }
 
 impl ShardCfKey {
+    #[allow(dead_code)]
     pub(crate) fn encode(&self) -> Vec<u8> {
         match self {
             ShardCfKey::LogEntry(index) => {
@@ -42,15 +43,46 @@ impl ShardCfKey {
                 key.extend_from_slice(&index.to_be_bytes());
                 key
             }
-            ShardCfKey::HardState   => vec![0x02],
-            ShardCfKey::SnapMeta    => vec![0x03],
-            ShardCfKey::SnapData    => vec![0x04],
+            ShardCfKey::HardState    => vec![0x02],
+            ShardCfKey::SnapMeta     => vec![0x03],
+            ShardCfKey::SnapData     => vec![0x04],
             ShardCfKey::AppliedIndex => vec![0x05],
-            ShardCfKey::Epoch       => vec![0x06],
+            ShardCfKey::Epoch        => vec![0x06],
         }
     }
 }
 
 pub(crate) fn shard_cf_name(id: u64) -> String {
     format!("{CF_SHARD_PREFIX}{id:016x}")
+}
+
+/// Opaque handle to the node's RocksDB instance.
+/// Callers interact only through this API — `rocksdb` does not leak outside this module.
+pub(crate) struct RaftDb(rocksdb::DB);
+
+impl RaftDb {
+    pub(crate) fn open(path: std::path::PathBuf) -> Self {
+        let mut opts = rocksdb::Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        let cf_names = rocksdb::DB::list_cf(&opts, &path).unwrap_or_default();
+        let db = rocksdb::DB::open_cf(&opts, &path, &cf_names)
+            .expect("failed to open RocksDB");
+        Self(db)
+    }
+
+    pub(crate) fn create_cf(&mut self, name: &str) {
+        self.0
+            .create_cf(name, &rocksdb::Options::default())
+            .expect("failed to create column family");
+    }
+
+    pub(crate) fn drop_cf(&mut self, name: &str) {
+        let _ = self.0.drop_cf(name);
+    }
+
+    pub(crate) fn has_cf(&self, name: &str) -> bool {
+        self.0.cf_handle(name).is_some()
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,7 +11,7 @@ use crate::clusters::{
 /// Per-shard key space within the default column family.
 /// read storage-key-layout.md for more information
 #[allow(dead_code)]
-pub(crate) enum ShardCfKey {
+enum ShardCfKey {
     LogEntry(u64),
     HardState,
     SnapMeta,
@@ -46,12 +46,12 @@ impl ShardCfKey {
     }
 }
 
-pub(crate) enum DbOp {
+enum DbOp {
     Put { key: Vec<u8>, value: Vec<u8> },
     DeleteRange { start: Vec<u8>, end: Vec<u8> },
 }
 impl DbOp {
-    pub(crate) fn from_log(id: &ShardGroupId, log: LogMutation) -> Self {
+    fn from_log(id: &ShardGroupId, log: LogMutation) -> Self {
         fn put_log_entry(group_id: u64, entry: &LogEntry) -> DbOp {
             let key = ShardCfKey::LogEntry(entry.index).encode_for(group_id);
             let value =

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,6 @@
+use crate::clusters::raft::log::LogEntry;
+use crate::clusters::{BINCODE_CONFIG, NodeId};
+
 #[allow(dead_code)]
 pub(crate) const CF_META: &str = "meta";
 pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
@@ -34,7 +37,6 @@ pub(crate) enum ShardCfKey {
 }
 
 impl ShardCfKey {
-    #[allow(dead_code)]
     pub(crate) fn encode(&self) -> Vec<u8> {
         match self {
             ShardCfKey::LogEntry(index) => {
@@ -43,23 +45,57 @@ impl ShardCfKey {
                 key.extend_from_slice(&index.to_be_bytes());
                 key
             }
-            ShardCfKey::HardState    => vec![0x02],
-            ShardCfKey::SnapMeta     => vec![0x03],
-            ShardCfKey::SnapData     => vec![0x04],
+            ShardCfKey::HardState => vec![0x02],
+            ShardCfKey::SnapMeta => vec![0x03],
+            ShardCfKey::SnapData => vec![0x04],
             ShardCfKey::AppliedIndex => vec![0x05],
-            ShardCfKey::Epoch        => vec![0x06],
+            ShardCfKey::Epoch => vec![0x06],
         }
     }
 }
+
+const LOG_ENTRY_RANGE_END: &[u8] = &[0x02];
 
 pub(crate) fn shard_cf_name(id: u64) -> String {
     format!("{CF_SHARD_PREFIX}{id:016x}")
 }
 
+pub(crate) enum WriteOperation {
+    Put {
+        cf: String,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    },
+    DeleteFrom {
+        cf: String,
+        index: Vec<u8>,
+    },
+}
+
+impl WriteOperation {
+    pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> Self {
+        let key = ShardCfKey::LogEntry(entry.index).encode();
+        let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
+        WriteOperation::Put { cf: cf.to_owned(), key, value }
+    }
+
+    pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> Self {
+        let key = ShardCfKey::HardState.encode();
+        let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
+            .expect("encode HardState failed");
+        WriteOperation::Put { cf: cf.to_owned(), key, value }
+    }
+
+    pub(crate) fn delete_from(cf: &str, from_index: u64) -> Self {
+        let index = ShardCfKey::LogEntry(from_index).encode();
+        WriteOperation::DeleteFrom { cf: cf.to_owned(), index }
+    }
+}
+
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
 pub(crate) struct RaftDb {
-    db: rocksdb::DB
+    db: rocksdb::DB,
 }
 
 impl RaftDb {
@@ -69,8 +105,7 @@ impl RaftDb {
         opts.create_missing_column_families(true);
 
         let cf_names = rocksdb::DB::list_cf(&opts, &path).unwrap_or_default();
-        let db = rocksdb::DB::open_cf(&opts, &path, &cf_names)
-            .expect("failed to open RocksDB");
+        let db = rocksdb::DB::open_cf(&opts, &path, &cf_names).expect("failed to open RocksDB");
         Self { db }
     }
 
@@ -86,5 +121,35 @@ impl RaftDb {
 
     pub(crate) fn has_cf(&self, name: &str) -> bool {
         self.db.cf_handle(name).is_some()
+    }
+
+    pub(crate) fn write_batch(&self, operations: &[WriteOperation]) {
+        let mut batch = rocksdb::WriteBatch::default();
+        for operation in operations {
+            match operation {
+                WriteOperation::Put { cf, key, value } => {
+                    let cf = self
+                        .db
+                        .cf_handle(cf)
+                        .unwrap_or_else(|| panic!("CF {cf} not found"));
+                    batch.put_cf(cf, key, value)
+                }
+                WriteOperation::DeleteFrom { cf, index: start } => {
+                    let cf = self
+                        .db
+                        .cf_handle(cf)
+                        .unwrap_or_else(|| panic!("CF {cf} not found"));
+                    batch.delete_range_cf(&cf, start.as_slice(), LOG_ENTRY_RANGE_END);
+                }
+            }
+        }
+
+        self.db.write(batch).expect("failed to write batch");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_cf(&self, cf_name: &str, key: &[u8]) -> Option<Vec<u8>> {
+        let cf = self.db.cf_handle(cf_name)?;
+        self.db.get_cf(cf, key).ok().flatten()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub(crate) const CF_META: &str = "meta";
 pub(crate) const CF_SHARD_PREFIX: &str = "shard-";
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn shard_cf_name(id: u64) -> String {
     format!("{CF_SHARD_PREFIX}{id:016x}")
 }
 
-pub(crate) enum WriteOperation {
+pub(crate) enum DbOp {
     Put {
         cf: String,
         key: Vec<u8>,
@@ -72,33 +72,34 @@ pub(crate) enum WriteOperation {
     },
 }
 
-impl WriteOperation {
+/// we place the following functions under WriteOperation so that Raft details don't leak into Storage layer
+impl DbOp {
     pub(crate) fn put_log_entry(cf: &str, entry: &LogEntry) -> Self {
         let key = ShardCfKey::LogEntry(entry.index).encode();
         let value = bincode::encode_to_vec(entry, BINCODE_CONFIG).expect("encode LogEntry failed");
-        WriteOperation::Put { cf: cf.to_owned(), key, value }
+        DbOp::Put { cf: cf.to_owned(), key, value }
     }
 
     pub(crate) fn put_hard_state(cf: &str, term: u64, voted_for: Option<NodeId>) -> Self {
         let key = ShardCfKey::HardState.encode();
         let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
             .expect("encode HardState failed");
-        WriteOperation::Put { cf: cf.to_owned(), key, value }
+        DbOp::Put { cf: cf.to_owned(), key, value }
     }
 
     pub(crate) fn delete_from(cf: &str, from_index: u64) -> Self {
         let index = ShardCfKey::LogEntry(from_index).encode();
-        WriteOperation::DeleteFrom { cf: cf.to_owned(), index }
+        DbOp::DeleteFrom { cf: cf.to_owned(), index }
     }
 }
 
 /// Opaque handle to the node's RocksDB instance.
 /// Callers interact only through this API — `rocksdb` does not leak outside this module.
-pub(crate) struct RaftDb {
+pub(crate) struct Db {
     db: rocksdb::DB,
 }
 
-impl RaftDb {
+impl Db {
     pub(crate) fn open(path: std::path::PathBuf) -> Self {
         let mut opts = rocksdb::Options::default();
         opts.create_if_missing(true);
@@ -123,18 +124,18 @@ impl RaftDb {
         self.db.cf_handle(name).is_some()
     }
 
-    pub(crate) fn write_batch(&self, operations: &[WriteOperation]) {
+    pub(crate) fn write_batch(&self, operations: &[DbOp]) {
         let mut batch = rocksdb::WriteBatch::default();
         for operation in operations {
             match operation {
-                WriteOperation::Put { cf, key, value } => {
+                DbOp::Put { cf, key, value } => {
                     let cf = self
                         .db
                         .cf_handle(cf)
                         .unwrap_or_else(|| panic!("CF {cf} not found"));
                     batch.put_cf(cf, key, value)
                 }
-                WriteOperation::DeleteFrom { cf, index: start } => {
+                DbOp::DeleteFrom { cf, index: start } => {
                     let cf = self
                         .db
                         .cf_handle(cf)


### PR DESCRIPTION
## Summary

Add RocksDB-backed persistence for Raft state, replacing the previous in-memory-only log with durable storage that survives node restarts.

### What changed

- **RocksDB integration** (`src/storage/mod.rs`): New `Db` struct wrapping RocksDB with sync writes. Implements `RaftStorage` trait — `load_state`, `persist_mutations`, `delete_group`. All mutations batched into single `WriteBatch` per flush cycle.

- **Storage trait** (`src/clusters/raft/storage.rs`): `RaftStorage` trait decouples Raft domain logic from storage backend. `RaftPersistentState` carries term, voted_for, and log entries for recovery.

- **Key layout** (`diagrams/metadata-management/storage-key-layout.md`): Single default CF with composite keys `[group_id:8B][key_type:1B][index:8B]`. Avoids per-group column families (which caused ~177s startup with 768 groups due to MANIFEST fsync per `create_cf`).

- **MultiRaft flush** (`src/clusters/raft/multi_raft.rs`): `flush()` now collects `LogMutation`s from all dirty groups, batch-writes to RocksDB, then advances `stabled_index` on each Raft instance. Previously discarded mutations.

- **Raft state recovery**: `Raft::new()` accepts `RaftPersistentState` — restores term, voted_for, and log from persisted data. `stabled_index` initialized from last restored entry.

- **stabled_index tracking** (`src/clusters/raft/state.rs`): New field tracks what's been flushed to disk. `apply_committed_entries()` gated behind `commit_index <= stabled_index` (entries only applied after durable). `simulate_flush()` added for unit tests.

- **Config**: New `--meta-dir` / `EASTGUARD_META_DIR` for Raft DB path, separate from data dir. Ticker channel sized to `vnodes_per_node * 4` instead of hardcoded 64.

### Test coverage

- Flush persists log entries and hard state to RocksDB
- `stabled_index` advances after flush
- Truncation removes entries from RocksDB
- Restart recovers log entries, hard state, and stabled index
- Group deletion cleans up all persisted data
- Existing Raft unit tests updated with `simulate_flush()` for stabled_index gating

## Reference
https://github.com/f-rustrated/EastGuard/issues/39#issuecomment-4272620794