### PR TITLE
Remove AddPeer, RemovePeer from RaftCommand 

### DIFF
--- a/src/clusters/raft/messages/command.rs
+++ b/src/clusters/raft/messages/command.rs
@@ -11,8 +11,6 @@ use crate::clusters::swims::{ShardGroup, ShardGroupId};
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum RaftCommand {
     Noop,
-    RemovePeer(NodeId),
-    AddPeer(NodeId),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -10,7 +10,6 @@ use crate::clusters::raft::state::Raft;
 
 use crate::clusters::raft::storage::RaftStorage;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
-use crate::schedulers::ticker_message::TimerCommand;
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
@@ -125,18 +124,11 @@ impl MultiRaft {
     }
 
     fn remove_group(&mut self, group_id: ShardGroupId) {
-        let Some(raft) = self.groups.remove(&group_id) else {
+        let Some(mut raft) = self.groups.remove(&group_id) else {
             return;
         };
-
-        self.pending_events
-            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: raft.election_seq(),
-            }));
-        self.pending_events
-            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: raft.heartbeat_seq(),
-            }));
+        raft.cancel_all_timers();
+        self.pending_events.extend(raft.take_events());
 
         self.storage.delete_group(group_id);
 
@@ -169,12 +161,10 @@ impl MultiRaft {
     }
 
     fn remove_node(&mut self, node_id: NodeId) {
-        self.pending_events
-            .push(RaftEvent::DisconnectPeer(node_id.clone()));
-
-        for raft in self.groups.values_mut() {
+        for (group_id, raft) in self.groups.iter_mut() {
             if raft.has_peer(&node_id) {
                 raft.remove_peer(&node_id);
+                self.dirty.insert(*group_id);
             }
         }
     }
@@ -263,6 +253,7 @@ mod tests {
 
     use crate::clusters::raft::storage::RaftPersistentState;
     use crate::impls::metadata_storage::MetadataStorage;
+    use crate::schedulers::ticker_message::TimerCommand;
     use std::collections::HashSet;
 
     fn node(id: &str) -> NodeId {

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -181,10 +181,10 @@ impl MultiRaft {
 
     fn add_node(&mut self, node_id: NodeId, affected_groups: Vec<ShardGroup>) {
         for group in &affected_groups {
-            if let Some(raft) = self.groups.get_mut(&group.id) {
-                if !raft.has_peer(&node_id) {
-                    raft.add_peer(node_id.clone());
-                }
+            if let Some(raft) = self.groups.get_mut(&group.id)
+                && !raft.has_peer(&node_id)
+            {
+                raft.add_peer(node_id.clone());
             }
         }
 

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -172,30 +172,19 @@ impl MultiRaft {
         self.pending_events
             .push(RaftEvent::DisconnectPeer(node_id.clone()));
 
-        let affected: Vec<ShardGroupId> = self
-            .groups
-            .iter()
-            .filter(|(_, r)| r.is_leader() && r.has_peer(&node_id))
-            .map(|(id, _)| *id)
-            .collect();
-
-        for group_id in &affected {
-            if let Some(raft) = self.groups.get_mut(group_id) {
-                let _ = raft.propose(RaftCommand::RemovePeer(node_id.clone()));
+        for raft in self.groups.values_mut() {
+            if raft.has_peer(&node_id) {
+                raft.remove_peer(&node_id);
             }
         }
-
-        self.dirty.extend(affected);
     }
 
     fn add_node(&mut self, node_id: NodeId, affected_groups: Vec<ShardGroup>) {
         for group in &affected_groups {
-            if let Some(raft) = self.groups.get_mut(&group.id)
-                && raft.is_leader()
-                && !raft.has_peer(&node_id)
-            {
-                let _ = raft.propose(RaftCommand::AddPeer(node_id.clone()));
-                self.dirty.insert(group.id);
+            if let Some(raft) = self.groups.get_mut(&group.id) {
+                if !raft.has_peer(&node_id) {
+                    raft.add_peer(node_id.clone());
+                }
             }
         }
 

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -48,7 +48,7 @@ pub struct Raft {
     voted_for: Option<NodeId>,
     log: Vec<LogEntry>,
     pending_log_mutations: Vec<LogMutation>, // must persist
-    pending_events: Vec<RaftEvent>,          // volatile side effects
+    events: Vec<RaftEvent>,                  // volatile side effects
     commit_index: u64,                       // majority voted
     stabled_index: u64,                      // flushed to disk
     last_applied_index: u64,                 // applied to state machine
@@ -82,7 +82,7 @@ impl Raft {
             voted_for: persistent.voted_for,
             log: persistent.log,
             pending_log_mutations: Vec::new(),
-            pending_events: Vec::new(),
+            events: Vec::new(),
             commit_index: 0,
             last_applied_index: 0,
             role: Role::Follower,
@@ -96,16 +96,12 @@ impl Raft {
         raft
     }
 
-    pub(crate) fn election_seq(&self) -> u32 {
-        self.election_seq
-    }
-
     pub(crate) fn heartbeat_seq(&self) -> u32 {
         self.heartbeat_seq
     }
 
     pub(crate) fn take_events(&mut self) -> Vec<RaftEvent> {
-        std::mem::take(&mut self.pending_events)
+        std::mem::take(&mut self.events)
     }
 
     pub fn take_log_mutations(&mut self) -> Vec<LogMutation> {
@@ -255,7 +251,7 @@ impl Raft {
             last_log_term: self.log_last_term(),
         };
         for peer_id in self.peers.iter() {
-            self.pending_events.push(
+            self.events.push(
                 OutboundRaftPacket::new(self.shard_group_id, peer_id.clone(), req.clone()).into(),
             );
         }
@@ -279,7 +275,7 @@ impl Raft {
             self.reset_election_timer();
         }
 
-        self.pending_events.push(
+        self.events.push(
             OutboundRaftPacket::new(
                 self.shard_group_id,
                 from,
@@ -338,7 +334,7 @@ impl Raft {
         self.role = Role::Leader;
         self.current_leader = Some(self.node_id.clone());
 
-        self.pending_events.push(
+        self.events.push(
             LeaderChange {
                 shard_group_id: self.shard_group_id,
                 leader_node_id: self.node_id.clone(),
@@ -419,7 +415,7 @@ impl Raft {
         let prev_log_term = self.log_term_at(prev_log_index);
         let entries = self.log_entries_from(peer_state.next_index);
 
-        self.pending_events.push(
+        self.events.push(
             OutboundRaftPacket::new(
                 self.shard_group_id,
                 peer_id,
@@ -521,7 +517,7 @@ impl Raft {
     }
 
     fn send_append_entries_response(&mut self, target: NodeId, success: bool) {
-        self.pending_events.push(
+        self.events.push(
             OutboundRaftPacket::new(
                 self.shard_group_id,
                 target,
@@ -632,6 +628,8 @@ impl Raft {
     pub(crate) fn remove_peer(&mut self, node_id: &NodeId) {
         self.peers.remove(node_id);
         self.peer_states.remove(node_id);
+        self.events
+            .push(RaftEvent::DisconnectPeer(self.node_id.clone()));
     }
 
     fn add_new_entry(&mut self, command: RaftCommand) {
@@ -674,11 +672,11 @@ impl Raft {
     }
 
     fn reset_election_timer(&mut self) {
-        self.pending_events
+        self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.election_seq,
             }));
-        self.pending_events
+        self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
                 seq: self.election_seq,
                 timer: RaftTimer::election(self.election_jitter, self.shard_group_id),
@@ -686,19 +684,19 @@ impl Raft {
     }
 
     fn schedule_heartbeat_timer(&mut self) {
-        self.pending_events
+        self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
                 seq: self.heartbeat_seq,
                 timer: RaftTimer::heartbeat(self.shard_group_id),
             }));
     }
 
-    fn cancel_all_timers(&mut self) {
-        self.pending_events
+    pub(crate) fn cancel_all_timers(&mut self) {
+        self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.election_seq,
             }));
-        self.pending_events
+        self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.heartbeat_seq,
             }));

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -609,7 +609,7 @@ impl Raft {
         }
     }
 
-    /// Directly add a peer to this Raft instance. Called by MultiRaftActor on
+    /// Directly add a peer to this Raft instance. Called by MultiRaft on
     /// SWIM `NodeAlive` events — bypasses the log since SWIM is membership authority.
     pub(crate) fn add_peer(&mut self, node_id: NodeId) {
         if node_id == self.node_id {
@@ -627,7 +627,7 @@ impl Raft {
         }
     }
 
-    /// Directly remove a peer from this Raft instance. Called by MultiRaftActor on
+    /// Directly remove a peer from this Raft instance. Called by MultiRaft on
     /// SWIM `NodeDead` events — bypasses the log since SWIM is membership authority.
     pub(crate) fn remove_peer(&mut self, node_id: &NodeId) {
         self.peers.remove(node_id);

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -588,7 +588,6 @@ impl Raft {
     }
 
     /// Apply committed (and persisted) but unapplied log entries.
-    /// Currently, handles Raft-internal ConfChanges (RemovePeer, AddPeer).
     /// Phase 4 will extend this with application state machine dispatch.
     fn apply_committed_entries(&mut self) {
         while self.last_applied_index < self.commit_index.min(self.stabled_index) {
@@ -596,7 +595,6 @@ impl Raft {
             let entry = match self.log_get(self.last_applied_index) {
                 Some(e) => e.clone(),
                 None => {
-                    // why is the log missing?
                     tracing::error!(
                         "[{}] committed entry at index {} missing from log",
                         self.node_id,
@@ -607,40 +605,33 @@ impl Raft {
             };
             match entry.command {
                 RaftCommand::Noop => {}
-                RaftCommand::RemovePeer(ref node_id) => {
-                    self.peers.remove(node_id);
-                    self.peer_states.remove(node_id);
-                    tracing::info!(
-                        "[{}] ConfChange applied: removed peer {} (index={})",
-                        self.node_id,
-                        node_id,
-                        self.last_applied_index
-                    );
-                }
-                RaftCommand::AddPeer(ref node_id) => {
-                    // Skip if target is self — self is never in peers.
-                    if node_id == &self.node_id {
-                        continue;
-                    }
-                    self.peers.insert(node_id.clone());
-                    if self.role == Role::Leader {
-                        self.peer_states.insert(
-                            node_id.clone(),
-                            PeerState {
-                                next_index: self.log_last_index() + 1,
-                                match_index: 0,
-                            },
-                        );
-                    }
-                    tracing::info!(
-                        "[{}] ConfChange applied: added peer {} (index={})",
-                        self.node_id,
-                        node_id,
-                        self.last_applied_index
-                    );
-                }
             }
         }
+    }
+
+    /// Directly add a peer to this Raft instance. Called by MultiRaftActor on
+    /// SWIM `NodeAlive` events — bypasses the log since SWIM is membership authority.
+    pub(crate) fn add_peer(&mut self, node_id: NodeId) {
+        if node_id == self.node_id {
+            return;
+        }
+        self.peers.insert(node_id.clone());
+        if self.role == Role::Leader {
+            self.peer_states.insert(
+                node_id,
+                PeerState {
+                    next_index: self.log_last_index() + 1,
+                    match_index: 0,
+                },
+            );
+        }
+    }
+
+    /// Directly remove a peer from this Raft instance. Called by MultiRaftActor on
+    /// SWIM `NodeDead` events — bypasses the log since SWIM is membership authority.
+    pub(crate) fn remove_peer(&mut self, node_id: &NodeId) {
+        self.peers.remove(node_id);
+        self.peer_states.remove(node_id);
     }
 
     fn add_new_entry(&mut self, command: RaftCommand) {
@@ -1521,92 +1512,16 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // ConfChange: RemovePeer
+    // Direct peer mutation: add_peer / remove_peer
     // -------------------------------------------------------------------
 
     #[test]
-    fn remove_peer_applied_after_commit_single_node() {
-        // Single-node leader: propose RemovePeer for a phantom peer,
-        // verify the apply machinery runs without panicking.
+    fn add_peer_inserts_into_peers() {
         let mut raft = single_node_raft();
-        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
-            shard_group_id: TEST_SHARD,
-        });
-        drain(&mut raft);
-
-        // Single-node commits immediately on propose.
-        let result = raft.propose(RaftCommand::RemovePeer(node("phantom")));
-        assert!(result.is_ok());
-        raft.simulate_flush();
-        // last_applied should have advanced
-        assert!(raft.last_applied_index > 0);
-    }
-
-    #[test]
-    fn remove_peer_removes_from_peers_on_commit() {
-        // 3-node cluster: node-1 is leader, proposes removing node-3.
-        let mut n1 = three_node_raft("node-1");
-        let mut n2 = three_node_raft("node-2");
-
-        // Elect node-1: timeout → candidate
-        n1.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
-            shard_group_id: TEST_SHARD,
-        });
-
-        // node-2 grants vote → node-1 becomes leader
-        let vote_reqs = packets(&mut n1);
-        for pkt in &vote_reqs {
-            if pkt.target == node("node-2") {
-                n2.step(node("node-1"), pkt.rpc.clone());
-            }
-        }
-        let vote_resp = packets(&mut n2);
-        for pkt in vote_resp {
-            n1.step(node("node-2"), pkt.rpc);
-        }
-        assert!(n1.is_leader());
-        drain(&mut n1); // drain heartbeats
-
-        assert!(n1.has_peer(&node("node-3")));
-
-        // Leader proposes RemovePeer(node-3)
-        let result = n1.propose(RaftCommand::RemovePeer(node("node-3")));
-        assert!(result.is_ok());
-        let ae_pkts = packets(&mut n1);
-
-        // node-2 acks the AppendEntries
-        for pkt in ae_pkts {
-            if pkt.target == node("node-2") {
-                n2.step(node("node-1"), pkt.rpc);
-            }
-        }
-        let acks = packets(&mut n2);
-        for pkt in acks {
-            n1.step(node("node-2"), pkt.rpc);
-        }
-        n1.simulate_flush();
-
-        // After majority ack, commit_index advances and RemovePeer is applied
-        assert!(!n1.has_peer(&node("node-3")));
-        assert_eq!(n1.peers_count(), 1); // only node-2 remains
-    }
-
-    // -------------------------------------------------------------------
-    // ConfChange: AddPeer
-    // -------------------------------------------------------------------
-
-    #[test]
-    fn add_peer_single_node_commits_immediately() {
-        let mut raft = single_node_raft();
-        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
-            shard_group_id: TEST_SHARD,
-        });
-        drain(&mut raft);
         assert_eq!(raft.peers_count(), 0);
 
-        let result = raft.propose(RaftCommand::AddPeer(node("node-2")));
-        assert!(result.is_ok());
-        raft.simulate_flush();
+        raft.add_peer(node("node-2"));
+
         assert!(raft.has_peer(&node("node-2")));
         assert_eq!(raft.peers_count(), 1);
     }
@@ -1614,25 +1529,48 @@ mod tests {
     #[test]
     fn add_peer_skips_self() {
         let mut raft = single_node_raft();
-        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
-            shard_group_id: TEST_SHARD,
-        });
-        drain(&mut raft);
-
-        let result = raft.propose(RaftCommand::AddPeer(node("node-1")));
-        assert!(result.is_ok());
-        // Self should NOT be in peers
+        raft.add_peer(node("node-1")); // node-1 is self
         assert!(!raft.has_peer(&node("node-1")));
         assert_eq!(raft.peers_count(), 0);
     }
 
     #[test]
     fn add_peer_leader_initializes_peer_state() {
-        // 3-node cluster, leader adds node-4.
+        let mut raft = single_node_raft();
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        drain(&mut raft);
+        assert!(raft.is_leader());
+
+        raft.add_peer(node("node-2"));
+        assert!(raft.has_peer(&node("node-2")));
+
+        // Next heartbeat must include AppendEntries to node-2.
+        raft.handle_timeout(RaftTimeoutCallback::HeartbeatTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        let heartbeats = packets(&mut raft);
+        let targets: Vec<&NodeId> = heartbeats.iter().map(|p| &p.target).collect();
+        assert!(targets.contains(&&node("node-2")));
+    }
+
+    #[test]
+    fn remove_peer_removes_from_peers() {
+        let mut raft = three_node_raft("node-1");
+        assert!(raft.has_peer(&node("node-3")));
+
+        raft.remove_peer(&node("node-3"));
+
+        assert!(!raft.has_peer(&node("node-3")));
+        assert_eq!(raft.peers_count(), 1);
+    }
+
+    #[test]
+    fn remove_peer_clears_peer_state_for_leader() {
         let mut n1 = three_node_raft("node-1");
         let mut n2 = three_node_raft("node-2");
 
-        // Elect node-1
         n1.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
         });
@@ -1648,36 +1586,16 @@ mod tests {
         assert!(n1.is_leader());
         drain(&mut n1);
 
-        assert!(!n1.has_peer(&node("node-4")));
+        n1.remove_peer(&node("node-3"));
 
-        // Propose AddPeer(node-4)
-        let result = n1.propose(RaftCommand::AddPeer(node("node-4")));
-        assert!(result.is_ok());
-        let ae_pkts = packets(&mut n1);
-
-        // node-2 acks
-        for pkt in ae_pkts {
-            if pkt.target == node("node-2") {
-                n2.step(node("node-1"), pkt.rpc);
-            }
-        }
-        for pkt in packets(&mut n2) {
-            n1.step(node("node-2"), pkt.rpc);
-        }
-        n1.simulate_flush();
-
-        // After commit, node-4 is a peer
-        assert!(n1.has_peer(&node("node-4")));
-        assert_eq!(n1.peers_count(), 3); // node-2, node-3, node-4
-
-        // Leader should have initialized peer state — next heartbeat
-        // should include AppendEntries to node-4.
+        // After removal, next heartbeat must NOT target node-3.
         n1.handle_timeout(RaftTimeoutCallback::HeartbeatTimeout {
             shard_group_id: TEST_SHARD,
         });
         let heartbeats = packets(&mut n1);
         let targets: Vec<&NodeId> = heartbeats.iter().map(|p| &p.target).collect();
-        assert!(targets.contains(&&node("node-4")));
+        assert!(!targets.contains(&&node("node-3")));
+        assert_eq!(n1.peers_count(), 1);
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
Peer information is an ephemeral thing which can be derived by SWIM, not from Raft logs. Let's remove it 