### PR TITLE
metadata layer impl - phase3 state application

### DIFF
--- a/metadata_management_roadmap.md
+++ b/metadata_management_roadmap.md
@@ -108,60 +108,59 @@ enum ProposeError {
 
 ## Phase 3: Application State Machine Dispatch
 
-**Goal:** Split `apply_committed_entries()` — ConfChange stays in `Raft`, application commands dispatched to `MetadataStateMachine`.
+**Goal:** `Raft` owns `MetadataStateMachine` and applies committed metadata commands inline — completing the Raft abstraction (log machine + state machine).
 
-This is the TODO at `state.rs:569`:
-> "Phase 4 will extend this with application state machine dispatch."
+This is the TODO at `state.rs:604`:
+> "Phase 3: dispatch to MetadataStateMachine"
 
-### 3a. Refactor `apply_committed_entries()` in `Raft`
+### 3a. Embed `MetadataStateMachine` inside `Raft`
 
-ConfChange handling (`AddPeer`/`RemovePeer`) stays inside `Raft` — it modifies Raft-internal peer state.
-
-Application commands buffered for caller:
+Raft = log machine + state machine. Not a generic Raft library — domain system. Only one state machine type ever exists. No trait, no generic, direct ownership.
 
 ```rust
-// In Raft:
-pending_applied: Vec<LogEntry>,
-
-fn apply_committed_entries(&mut self) {
-    for entry in last_applied+1..=commit_index:
-        match entry.command:
-            Noop             => {}
-            RemovePeer(id)   => self.peers.remove(id); ...
-            AddPeer(id)      => self.peers.insert(id); ...
-            _                => self.pending_applied.push(entry)  // new
-}
-
-fn take_applied_entries(&mut self) -> Vec<LogEntry>  // new drain method
-```
-
-### 3b. Embed `MetadataStateMachine` per shard group in `MultiRaft`
-
-```rust
-// In multi_raft.rs:
-struct ShardGroupState {
-    raft: Raft,
+// In state.rs:
+pub struct Raft {
+    // ... existing consensus fields ...
     state_machine: MetadataStateMachine,
 }
-
-groups: HashMap<ShardGroupId, ShardGroupState>,
 ```
 
-### 3c. Dispatch in `flush()`
+Initialized to `MetadataStateMachine::default()` in `Raft::new()`.
+
+### 3b. Inline apply in `apply_committed_entries()`
 
 ```rust
-for id in dirty:
-    for entry in shard.raft.take_applied_entries():
-        match entry.command:
-            CreateTopic { .. }  => shard.state_machine.apply_create_topic(..)
-            SplitRange { .. }   => shard.state_machine.apply_split_range(..)
-            SealSegment { .. }  => shard.state_machine.apply_seal_segment(..)
+fn apply_committed_entries(&mut self) {
+    while self.last_applied_index < self.commit_index.min(self.stabled_index) {
+        self.last_applied_index += 1;
+        let entry = self.log_get(self.last_applied_index).clone();
+        match entry.command {
+            RaftCommand::Noop => {}
+            RaftCommand::Metadata(cmd) => {
+                match self.state_machine.apply(cmd) {
+                    Ok(result)  => tracing::debug!("Applied: {:?}", result),
+                    Err(e)      => tracing::error!("Apply error: {:?}", e),
+                }
+            }
+        }
+    }
+}
 ```
 
-Matches `storage_implementation_plan.md` § "State machine application" exactly.
+No buffer-drain pattern. No `take_applied_entries()`. Apply happens at consensus boundary, inside `Raft`, guarded by `commit_index.min(stabled_index)`.
+
+### 3c. Expose read-only accessor
+
+```rust
+pub(crate) fn state_machine(&self) -> &MetadataStateMachine {
+    &self.state_machine
+}
+```
+
+For `MultiRaft` and tests to query applied state.
 
 **Depends on:** Phases 1 + 2.
-**Scope:** 1-2 PRs.
+**Scope:** ~50-80 lines + tests. 1 PR.
 
 ---
 
@@ -360,11 +359,8 @@ Covers: RocksDB dependency, `MultiRaft` → `MultiRaftStore` refactor, `WriteBat
 **1. MultiRaftActor handles routing — no separate broker layer.**
 `MultiRaftActorCommand::Propose` takes `resource_key`, not `shard_group_id`. MultiRaft hashes the key to find the shard group, checks leadership, and proposes — all internally. Client handler in `lib.rs` stays thin (just forwards). No async topology queries needed because `ShardGroupId::new(key)` is a pure hash function.
 
-**2. MetadataStateMachine lives per shard group, inside MultiRaft(Store).**
-Not inside `Raft`. Raft remains a pure consensus state machine — no knowledge of topics, ranges, segments.
-
-**3. Application commands use buffer-drain pattern.**
-Consistent with `take_outbound()`, `take_timer_commands()`, `take_log_mutations()`. New: `take_applied_entries()`.
+**2. `Raft` owns `MetadataStateMachine` directly — no external dispatch.**
+Raft = log machine + state machine. EastGuard is a metadata system, not a generic Raft library. Only one state machine type ever exists. `apply_committed_entries()` calls `self.state_machine.apply()` inline. No buffer-drain, no wrapper struct, no trait/generic. `MultiRaft` stays `HashMap<ShardGroupId, Raft>`.
 
 **4. Commit completion tracked via pending_proposals map.**
 `raft.propose()` returns immediately (entry appended). Actual commit notification comes asynchronously. `MultiRaft` tracks `(shard_id, log_index) → oneshot::Sender` to resolve reply on commit+apply. Leader stepdown drains all pending with `NotLeader`.

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -103,6 +103,7 @@ impl Raft {
         self.heartbeat_seq
     }
 
+    #[cfg(test)]
     pub(crate) fn state_machine(&self) -> &MetadataStateMachine {
         &self.state_machine
     }

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::clusters::NodeId;
+use crate::clusters::metadata::state_machine::MetadataStateMachine;
 use crate::clusters::raft::log::LogEntry;
 use crate::clusters::raft::messages::*;
 use crate::clusters::raft::storage::RaftPersistentState;
@@ -58,6 +59,7 @@ pub struct Raft {
     current_leader: Option<NodeId>,
     // LEADER-ONLY volatile state
     peer_states: HashMap<NodeId, PeerState>,
+    state_machine: MetadataStateMachine,
     election_jitter: u32,
     election_seq: u32,
     heartbeat_seq: u32,
@@ -87,6 +89,7 @@ impl Raft {
             last_applied_index: 0,
             role: Role::Follower,
             current_leader: None,
+            state_machine: MetadataStateMachine::default(),
             peer_states: HashMap::new(),
             election_jitter,
             election_seq,
@@ -98,6 +101,10 @@ impl Raft {
 
     pub(crate) fn heartbeat_seq(&self) -> u32 {
         self.heartbeat_seq
+    }
+
+    pub(crate) fn state_machine(&self) -> &MetadataStateMachine {
+        &self.state_machine
     }
 
     pub(crate) fn take_events(&mut self) -> Vec<RaftEvent> {
@@ -583,8 +590,6 @@ impl Raft {
         self.apply_committed_entries();
     }
 
-    /// Apply committed (and persisted) but unapplied log entries.
-    /// Phase 3 will dispatch Metadata commands to MetadataStateMachine.
     fn apply_committed_entries(&mut self) {
         while self.last_applied_index < self.commit_index.min(self.stabled_index) {
             self.last_applied_index += 1;
@@ -601,9 +606,24 @@ impl Raft {
             };
             match entry.command {
                 RaftCommand::Noop => {}
-                RaftCommand::Metadata(_) => {
-                    // Phase 3: dispatch to MetadataStateMachine
-                }
+                RaftCommand::Metadata(cmd) => match self.state_machine.apply(cmd) {
+                    Ok(result) => {
+                        tracing::debug!(
+                            "[{}] Applied metadata at index {}: {:?}",
+                            self.node_id,
+                            entry.index,
+                            result
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "[{}] Metadata apply error at index {}: {:?}",
+                            self.node_id,
+                            entry.index,
+                            e
+                        );
+                    }
+                },
             }
         }
     }
@@ -1728,5 +1748,91 @@ mod tests {
         let events = leader_events(&mut raft);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].term, 2);
+    }
+
+    // -------------------------------------------------------------------
+    // Phase 3 — MetadataStateMachine apply
+    // -------------------------------------------------------------------
+
+    use crate::clusters::metadata::command::{CreateTopic, MetadataCommand};
+    use crate::clusters::metadata::strategy::{PartitionStrategy, StoragePolicy};
+
+    fn test_create_topic_cmd(name: &str) -> RaftCommand {
+        RaftCommand::Metadata(MetadataCommand::CreateTopic(CreateTopic {
+            name: name.to_string(),
+            storage_policy: StoragePolicy {
+                retention_ms: 3_600_000,
+                replication_factor: 3,
+                partition_strategy: PartitionStrategy::AutoSplit,
+            },
+            replica_set: vec![node("n1"), node("n2"), node("n3")],
+            created_at: 1000,
+        }))
+    }
+
+    #[test]
+    fn apply_metadata_command_creates_topic() {
+        let mut raft = single_node_raft();
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        drain(&mut raft);
+        raft.simulate_flush();
+
+        raft.propose(test_create_topic_cmd("blue")).unwrap();
+        raft.simulate_flush();
+
+        assert!(raft.state_machine().get_topic_by_name("blue").is_some());
+    }
+
+    #[test]
+    fn apply_noop_does_not_affect_state_machine() {
+        let mut raft = single_node_raft();
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        drain(&mut raft);
+        raft.simulate_flush();
+
+        raft.propose(RaftCommand::Noop).unwrap();
+        raft.simulate_flush();
+
+        assert_eq!(raft.state_machine().topic_count(), 0);
+    }
+
+    #[test]
+    fn apply_duplicate_topic_logs_error_no_panic() {
+        let mut raft = single_node_raft();
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        drain(&mut raft);
+        raft.simulate_flush();
+
+        raft.propose(test_create_topic_cmd("red")).unwrap();
+        raft.simulate_flush();
+
+        raft.propose(test_create_topic_cmd("red")).unwrap();
+        raft.simulate_flush();
+
+        assert_eq!(raft.state_machine().topic_count(), 1);
+    }
+
+    #[test]
+    fn apply_multiple_topics_independent() {
+        let mut raft = single_node_raft();
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        drain(&mut raft);
+        raft.simulate_flush();
+
+        raft.propose(test_create_topic_cmd("alpha")).unwrap();
+        raft.propose(test_create_topic_cmd("beta")).unwrap();
+        raft.simulate_flush();
+
+        assert_eq!(raft.state_machine().topic_count(), 2);
+        assert!(raft.state_machine().get_topic_by_name("alpha").is_some());
+        assert!(raft.state_machine().get_topic_by_name("beta").is_some());
     }
 }


### PR DESCRIPTION
## Summary

- **Raft now owns MetadataStateMachine directly** — completing the Raft abstraction (log machine + state machine). Not a generic library; EastGuard is a domain system with exactly one state machine type.
- `apply_committed_entries()` dispatches committed `Metadata` commands to `self.state_machine.apply()` inline — no buffer-drain, no external dispatch, no wrapper struct.
- Entries are applied only after both consensus and persistence (`commit_index.min(stabled_index)` guard), with a one-flush-cycle delay for safety.
- Apply errors (e.g., duplicate topic name from concurrent proposals) are logged and skipped — committed entries are irrevocable, so the state machine must not panic.

## Changes

**`src/clusters/raft/state.rs`**
- Added `state_machine: MetadataStateMachine` field to `Raft` struct
- `apply_committed_entries()`: replaced Phase 3 TODO with inline `self.state_machine.apply(cmd)` call
- Added `state_machine()` read-only accessor
- 4 new tests: topic creation through Raft, noop passthrough, duplicate error handling, multiple independent topics

**`metadata_management_roadmap.md`**
- Updated Phase 3 section to reflect Raft-owns-state-machine design (was: external dispatch via buffer-drain in MultiRaft)
- Updated design decision #2 accordingly

## Design doc

See `diagrams/metadata-management/phase3-dispatch.md` for full design rationale, consensus→apply chain, and invariants.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] All 199 existing tests pass (1 pre-existing flaky test: `leader_election_emits_leader_change_event`)
- [x] `apply_metadata_command_creates_topic` — propose CreateTopic, verify state machine has topic after flush
- [x] `apply_noop_does_not_affect_state_machine` — Noop doesn't touch state machine
- [x] `apply_duplicate_topic_logs_error_no_panic` — second CreateTopic with same name: error logged, no panic, count stays 1
- [x] `apply_multiple_topics_independent` — two topics created independently in same flush cycle

