### PR TITLE
feat: metadata layer - Leader forwarding + Shard discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ cargo run --bin server
 ```shell 
 # Terminal 1 (node-1):
 cargo run --bin server -- \
---port 3001 \
+--client-port 3001 \
 --cluster-port 13001 \
 --advertise-host 127.0.0.1 \
 --data-dir /tmp/eg-node1 \
@@ -43,7 +43,7 @@ cargo run --bin server -- \
 
 # Terminal 2 (node-2):
 cargo run --bin server -- \
---port 3002 \
+--client-port 3002 \
 --cluster-port 13002 \
 --advertise-host 127.0.0.1 \
 --data-dir /tmp/eg-node2 \
@@ -55,7 +55,7 @@ cargo run --bin server -- \
 
 # Terminal 3 (node-3):
 cargo run --bin server -- \
---port 3003 \
+--client-port 3003 \
 --cluster-port 13003 \
 --advertise-host 127.0.0.1 \
 --data-dir /tmp/eg-node3 \

--- a/diagrams/metadata-management/leader-forwarding.mmd
+++ b/diagrams/metadata-management/leader-forwarding.mmd
@@ -1,0 +1,46 @@
+sequenceDiagram
+    participant C as Client
+    participant F as Follower Node<br/>(client_port)
+    participant S as SWIM Topology<br/>(on Follower)
+    participant R as Raft<br/>(on Follower)
+    participant L as Leader Node<br/>(client_port)
+
+    C->>F: ProposeRequest { resource_key, command, forwarded: false }
+
+    F->>S: ResolveShardGroup(resource_key)
+    S-->>F: ShardGroup { id, members }
+
+    F->>R: propose(command)
+    R-->>F: Err(NotLeader(Some(leader_id)))
+
+    Note over F: forwarded == false<br> → attempt forward
+
+    F->>S: ResolveShardLeader(shard_group_id)
+    S-->>F: ShardLeaderEntry { client_addr, ... }
+
+    F->>L: TCP connect to client_addr
+    F->>L: ProposeRequest { ..., forwarded: true }
+
+    Note over L: Leader processes<br> propose normally
+
+    L-->>F: ProposeResponse::Success
+    F-->>C: ProposeResponse::Success
+
+    Note over F,L: Failure paths below
+
+
+    Note over F: If leader returns NotLeader<br>(leader changed mid-flight)
+    L-->>F: ProposeResponse::Error(NotLeader)
+    F-->>C: ProposeResponse::Error(NotLeader)
+    Note over F: Max 1 hop — follower<br>does not forward again
+
+
+
+    Note over F: If TCP connect fails<br>or leader unreachable
+    F-->>C: ProposeResponse::Error(NotLeader)
+
+
+
+    Note over F: If ResolveShardLeader<br>returns None (no known leader)
+    F-->>C: ProposeResponse::Error(NotLeader(None))
+

--- a/diagrams/metadata-management/metadata_management_roadmap.md
+++ b/diagrams/metadata-management/metadata_management_roadmap.md
@@ -108,7 +108,7 @@ enum ProposeError {
 }
 ```
 
-`EpochNotMatch` and `NotLeaderHint` deferred to Phase 5.
+`NotLeader(Option<NodeId>)` added in Phase 5 — carries leader hint. Epoch cancelled (not needed).
 
 **Depends on:** Phase 1 (needs `TopicId`, `StoragePolicy`, etc.).
 **Scope:** Mostly type changes + match arm updates.
@@ -291,78 +291,52 @@ Client                 lib.rs              MultiRaftActor            Raft
 
 ---
 
-## Phase 5: Leader Forwarding + Epoch Validation
+## Phase 5: Leader Forwarding + Shard Discovery 
 
-**Goal:** Non-leader nodes forward proposals transparently; stale routing detected via epochs.
+**Goal:** Non-leader nodes forward proposals transparently; clients can discover shard → leader mappings.
 
-### 5a. Leader forwarding
+### 5a. Leader forwarding 
 
-When `MultiRaft::propose()` returns `NotLeaderHint(Some(leader_id))`:
-1. Resolve leader address via `SwimQueryCommand::ResolveAddress`
-2. Forward `ProposeRequest` over TCP to leader's node
-3. Relay response back to client
+`ProposeError::NotLeader(Option<NodeId>)` carries leader hint. Non-leader nodes transparently forward proposals to the leader via TCP. Two-strategy forwarding:
+1. **Fast path:** Use leader hint + `ResolveAddress` → `NodeAddress.client_addr` (SWIM membership, converges in ~2-3s)
+2. **Slow path:** Fall back to `ResolveShardLeader` → shard leader gossip
 
-Falls back to `NotLeader(None)` if leader unknown (election in progress) — client retries with backoff.
+Max 1 hop — `ProposeRequest.forwarded: bool` prevents re-forwarding.
 
-### 5b. Epoch validation
+### 5b. Epoch validation — cancelled ❌
 
-```rust
-struct ShardEpoch {
-    conf_ver: u64,  // incremented on AddPeer/RemovePeer commit
-    version: u64,   // incremented on split/merge (future)
-}
-```
+Originally planned to track `conf_ver` per shard group. Cancelled because:
+- Clients never send replica sets — server resolves from SWIM topology
+- SWIM convergence (~2-3s) makes staleness window near-zero
+- `NotLeader` hint + forwarding already handles leader changes
+- Even stale replica sets are self-healing on subsequent operations
 
-Every `Propose` includes client's cached epoch. Shard group validates before accepting:
-- `client_epoch < current_epoch` → `EpochNotMatch { current }` → client refreshes routing cache
+Revisit only if client-side routing cache bypasses server-side routing.
 
-### 5c. Shard discovery query
+### 5c. Shard discovery query 
 
 ```rust
-// New QueryCommand variant:
-GetShardInfo { key: Vec<u8> }
-// Returns: { shard_group_id, leader_node_id, leader_addr, epoch }
+QueryCommand::GetShardInfo { key: Vec<u8> }
+// Returns: Option<ShardInfoResponse { shard_group_id, leader_node_id, leader_addr }>
 ```
 
-### 5d. Client-side routing cache
+Single actor round-trip via `SwimQueryCommand::GetShardInfo` — resolves shard group + leader in one hop.
 
-**What is cached:** Shard → leader mapping. Each entry:
+### 5d. Client-side routing cache (backlog)
 
-```rust
-struct CachedRoute {
-    shard_group_id: ShardGroupId,
-    leader_node_id: NodeId,
-    leader_addr: SocketAddr,
-    epoch: ShardEpoch,
-}
-```
+Client SDK concern. Server-side signals available:
+- `ProposeResponse::Error(NotLeader(Some(leader_id)))` — cache miss
+- `GetShardInfo` — cache population
+- Error-driven invalidation (no TTL, no polling)
 
-Client maintains `HashMap<ShardGroupId, CachedRoute>`. No full topology or hash ring on client — server resolves key → shard, client only caches the result.
+### Architecture changes in Phase 5
 
-**Cache population:** Lazy, on first use. Every `GetShardInfo` response and successful `Propose` response populates or updates the cache entry for that shard. No bulk bootstrap — cache warms organically as client operates.
-
-**Invalidation:** Error-driven only. No TTL, no polling.
-
-| Error | Client action |
-|---|---|
-| `NotLeader(None)` | Evict cached route for shard. Retry with `GetShardInfo` to discover new leader. Exponential backoff (election in progress). |
-| `NotLeader(Some(leader_hint))` | Update cache with hint. Retry to hinted leader immediately. If that also fails → evict + `GetShardInfo`. |
-| `EpochNotMatch { current }` | Evict stale entry. Call `GetShardInfo` to get new shard info with current epoch. |
-| `ShardNotFound` | Evict cache entry. Call `GetShardInfo` — shard may have moved after split/merge. |
-| Connection refused / timeout | Evict cached route. `GetShardInfo` to discover new leader. |
-
-**Retry policy:**
-- Max 3 redirect attempts per propose before returning error to caller.
-- On `NotLeader(None)` or connection failure: exponential backoff starting at 100ms, capped at 2s.
-- On `EpochNotMatch`: immediate retry after cache refresh (no backoff — not a transient failure, just stale data).
-
-**Why error-driven, no TTL:**
-- Leader changes are infrequent (metadata control plane, not data plane).
-- Server-side forwarding (§5a) handles most cases transparently — client cache miss only matters when forwarding also fails.
-- Polling would add unnecessary load across all clients × all cached shards.
+- **`NodeAddress { cluster_addr, client_addr }`** — first-class value object used in `SwimNode.addr`, `ShardLeaderInfo`, `ShardLeaderEntry`, `Swim.self_addr`, `RaftWriters.addr_cache`. Derives `Copy`.
+- **`SwimSender` / `RaftSender`** — typed wrappers encapsulating channel + oneshot request-reply pattern. Clean client handler code in `clients.rs`.
+- **`port` → `client_port`** — explicit naming (`--client-port`, `EASTGUARD_CLIENT_PORT`). Port collision check in `init()`.
 
 **Depends on:** Phase 4.
-**Scope:** 2-3 PRs.
+**Scope:** Completed in 4 PRs (epoch cancelled).
 
 ---
 
@@ -489,7 +463,7 @@ Phase 3 (Application State Machine Dispatch)
 Phase 4 (Propose Pathway)   Phase 6 (Hot Range Detection)
     │                          (needs Phase 4 for end-to-end,
     ▼                           but core logic testable after Phase 3)
-Phase 5 (Leader Forwarding + Epoch + Client Routing Cache)
+Phase 5 (Leader Forwarding + Shard Discovery) ✅
 ```
 
 ---
@@ -561,7 +535,7 @@ Ranges nested inside `TopicMeta`, segments nested inside `RangeMeta`. ID counter
 | Risk | Mitigation |
 |---|---|
 | Pending proposals leak on leader stepdown | Drain and error all pending in `step_down()` |
-| Hash ring divergence between client/broker | Epoch validation catches stale routing (Phase 5) |
+| Hash ring divergence between client/broker | Server resolves routing from SWIM topology (~2-3s convergence). Leader forwarding handles misrouted proposals. Epoch cancelled — not needed. |
 | Bincode format change on new `RaftCommand` variants | In-memory only for now; version byte on `LogEntry` when RocksDB lands |
 | Midpoint split doesn't balance skewed workloads | Acceptable for Phase 6 — percentile-based split in backlog |
 | Seal tracker grows unbounded for long-lived ranges | Sliding window bounded; entries removed on range seal/delete |

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -6,6 +6,7 @@ use crate::clusters::NodeId;
 use crate::clusters::raft::messages::*;
 use crate::clusters::raft::multi_raft::MultiRaft;
 use crate::clusters::raft::storage::RaftStorage;
+use crate::clusters::swims::ShardGroupId;
 use crate::clusters::swims::SwimCommand;
 use crate::clusters::swims::actor::SwimSender;
 use crate::schedulers::ticker_message::TickerCommand;
@@ -16,6 +17,11 @@ use tokio::sync::mpsc;
 pub struct MultiRaftActor;
 
 impl MultiRaftActor {
+    pub fn channel(buffer: usize) -> (RaftSender, mpsc::Receiver<MultiRaftActorCommand>) {
+        let (tx, rx) = mpsc::channel(buffer);
+        (RaftSender(tx), rx)
+    }
+
     pub async fn run(
         node_id: NodeId,
         storage: Box<dyn RaftStorage>,
@@ -73,5 +79,33 @@ impl MultiRaftActor {
                 cb();
             }
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RaftSender(mpsc::Sender<MultiRaftActorCommand>);
+
+impl RaftSender {
+    pub(crate) async fn propose(
+        &self,
+        shard_group_id: ShardGroupId,
+        command: RaftCommand,
+    ) -> Option<Result<(), ProposeError>> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.0
+            .send(MultiRaftActorCommand::Propose {
+                shard_group_id,
+                command,
+                reply: send,
+            })
+            .await
+            .ok()?;
+        recv.await.ok()
+    }
+}
+
+impl From<RaftSender> for mpsc::Sender<MultiRaftActorCommand> {
+    fn from(value: RaftSender) -> Self {
+        value.0
     }
 }

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -7,6 +7,7 @@ use crate::clusters::raft::messages::*;
 use crate::clusters::raft::multi_raft::MultiRaft;
 use crate::clusters::raft::storage::RaftStorage;
 use crate::clusters::swims::SwimCommand;
+use crate::clusters::swims::actor::SwimSender;
 use crate::schedulers::ticker_message::TickerCommand;
 
 use tokio::sync::mpsc;
@@ -21,7 +22,7 @@ impl MultiRaftActor {
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
-        swim_tx: mpsc::Sender<SwimCommand>,
+        swim_tx: SwimSender,
     ) {
         let mut store = MultiRaft::new(node_id, storage);
         let mut buf = Vec::with_capacity(64);

--- a/src/clusters/raft/messages/command.rs
+++ b/src/clusters/raft/messages/command.rs
@@ -15,9 +15,9 @@ pub enum RaftCommand {
     Metadata(MetadataCommand),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Decode, Encode)]
 pub enum ProposeError {
-    NotLeader,
+    NotLeader(Option<NodeId>),
     ShardNotFound,
 }
 

--- a/src/clusters/raft/messages/command.rs
+++ b/src/clusters/raft/messages/command.rs
@@ -57,7 +57,7 @@ pub(crate) enum MultiRaftReply {
 }
 
 /// Commands received by the MultiRaftActor from external sources.
-pub enum MultiRaftActorCommand {
+pub(crate) enum MultiRaftActorCommand {
     /// Fire-and-forget: no reply channel needed.
     Command(MultiRaftCommand),
     /// Query the current leader of a shard group.

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -196,7 +196,7 @@ impl MultiRaft {
                 self.dirty.insert(shard_id);
                 result
             }
-            None => Err(ProposeError::NotLeader),
+            None => Err(ProposeError::NotLeader(None)),
         }
     }
 

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -675,7 +675,7 @@ impl Raft {
     // -> Applied to MetadataStateMachine → topic blue exists
     pub fn propose(&mut self, command: RaftCommand) -> Result<(), ProposeError> {
         if self.role != Role::Leader {
-            return Err(ProposeError::NotLeader);
+            return Err(ProposeError::NotLeader(self.current_leader.clone()));
         }
 
         self.add_new_entry(command);
@@ -1165,7 +1165,30 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         assert_eq!(
             raft.propose(RaftCommand::Noop),
-            Err(ProposeError::NotLeader)
+            Err(ProposeError::NotLeader(None))
+        );
+    }
+
+    #[test]
+    fn follower_propose_returns_leader_hint_when_known() {
+        let mut raft = three_node_raft("node-2");
+        // Receive AppendEntries from node-1 so follower learns who leader is
+        raft.step(
+            node("node-1"),
+            RaftRpc::AppendEntries(AppendEntries {
+                term: 1,
+                leader_id: node("node-1"),
+                prev_log_index: 0,
+                prev_log_term: 0,
+                entries: vec![],
+                leader_commit: 0,
+            }),
+        );
+        assert_eq!(raft.current_leader(), Some(&node("node-1")));
+
+        assert_eq!(
+            raft.propose(RaftCommand::Noop),
+            Err(ProposeError::NotLeader(Some(node("node-1"))))
         );
     }
 

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -8,6 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::messages::{OutboundRaftPacket, RaftTransportCommand, WireRaftMessage};
+use crate::clusters::swims::actor::SwimSender;
 use crate::clusters::swims::{SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeAddress, NodeId};
 use crate::net::{OwnedReadHalf, OwnedWriteHalf, TcpListener, TcpStream};
@@ -105,7 +106,7 @@ impl RaftWriters {
         &mut self,
         packets: Vec<OutboundRaftPacket>,
         raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
-        swim_tx: &mpsc::Sender<SwimCommand>,
+        swim_tx: &SwimSender,
     ) {
         // Group by target — flush_dirty already groups, but be defensive.
         let mut by_target: HashMap<NodeId, Vec<WireRaftMessage>> = HashMap::new();
@@ -191,7 +192,7 @@ impl RaftWriters {
     async fn resolve_address(
         &mut self,
         node_id: &NodeId,
-        swim_tx: &mpsc::Sender<SwimCommand>,
+        swim_tx: &SwimSender,
     ) -> Option<NodeAddress> {
         if let Some(&addr) = self.addr_cache.get(node_id) {
             return Some(addr);
@@ -272,7 +273,7 @@ impl RaftTransportActor {
         listener: TcpListener,
         raft_tx: mpsc::Sender<MultiRaftActorCommand>,
         mut from_actor: mpsc::Receiver<RaftTransportCommand>,
-        swim_tx: mpsc::Sender<SwimCommand>,
+        swim_tx: SwimSender,
     ) {
         let mut state = RaftWriters::new(node_id);
         let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(300));

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
@@ -10,7 +9,7 @@ use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::messages::{OutboundRaftPacket, RaftTransportCommand, WireRaftMessage};
 use crate::clusters::swims::{SwimCommand, SwimQueryCommand};
-use crate::clusters::{BINCODE_CONFIG, NodeId};
+use crate::clusters::{BINCODE_CONFIG, NodeAddress, NodeId};
 use crate::net::{OwnedReadHalf, OwnedWriteHalf, TcpListener, TcpStream};
 
 struct RaftReader(OwnedReadHalf);
@@ -67,7 +66,7 @@ impl RaftReader {
 struct RaftWriters {
     node_id: NodeId,
     writers: HashMap<NodeId, OwnedWriteHalf>,
-    addr_cache: HashMap<NodeId, SocketAddr>,
+    addr_cache: HashMap<NodeId, NodeAddress>,
     /// Peers explicitly disconnected via DisconnectPeer. Outbound RPCs
     /// to these peers are silently dropped until a new connection is
     /// accepted (peer restart with new UUID won't hit this — different NodeId).
@@ -133,7 +132,7 @@ impl RaftWriters {
             }
 
             // Establish new connection
-            let Some(target_addr) = self.resolve_address(&target_id, swim_tx).await else {
+            let Some(node_addr) = self.resolve_address(&target_id, swim_tx).await else {
                 tracing::warn!(
                     "[{}] Cannot resolve address for {:?}",
                     self.node_id,
@@ -142,11 +141,11 @@ impl RaftWriters {
                 continue;
             };
 
-            let Ok(stream) = TcpStream::connect(target_addr).await else {
+            let Ok(stream) = TcpStream::connect(node_addr.cluster_addr).await else {
                 tracing::warn!(
                     "[{}] Failed to connect to {} ({:?})",
                     self.node_id,
-                    target_addr,
+                    node_addr.cluster_addr,
                     target_id
                 );
                 continue;
@@ -193,7 +192,7 @@ impl RaftWriters {
         &mut self,
         node_id: &NodeId,
         swim_tx: &mpsc::Sender<SwimCommand>,
-    ) -> Option<SocketAddr> {
+    ) -> Option<NodeAddress> {
         if let Some(&addr) = self.addr_cache.get(node_id) {
             return Some(addr);
         }
@@ -208,9 +207,9 @@ impl RaftWriters {
             return None;
         }
 
-        if let Ok(Some(addr)) = rx.await {
-            self.addr_cache.insert(node_id.clone(), addr);
-            Some(addr)
+        if let Ok(Some(node_addr)) = rx.await {
+            self.addr_cache.insert(node_id.clone(), node_addr);
+            Some(node_addr)
         } else {
             None
         }

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -6,6 +6,7 @@ use crate::clusters::swims::swim::Swim;
 use crate::schedulers::ticker_message::TickerCommand;
 
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::SendError;
 
 // ==========================================
 // PROTOCOL LAYER (SWIM Actor)
@@ -14,6 +15,10 @@ use tokio::sync::mpsc;
 pub struct SwimActor;
 
 impl SwimActor {
+    pub fn channel(buffer: usize) -> (SwimSender, mpsc::Receiver<SwimCommand>) {
+        let (swim_sender, swim_mailbox) = mpsc::channel(buffer);
+        (SwimSender(swim_sender), swim_mailbox)
+    }
     pub async fn run(
         mut mailbox: mpsc::Receiver<SwimCommand>,
         mut state: Swim,
@@ -92,5 +97,22 @@ impl SwimActor {
                 )
             }
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SwimSender(mpsc::Sender<SwimCommand>);
+impl SwimSender {
+    pub(crate) async fn send(
+        &self,
+        cmd: impl Into<SwimCommand>,
+    ) -> Result<(), SendError<SwimCommand>> {
+        self.0.send(cmd.into()).await
+    }
+}
+
+impl From<SwimSender> for mpsc::Sender<SwimCommand> {
+    fn from(value: SwimSender) -> Self {
+        value.0
     }
 }

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -137,6 +137,17 @@ impl SwimSender {
         recv.await.ok()?
     }
 
+    pub(crate) async fn get_shard_info(
+        &self,
+        key: Vec<u8>,
+    ) -> Option<(ShardGroup, Option<ShardLeaderEntry>)> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.send(SwimQueryCommand::GetShardInfo { key, reply: send })
+            .await
+            .ok()?;
+        recv.await.ok()?
+    }
+
     pub(crate) async fn resolve_address(&self, node_id: NodeId) -> Option<NodeAddress> {
         let (send, recv) = tokio::sync::oneshot::channel();
         self.send(SwimQueryCommand::ResolveAddress {

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::clusters::NodeAddress;
+use crate::clusters::NodeId;
 use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::swims::swim::Swim;
@@ -103,11 +105,37 @@ impl SwimActor {
 #[derive(Clone, Debug)]
 pub struct SwimSender(mpsc::Sender<SwimCommand>);
 impl SwimSender {
+    #[inline]
     pub(crate) async fn send(
         &self,
         cmd: impl Into<SwimCommand>,
     ) -> Result<(), SendError<SwimCommand>> {
         self.0.send(cmd.into()).await
+    }
+
+    pub(crate) async fn resolve_shard_leader(
+        &self,
+        shard_group_id: ShardGroupId,
+    ) -> Option<ShardLeaderEntry> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.send(SwimQueryCommand::ResolveShardLeader {
+            shard_group_id,
+            reply: send,
+        })
+        .await
+        .ok()?;
+        recv.await.ok()?
+    }
+
+    pub(crate) async fn resolve_address(&self, node_id: NodeId) -> Option<NodeAddress> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.send(SwimQueryCommand::ResolveAddress {
+            node_id,
+            reply: send,
+        })
+        .await
+        .ok()?;
+        recv.await.ok()?
     }
 }
 

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -113,6 +113,16 @@ impl SwimSender {
         self.0.send(cmd.into()).await
     }
 
+    pub(crate) async fn resolve_shard_group(&self, resource_key: Vec<u8>) -> Option<ShardGroup> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.send(SwimQueryCommand::ResolveShardGroup {
+            key: resource_key,
+            reply: send,
+        })
+        .await
+        .ok()?;
+        recv.await.ok()?
+    }
     pub(crate) async fn resolve_shard_leader(
         &self,
         shard_group_id: ShardGroupId,

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -1,7 +1,8 @@
 use std::net::SocketAddr;
 
 use crate::clusters::raft::messages::LeaderChange;
-use crate::clusters::swims::ShardGroup;
+use crate::clusters::swims::topology::ShardLeaderEntry;
+use crate::clusters::swims::{ShardGroup, ShardGroupId};
 use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::{NodeId, SwimNode};
 use crate::schedulers::ticker_message::TimerCommand;
@@ -23,6 +24,7 @@ pub enum SwimCommand {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum SwimQueryCommand {
     GetMembers {
         reply: tokio::sync::oneshot::Sender<Vec<SwimNode>>,
@@ -34,6 +36,10 @@ pub enum SwimQueryCommand {
     ResolveShardGroup {
         key: Vec<u8>,
         reply: tokio::sync::oneshot::Sender<Option<ShardGroup>>,
+    },
+    ResolveShardLeader {
+        shard_group_id: ShardGroupId,
+        reply: tokio::sync::oneshot::Sender<Option<ShardLeaderEntry>>,
     },
 }
 

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -40,6 +40,10 @@ pub enum SwimQueryCommand {
         shard_group_id: ShardGroupId,
         reply: tokio::sync::oneshot::Sender<Option<ShardLeaderEntry>>,
     },
+    GetShardInfo {
+        key: Vec<u8>,
+        reply: tokio::sync::oneshot::Sender<Option<(ShardGroup, Option<ShardLeaderEntry>)>>,
+    },
 }
 
 impl From<SwimQueryCommand> for SwimCommand {

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 
 use crate::clusters::raft::messages::LeaderChange;
+use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::swims::topology::ShardLeaderEntry;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
-use crate::clusters::swims::peer_discovery::JoinAttempt;
-use crate::clusters::{NodeId, SwimNode};
+use crate::clusters::{NodeAddress, NodeId, SwimNode};
 use crate::schedulers::ticker_message::TimerCommand;
 
 use super::packet::{OutboundPacket, SwimPacket};
@@ -24,14 +24,13 @@ pub enum SwimCommand {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum SwimQueryCommand {
     GetMembers {
         reply: tokio::sync::oneshot::Sender<Vec<SwimNode>>,
     },
     ResolveAddress {
         node_id: NodeId,
-        reply: tokio::sync::oneshot::Sender<Option<SocketAddr>>,
+        reply: tokio::sync::oneshot::Sender<Option<NodeAddress>>,
     },
     ResolveShardGroup {
         key: Vec<u8>,
@@ -41,6 +40,12 @@ pub enum SwimQueryCommand {
         shard_group_id: ShardGroupId,
         reply: tokio::sync::oneshot::Sender<Option<ShardLeaderEntry>>,
     },
+}
+
+impl From<SwimQueryCommand> for SwimCommand {
+    fn from(value: SwimQueryCommand) -> Self {
+        SwimCommand::Query(value)
+    }
 }
 
 impl From<SwimTimeOutCallback> for SwimCommand {

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -12,7 +12,7 @@ use super::timer::SwimTimer;
 
 /// Internal Events (Actor Logic)
 #[derive(Debug)]
-pub enum SwimCommand {
+pub(crate) enum SwimCommand {
     // From Transport(External)
     PacketReceived { src: SocketAddr, packet: SwimPacket },
     // From Ticker(Internal)

--- a/src/clusters/swims/messages/dissemination_buffer.rs
+++ b/src/clusters/swims/messages/dissemination_buffer.rs
@@ -1,9 +1,7 @@
-use std::net::SocketAddr;
-
 use bincode::{Decode, Encode};
 
 use crate::clusters::swims::topology::ShardGroupId;
-use crate::clusters::{BINCODE_CONFIG, NodeId, SwimNode};
+use crate::clusters::{BINCODE_CONFIG, NodeAddress, NodeId, SwimNode};
 
 // UDP does not handle splitting large messages up.
 // Preventing IP fragmentation is therefore necessary unless we have dedicated fragmentation handling logics.
@@ -118,8 +116,7 @@ impl<T: Disseminable> DisseminationBuffer<T> {
 pub(crate) struct ShardLeaderInfo {
     pub shard_group_id: ShardGroupId,
     pub leader_node_id: NodeId,
-    pub leader_addr: SocketAddr,
-    pub client_addr: SocketAddr,
+    pub leader_addr: NodeAddress,
     pub term: u64,
 }
 
@@ -159,7 +156,7 @@ pub(in crate::clusters::swims) fn dissemination_count(cluster_size: usize) -> u3
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clusters::{NodeId, SwimNodeState};
+    use crate::clusters::{NodeAddress, NodeId, SwimNodeState};
     use std::net::SocketAddr;
 
     fn addr(port: u16) -> SocketAddr {
@@ -169,7 +166,10 @@ mod tests {
     fn member(port: u16, state: SwimNodeState, incarnation: u64) -> SwimNode {
         SwimNode {
             node_id: NodeId::new(port.to_string()),
-            addr: addr(port),
+            addr: NodeAddress {
+                cluster_addr: addr(port),
+                client_addr: addr(port),
+            },
             state,
             incarnation,
         }
@@ -184,7 +184,7 @@ mod tests {
         let result = buf.collect(MAX_GOSSIP_BYTES);
         assert_eq!(result.len(), 2);
 
-        let addrs: Vec<_> = result.iter().map(|m| m.addr).collect();
+        let addrs: Vec<_> = result.iter().map(|m| m.addr.cluster_addr).collect();
         assert!(addrs.contains(&addr(1)));
         assert!(addrs.contains(&addr(2)));
     }
@@ -244,14 +244,14 @@ mod tests {
 
         let first = buf.collect(MAX_GOSSIP_BYTES);
         assert_eq!(
-            first[0].addr,
+            first[0].addr.cluster_addr,
             addr(2),
             "member(2) should lead (higher remaining)"
         );
 
         let second = buf.collect(MAX_GOSSIP_BYTES);
         assert_eq!(
-            second[0].addr,
+            second[0].addr.cluster_addr,
             addr(2),
             "member(2) should still lead after sort() in previous collect()"
         );
@@ -269,8 +269,8 @@ mod tests {
 
         let result = buf.collect(MAX_GOSSIP_BYTES);
         assert_eq!(result.len(), 2);
-        assert_eq!(result[0].addr, addr(2));
-        assert_eq!(result[1].addr, addr(1));
+        assert_eq!(result[0].addr.cluster_addr, addr(2));
+        assert_eq!(result[1].addr.cluster_addr, addr(1));
     }
 
     #[test]
@@ -316,7 +316,7 @@ mod tests {
         buf.enqueue(new, 10);
 
         let result = buf.collect(MAX_GOSSIP_BYTES);
-        assert!(result.iter().any(|m| m.addr == addr(999)));
+        assert!(result.iter().any(|m| m.addr.cluster_addr == addr(999)));
     }
 
     #[test]
@@ -334,8 +334,10 @@ mod tests {
         ShardLeaderInfo {
             shard_group_id: ShardGroupId(group),
             leader_node_id: NodeId::new(leader),
-            leader_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
-            client_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+                client_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+            },
             term,
         }
     }

--- a/src/clusters/swims/messages/dissemination_buffer.rs
+++ b/src/clusters/swims/messages/dissemination_buffer.rs
@@ -119,6 +119,7 @@ pub(crate) struct ShardLeaderInfo {
     pub shard_group_id: ShardGroupId,
     pub leader_node_id: NodeId,
     pub leader_addr: SocketAddr,
+    pub client_addr: SocketAddr,
     pub term: u64,
 }
 
@@ -334,6 +335,7 @@ mod tests {
             shard_group_id: ShardGroupId(group),
             leader_node_id: NodeId::new(leader),
             leader_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+            client_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
             term,
         }
     }

--- a/src/clusters/swims/messages/dissemination_buffer.rs
+++ b/src/clusters/swims/messages/dissemination_buffer.rs
@@ -113,11 +113,11 @@ impl<T: Disseminable> DisseminationBuffer<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-pub(crate) struct ShardLeaderInfo {
+pub struct ShardLeaderInfo {
     pub shard_group_id: ShardGroupId,
     pub leader_node_id: NodeId,
     pub leader_addr: NodeAddress,
-    pub term: u64,
+    pub(crate) term: u64,
 }
 
 impl ShardLeaderInfo {

--- a/src/clusters/swims/messages/mod.rs
+++ b/src/clusters/swims/messages/mod.rs
@@ -3,7 +3,8 @@ pub(crate) mod dissemination_buffer;
 mod packet;
 mod timer;
 
-pub use command::{MembershipEvent, SwimCommand, SwimEvent, SwimQueryCommand};
-pub(crate) use command::{SwimTimeOutCallback, SwimTimerKind};
+pub use command::{MembershipEvent, SwimEvent, SwimQueryCommand};
+
+pub(crate) use command::{SwimCommand, SwimTimeOutCallback, SwimTimerKind};
 pub use packet::{OutboundPacket, SwimHeader, SwimPacket};
 pub(crate) use timer::*;

--- a/src/clusters/swims/mod.rs
+++ b/src/clusters/swims/mod.rs
@@ -29,7 +29,9 @@ pub mod common {
     };
 
     pub fn make_protocol(local_id: &str, local_port: u16) -> Swim {
-        let addr: SocketAddr = format!("127.0.0.1:{}", local_port).parse().unwrap();
+        let peer_addr: SocketAddr = format!("127.0.0.1:{}", local_port).parse().unwrap();
+        let client_addr: SocketAddr =
+            format!("127.0.0.1:{}", local_port + 1000).parse().unwrap();
         let topology = Topology::new(
             std::iter::empty(),
             TopologyConfig {
@@ -37,7 +39,7 @@ pub mod common {
                 replication_factor: 3,
             },
         );
-        Swim::new(NodeId::new(local_id), addr, topology, 0)
+        Swim::new(NodeId::new(local_id), peer_addr, client_addr, topology, 0)
     }
 
     /// Test harness that coordinates SwimProtocol + SwimTicker, mirroring

--- a/src/clusters/swims/mod.rs
+++ b/src/clusters/swims/mod.rs
@@ -19,7 +19,7 @@ pub mod common {
 
     use crate::{
         clusters::{
-            NodeId,
+            NodeAddress, NodeId,
             swims::{
                 OutboundPacket, SwimEvent, SwimPacket, SwimTimer, Topology, TopologyConfig,
                 swim::Swim,
@@ -30,8 +30,7 @@ pub mod common {
 
     pub fn make_protocol(local_id: &str, local_port: u16) -> Swim {
         let peer_addr: SocketAddr = format!("127.0.0.1:{}", local_port).parse().unwrap();
-        let client_addr: SocketAddr =
-            format!("127.0.0.1:{}", local_port + 1000).parse().unwrap();
+        let client_addr: SocketAddr = format!("127.0.0.1:{}", local_port + 1000).parse().unwrap();
         let topology = Topology::new(
             std::iter::empty(),
             TopologyConfig {
@@ -39,7 +38,15 @@ pub mod common {
                 replication_factor: 3,
             },
         );
-        Swim::new(NodeId::new(local_id), peer_addr, client_addr, topology, 0)
+        Swim::new(
+            NodeId::new(local_id),
+            NodeAddress {
+                cluster_addr: peer_addr,
+                client_addr,
+            },
+            topology,
+            0,
+        )
     }
 
     /// Test harness that coordinates SwimProtocol + SwimTicker, mirroring

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -197,6 +197,14 @@ impl Swim {
                 let entry = self.topology.shard_leader(shard_group_id).cloned();
                 let _ = reply.send(entry);
             }
+            SwimQueryCommand::GetShardInfo { key, reply } => {
+                let result = self.topology.shard_group_for(&key).cloned().map(|group| {
+                    // ! While shard group exists, it's possible that there might not be ShardLeaderEntry because of in-transit election
+                    let leader = self.topology.shard_leader(group.id).cloned();
+                    (group, leader)
+                });
+                let _ = reply.send(result);
+            }
         }
     }
 

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -56,6 +56,7 @@ pub struct Swim {
     // Identity
     pub(crate) node_id: NodeId,
     pub(crate) advertise_addr: SocketAddr,
+    advertise_client_addr: SocketAddr,
     incarnation: u64,
 
     // Protocol state
@@ -78,12 +79,14 @@ impl Swim {
     pub fn new(
         node_id: NodeId,
         advertise_addr: SocketAddr,
+        advertise_client_addr: SocketAddr,
         topology: Topology,
         rng_seed: u64,
     ) -> Self {
         let mut swim = Self {
             node_id,
             advertise_addr,
+            advertise_client_addr,
             incarnation: 0,
             topology,
             members: BTreeMap::new(),
@@ -194,6 +197,13 @@ impl Swim {
             SwimQueryCommand::ResolveShardGroup { key, reply } => {
                 let group = self.topology.shard_group_for(&key).cloned();
                 let _ = reply.send(group);
+            }
+            SwimQueryCommand::ResolveShardLeader {
+                shard_group_id,
+                reply,
+            } => {
+                let entry = self.topology.shard_leader(shard_group_id).cloned();
+                let _ = reply.send(entry);
             }
         }
     }
@@ -333,6 +343,7 @@ impl Swim {
                     shard_group_id: event.shard_group_id,
                     leader_node_id: event.leader_node_id,
                     leader_addr: self.advertise_addr,
+                    client_addr: self.advertise_client_addr,
                     term: event.term,
                 };
                 self.apply_shard_leader_update(&info);
@@ -1487,6 +1498,7 @@ mod tests {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
                     leader_addr: b_addr,
+                    client_addr: b_addr,
                     term: 3,
                 }],
             };
@@ -1517,6 +1529,7 @@ mod tests {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
                     leader_addr: b_addr,
+                    client_addr: b_addr,
                     term: 3,
                 }],
             };
@@ -1554,6 +1567,7 @@ mod tests {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
                     leader_addr: b_addr,
+                    client_addr: b_addr,
                     term: 5,
                 }],
             };
@@ -1570,6 +1584,7 @@ mod tests {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-other"),
                     leader_addr: "127.0.0.1:9999".parse().unwrap(),
+                    client_addr: "127.0.0.1:9999".parse().unwrap(),
                     term: 2,
                 }],
             };
@@ -1636,7 +1651,8 @@ mod tests {
         #[test]
         fn announce_leader_updates_topology() {
             let mut h = TestHarness::new("node-local", 8000);
-            let local_addr: SocketAddr = "127.0.0.1:8000".parse().unwrap();
+            let peer_addr: SocketAddr = "127.0.0.1:8000".parse().unwrap();
+            let client_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
             h.protocol
                 .process(SwimCommand::AnnounceShardLeader(LeaderChange {
@@ -1650,7 +1666,8 @@ mod tests {
             assert!(entry.is_some(), "topology should have shard leader entry");
             let entry = entry.unwrap();
             assert_eq!(entry.leader_node_id, NodeId::new("node-local"));
-            assert_eq!(entry.leader_addr, local_addr);
+            assert_eq!(entry.leader_addr, peer_addr);
+            assert_eq!(entry.client_addr, client_addr);
             assert_eq!(entry.term, 1);
         }
 
@@ -1669,6 +1686,7 @@ mod tests {
                     shard_group_id: ShardGroupId(99),
                     leader_node_id: NodeId::new("node-b"),
                     leader_addr: b_addr,
+                    client_addr: b_addr,
                     term: 7,
                 }],
             };

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::swims::topology::Topology;
 
-use crate::clusters::{NodeId, SwimNode, SwimNodeState};
+use crate::clusters::{NodeAddress, NodeId, SwimNode, SwimNodeState};
 use crate::schedulers::ticker_message::TimerCommand;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
@@ -55,8 +55,7 @@ const INDIRECT_PING_COUNT: usize = 3;
 pub struct Swim {
     // Identity
     pub(crate) node_id: NodeId,
-    pub(crate) advertise_addr: SocketAddr,
-    advertise_client_addr: SocketAddr,
+    self_addr: NodeAddress,
     incarnation: u64,
 
     // Protocol state
@@ -76,17 +75,10 @@ pub struct Swim {
 }
 
 impl Swim {
-    pub fn new(
-        node_id: NodeId,
-        advertise_addr: SocketAddr,
-        advertise_client_addr: SocketAddr,
-        topology: Topology,
-        rng_seed: u64,
-    ) -> Self {
+    pub fn new(node_id: NodeId, self_addr: NodeAddress, topology: Topology, rng_seed: u64) -> Self {
         let mut swim = Self {
             node_id,
-            advertise_addr,
-            advertise_client_addr,
+            self_addr,
             incarnation: 0,
             topology,
             members: BTreeMap::new(),
@@ -100,7 +92,7 @@ impl Swim {
         };
         swim.update_member(
             swim.node_id.clone(),
-            advertise_addr,
+            self_addr,
             SwimNodeState::Alive,
             swim.incarnation,
         );
@@ -110,7 +102,7 @@ impl Swim {
     pub fn bootstrap(mut self, bootstrap_servers: Vec<JoinAttempt>) -> Self {
         for attempt in bootstrap_servers
             .into_iter()
-            .filter(|t| t.seed_addr != self.advertise_addr)
+            .filter(|t| t.seed_addr != self.self_addr.cluster_addr)
             .collect::<Vec<_>>()
         {
             self.handle_join(attempt);
@@ -218,16 +210,19 @@ impl Swim {
                 return;
             }
 
-            let target = match self.members.get(&target_node_id).map(|m| m.addr) {
-                Some(addr) => addr,
-                None => return,
+            let Some(cluster_addr) = self
+                .members
+                .get(&target_node_id)
+                .map(|m| m.addr.cluster_addr)
+            else {
+                return;
             };
 
             let seq = self.next_seq();
             let packet = SwimPacket::Ping(self.generate_swim_header(seq));
 
             self.pending_events
-                .push(SwimEvent::Packet(OutboundPacket::new(target, packet)));
+                .push(SwimEvent::Packet(OutboundPacket::new(cluster_addr, packet)));
 
             self.pending_events
                 .push(SwimEvent::Timer(TimerCommand::SetSchedule {
@@ -241,9 +236,12 @@ impl Swim {
     // indirect probe timeout when we receive a long-running Ack message
     // from the previous direct probe
     fn start_indirect_probe(&mut self, target_node_id: NodeId, seq: u32) {
-        let target_addr = match self.members.get(&target_node_id).map(|m| m.addr) {
-            Some(addr) => addr,
-            None => return,
+        let Some(cluster_addr) = self
+            .members
+            .get(&target_node_id)
+            .map(|m| m.addr.cluster_addr)
+        else {
+            return;
         };
 
         // * OPT : pre-allocation
@@ -259,7 +257,7 @@ impl Swim {
             }
 
             if let Some(peer_member) = self.members.get(&peer_node_id) {
-                peer_addrs.push(peer_member.addr);
+                peer_addrs.push(peer_member.addr.cluster_addr);
 
                 // * OPT : Check length ONLY after a successful insertion
                 if peer_addrs.len() == INDIRECT_PING_COUNT {
@@ -275,7 +273,7 @@ impl Swim {
 
         let packet = SwimPacket::PingReq {
             header: self.generate_swim_header(seq),
-            target: target_addr,
+            target: cluster_addr,
         };
         for target in peer_addrs {
             self.pending_events
@@ -342,8 +340,7 @@ impl Swim {
                 let info = ShardLeaderInfo {
                     shard_group_id: event.shard_group_id,
                     leader_node_id: event.leader_node_id,
-                    leader_addr: self.advertise_addr,
-                    client_addr: self.advertise_client_addr,
+                    leader_addr: self.self_addr,
                     term: event.term,
                 };
                 self.apply_shard_leader_update(&info);
@@ -470,7 +467,7 @@ impl Swim {
                 self.gossip_buffer.enqueue(
                     SwimNode {
                         node_id: self.node_id.clone(),
-                        addr: self.advertise_addr,
+                        addr: self.self_addr,
                         state: SwimNodeState::Alive,
                         incarnation: new_incarnation,
                     },
@@ -499,6 +496,8 @@ impl Swim {
         // If their incarnation is higher than we thought, update it.
         if let Some(member) = self.members.get(&source_node_id) {
             if remote_inc > member.incarnation {
+                let mut node_addr = member.addr;
+                node_addr.cluster_addr = addr;
                 if let Some(suspect_seq) = self.last_suspected_seqs.remove(&source_node_id) {
                     self.pending_events
                         .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
@@ -507,16 +506,18 @@ impl Swim {
                 }
                 self.update_member(
                     source_node_id.clone(),
-                    addr,
+                    node_addr,
                     SwimNodeState::Alive,
                     remote_inc,
                 );
             }
         } else {
-            // New member discovered via direct message
             self.update_member(
                 source_node_id.clone(),
-                addr,
+                NodeAddress {
+                    cluster_addr: addr,
+                    client_addr: addr,
+                },
                 SwimNodeState::Alive,
                 remote_inc,
             );
@@ -526,7 +527,7 @@ impl Swim {
     fn update_member(
         &mut self,
         node_id: NodeId,
-        addr: SocketAddr,
+        addr: NodeAddress,
         state: SwimNodeState,
         incarnation: u64,
     ) {
@@ -581,7 +582,7 @@ impl Swim {
 
         if changed {
             tracing::info!(
-                "[{}] Member update: {} @ {} → {:?} (inc {})",
+                "[{}] Member update: {} @ {:?} → {:?} (inc {})",
                 self.node_id,
                 node_id,
                 addr,
@@ -600,7 +601,7 @@ impl Swim {
                     self.pending_events
                         .push(SwimEvent::Membership(MembershipEvent::NodeAlive {
                             node_id: node_id.clone(),
-                            addr,
+                            addr: addr.cluster_addr,
                         }));
                 }
                 SwimNodeState::Dead => {
@@ -696,7 +697,10 @@ mod tests {
     fn node(id: &str, port: u16, state: SwimNodeState, inc: u64) -> SwimNode {
         SwimNode {
             node_id: NodeId::new(id),
-            addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+            addr: NodeAddress {
+                cluster_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+                client_addr: format!("127.0.0.1:{}", port + 1000).parse().unwrap(),
+            },
             state,
             incarnation: inc,
         }
@@ -760,7 +764,7 @@ mod tests {
                 .get("node-b")
                 .expect("unknown node should be added");
             assert_eq!(member.state, SwimNodeState::Alive);
-            assert_eq!(member.addr, sender);
+            assert_eq!(member.addr.cluster_addr, sender);
 
             let out = p.take_packets();
             assert_eq!(out.len(), 1);
@@ -1497,8 +1501,10 @@ mod tests {
                 shard_leaders: vec![ShardLeaderInfo {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
-                    leader_addr: b_addr,
-                    client_addr: b_addr,
+                    leader_addr: NodeAddress {
+                        cluster_addr: b_addr,
+                        client_addr: b_addr,
+                    },
                     term: 3,
                 }],
             };
@@ -1528,8 +1534,10 @@ mod tests {
                 shard_leaders: vec![ShardLeaderInfo {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
-                    leader_addr: b_addr,
-                    client_addr: b_addr,
+                    leader_addr: NodeAddress {
+                        cluster_addr: b_addr,
+                        client_addr: b_addr,
+                    },
                     term: 3,
                 }],
             };
@@ -1566,8 +1574,10 @@ mod tests {
                 shard_leaders: vec![ShardLeaderInfo {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-b"),
-                    leader_addr: b_addr,
-                    client_addr: b_addr,
+                    leader_addr: NodeAddress {
+                        cluster_addr: b_addr,
+                        client_addr: b_addr,
+                    },
                     term: 5,
                 }],
             };
@@ -1583,8 +1593,10 @@ mod tests {
                 shard_leaders: vec![ShardLeaderInfo {
                     shard_group_id: ShardGroupId(42),
                     leader_node_id: NodeId::new("node-other"),
-                    leader_addr: "127.0.0.1:9999".parse().unwrap(),
-                    client_addr: "127.0.0.1:9999".parse().unwrap(),
+                    leader_addr: NodeAddress {
+                        cluster_addr: "127.0.0.1:9999".parse().unwrap(),
+                        client_addr: "127.0.0.1:9999".parse().unwrap(),
+                    },
                     term: 2,
                 }],
             };
@@ -1666,8 +1678,8 @@ mod tests {
             assert!(entry.is_some(), "topology should have shard leader entry");
             let entry = entry.unwrap();
             assert_eq!(entry.leader_node_id, NodeId::new("node-local"));
-            assert_eq!(entry.leader_addr, peer_addr);
-            assert_eq!(entry.client_addr, client_addr);
+            assert_eq!(entry.leader_addr.cluster_addr, peer_addr);
+            assert_eq!(entry.leader_addr.client_addr, client_addr);
             assert_eq!(entry.term, 1);
         }
 
@@ -1685,8 +1697,10 @@ mod tests {
                 shard_leaders: vec![ShardLeaderInfo {
                     shard_group_id: ShardGroupId(99),
                     leader_node_id: NodeId::new("node-b"),
-                    leader_addr: b_addr,
-                    client_addr: b_addr,
+                    leader_addr: NodeAddress {
+                        cluster_addr: b_addr,
+                        client_addr: b_addr,
+                    },
                     term: 7,
                 }],
             };

--- a/src/clusters/swims/topology.rs
+++ b/src/clusters/swims/topology.rs
@@ -1,12 +1,10 @@
+use bincode::{Decode, Encode};
 use murmur3::murmur3_32;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::Cursor;
-use std::net::SocketAddr;
-
-use bincode::{Decode, Encode};
 
 use crate::clusters::swims::messages::dissemination_buffer::ShardLeaderInfo;
-use crate::clusters::{NodeId, SwimNodeState};
+use crate::clusters::{NodeAddress, NodeId, SwimNodeState};
 
 /// Deterministic identifier for a shard group, derived from the hash of the first
 /// virtual node on the consistent hash ring for a given key.
@@ -42,8 +40,7 @@ pub struct VirtualNodeToken {
 #[allow(dead_code)]
 pub struct ShardLeaderEntry {
     pub leader_node_id: NodeId,
-    pub leader_addr: SocketAddr,
-    pub client_addr: SocketAddr,
+    pub leader_addr: NodeAddress,
     pub term: u64,
 }
 
@@ -231,7 +228,6 @@ impl Topology {
             ShardLeaderEntry {
                 leader_node_id: info.leader_node_id.clone(),
                 leader_addr: info.leader_addr,
-                client_addr: info.client_addr,
                 term: info.term,
             },
         );
@@ -272,6 +268,7 @@ fn hash_stable(key: &[u8]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddr;
 
     fn topology_from(nodes: &[&str], config: TopologyConfig) -> Topology {
         let ids = nodes.iter().map(|id| NodeId::new(*id));
@@ -574,16 +571,24 @@ mod tests {
         let info = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:7080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:7080".parse().unwrap(),
+            },
             term: 1,
         };
         assert!(topology.update_shard_leader(&info));
 
         let entry = topology.shard_leader(ShardGroupId(42)).unwrap();
         assert_eq!(entry.leader_node_id, NodeId::new("node-0"));
-        assert_eq!(entry.leader_addr, "127.0.0.1:8080".parse::<SocketAddr>().unwrap());
-        assert_eq!(entry.client_addr, "127.0.0.1:7080".parse::<SocketAddr>().unwrap());
+        assert_eq!(
+            entry.leader_addr.cluster_addr,
+            "127.0.0.1:8080".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(
+            entry.leader_addr.client_addr,
+            "127.0.0.1:7080".parse::<SocketAddr>().unwrap()
+        );
         assert_eq!(entry.term, 1);
     }
 
@@ -600,8 +605,10 @@ mod tests {
         let info1 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:8080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:8080".parse().unwrap(),
+            },
             term: 1,
         };
         topology.update_shard_leader(&info1);
@@ -609,8 +616,10 @@ mod tests {
         let info2 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
-            leader_addr: "127.0.0.1:8081".parse().unwrap(),
-            client_addr: "127.0.0.1:8081".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8081".parse().unwrap(),
+                client_addr: "127.0.0.1:8081".parse().unwrap(),
+            },
             term: 3,
         };
         assert!(topology.update_shard_leader(&info2));
@@ -633,8 +642,10 @@ mod tests {
         let info1 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:8080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:8080".parse().unwrap(),
+            },
             term: 5,
         };
         topology.update_shard_leader(&info1);
@@ -642,8 +653,10 @@ mod tests {
         let stale = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
-            leader_addr: "127.0.0.1:8081".parse().unwrap(),
-            client_addr: "127.0.0.1:8081".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8081".parse().unwrap(),
+                client_addr: "127.0.0.1:8081".parse().unwrap(),
+            },
             term: 2,
         };
         assert!(!topology.update_shard_leader(&stale));
@@ -651,8 +664,10 @@ mod tests {
         let equal = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
-            leader_addr: "127.0.0.1:8081".parse().unwrap(),
-            client_addr: "127.0.0.1:8081".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8081".parse().unwrap(),
+                client_addr: "127.0.0.1:8081".parse().unwrap(),
+            },
             term: 5,
         };
         assert!(!topology.update_shard_leader(&equal));
@@ -675,8 +690,10 @@ mod tests {
         let info = ShardLeaderInfo {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:8080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:8080".parse().unwrap(),
+            },
             term: 1,
         };
         topology.update_shard_leader(&info);
@@ -716,15 +733,19 @@ mod tests {
         let info1 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(10),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:8080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:8080".parse().unwrap(),
+            },
             term: 1,
         };
         let info2 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(20),
             leader_node_id: NodeId::new("node-0"),
-            leader_addr: "127.0.0.1:8080".parse().unwrap(),
-            client_addr: "127.0.0.1:8080".parse().unwrap(),
+            leader_addr: NodeAddress {
+                cluster_addr: "127.0.0.1:8080".parse().unwrap(),
+                client_addr: "127.0.0.1:8080".parse().unwrap(),
+            },
             term: 2,
         };
         topology.update_shard_leader(&info1);

--- a/src/clusters/swims/topology.rs
+++ b/src/clusters/swims/topology.rs
@@ -43,6 +43,7 @@ pub struct VirtualNodeToken {
 pub struct ShardLeaderEntry {
     pub leader_node_id: NodeId,
     pub leader_addr: SocketAddr,
+    pub client_addr: SocketAddr,
     pub term: u64,
 }
 
@@ -230,6 +231,7 @@ impl Topology {
             ShardLeaderEntry {
                 leader_node_id: info.leader_node_id.clone(),
                 leader_addr: info.leader_addr,
+                client_addr: info.client_addr,
                 term: info.term,
             },
         );
@@ -573,12 +575,15 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:7080".parse().unwrap(),
             term: 1,
         };
         assert!(topology.update_shard_leader(&info));
 
         let entry = topology.shard_leader(ShardGroupId(42)).unwrap();
         assert_eq!(entry.leader_node_id, NodeId::new("node-0"));
+        assert_eq!(entry.leader_addr, "127.0.0.1:8080".parse::<SocketAddr>().unwrap());
+        assert_eq!(entry.client_addr, "127.0.0.1:7080".parse::<SocketAddr>().unwrap());
         assert_eq!(entry.term, 1);
     }
 
@@ -596,6 +601,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:8080".parse().unwrap(),
             term: 1,
         };
         topology.update_shard_leader(&info1);
@@ -604,6 +610,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
             leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            client_addr: "127.0.0.1:8081".parse().unwrap(),
             term: 3,
         };
         assert!(topology.update_shard_leader(&info2));
@@ -627,6 +634,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:8080".parse().unwrap(),
             term: 5,
         };
         topology.update_shard_leader(&info1);
@@ -635,6 +643,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
             leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            client_addr: "127.0.0.1:8081".parse().unwrap(),
             term: 2,
         };
         assert!(!topology.update_shard_leader(&stale));
@@ -643,6 +652,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-1"),
             leader_addr: "127.0.0.1:8081".parse().unwrap(),
+            client_addr: "127.0.0.1:8081".parse().unwrap(),
             term: 5,
         };
         assert!(!topology.update_shard_leader(&equal));
@@ -666,6 +676,7 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:8080".parse().unwrap(),
             term: 1,
         };
         topology.update_shard_leader(&info);
@@ -706,12 +717,14 @@ mod tests {
             shard_group_id: ShardGroupId(10),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:8080".parse().unwrap(),
             term: 1,
         };
         let info2 = ShardLeaderInfo {
             shard_group_id: ShardGroupId(20),
             leader_node_id: NodeId::new("node-0"),
             leader_addr: "127.0.0.1:8080".parse().unwrap(),
+            client_addr: "127.0.0.1:8080".parse().unwrap(),
             term: 2,
         };
         topology.update_shard_leader(&info1);

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -121,11 +121,13 @@ async fn setup_with_config(port: u32, join_config: JoinConfig) -> TestHarness {
     let (tx_out, rx_out) = mpsc::channel(100);
     let (ticker_tx, ticker_rx) = mpsc::channel(100);
 
-    let addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
+    let peer_addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
+    let client_addr: SocketAddr = format!("127.0.0.1:{}", port + 1000).parse().unwrap();
 
     let swim = Swim::new(
         NodeId::new(format!("node-local-{}", port).as_str()),
-        addr,
+        peer_addr,
+        client_addr,
         Topology::new(
             std::iter::empty(),
             TopologyConfig {
@@ -153,7 +155,7 @@ async fn setup_with_config(port: u32, join_config: JoinConfig) -> TestHarness {
         tx_out,
         rx_out: Some(rx_out),
         ticker_tx,
-        local_addr: addr,
+        local_addr: peer_addr,
         config: join_config,
     }
 }

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::clusters::NodeAddress;
 use crate::clusters::swims::actor::SwimActor;
 use crate::clusters::swims::peer_discovery::JoinConfig;
 use crate::clusters::swims::swim::Swim;
@@ -126,8 +127,10 @@ async fn setup_with_config(port: u32, join_config: JoinConfig) -> TestHarness {
 
     let swim = Swim::new(
         NodeId::new(format!("node-local-{}", port).as_str()),
-        peer_addr,
-        client_addr,
+        NodeAddress {
+            cluster_addr: peer_addr,
+            client_addr,
+        },
         Topology::new(
             std::iter::empty(),
             TopologyConfig {
@@ -207,7 +210,10 @@ async fn test_refutation_mechanism() {
     // The actor starts at Incarnation 0. We send Suspect with Incarnation 0.
     let lie = SwimNode {
         node_id: "node-local-8000".into(),
-        addr: harness.local_addr,
+        addr: NodeAddress {
+            cluster_addr: harness.local_addr,
+            client_addr: harness.local_addr,
+        },
         state: SwimNodeState::Suspect,
         incarnation: 0,
     };
@@ -257,7 +263,10 @@ async fn test_gossip_propagation() {
     // 1. Tell the actor that "Node 9999" is DEAD via gossip
     let gossip_msg = SwimNode {
         node_id: "node-dead".into(),
-        addr: dead_node,
+        addr: NodeAddress {
+            cluster_addr: dead_node,
+            client_addr: dead_node,
+        },
         state: SwimNodeState::Dead,
         incarnation: 5,
     };
@@ -303,7 +312,7 @@ async fn test_gossip_propagation() {
             && let SwimPacket::Ack(SwimHeader { gossip, .. }) = response.packet()
         {
             // Check if our rumor is in this specific Ack
-            if let Some(rumor) = gossip.iter().find(|m| m.addr == dead_node) {
+            if let Some(rumor) = gossip.iter().find(|m| m.addr.cluster_addr == dead_node) {
                 assert_eq!(rumor.state, SwimNodeState::Dead);
                 propagated = true;
                 break; // Success!
@@ -334,13 +343,19 @@ async fn test_indirect_ping_trigger() {
     // We do this by sending them as gossip from a "bootstrap" packet
     let p1 = SwimNode {
         node_id: "node-peer-1".into(),
-        addr: peer_1,
+        addr: NodeAddress {
+            cluster_addr: peer_1,
+            client_addr: peer_1,
+        },
         state: SwimNodeState::Alive,
         incarnation: 1,
     };
     let p2 = SwimNode {
         node_id: "node-peer-2".into(),
-        addr: peer_2,
+        addr: NodeAddress {
+            cluster_addr: peer_2,
+            client_addr: peer_2,
+        },
         state: SwimNodeState::Alive,
         incarnation: 1,
     };
@@ -441,7 +456,10 @@ async fn test_alive_gossip_adds_node_to_topology() {
                 source_incarnation: 1,
                 gossip: vec![SwimNode {
                     node_id: "node-new".into(),
-                    addr: new_node,
+                    addr: NodeAddress {
+                        cluster_addr: new_node,
+                        client_addr: new_node,
+                    },
                     state: SwimNodeState::Alive,
                     incarnation: 1,
                 }],
@@ -474,7 +492,10 @@ async fn test_dead_gossip_removes_node_from_topology() {
                     source_incarnation: 1,
                     gossip: vec![SwimNode {
                         node_id: "node-target".into(),
-                        addr: node,
+                        addr: NodeAddress {
+                            cluster_addr: node,
+                            client_addr: node,
+                        },
                         state: SwimNodeState::Alive,
                         incarnation: 1,
                     }],
@@ -500,7 +521,10 @@ async fn test_dead_gossip_removes_node_from_topology() {
                 source_incarnation: 1,
                 gossip: vec![SwimNode {
                     node_id: "node-target".into(),
-                    addr: node,
+                    addr: NodeAddress {
+                        cluster_addr: node,
+                        client_addr: node,
+                    },
                     state: SwimNodeState::Dead,
                     incarnation: 2,
                 }],

--- a/src/clusters/transport.rs
+++ b/src/clusters/transport.rs
@@ -1,4 +1,4 @@
-use crate::clusters::swims::{OutboundPacket, SwimCommand};
+use crate::clusters::swims::{OutboundPacket, SwimCommand, actor::SwimSender};
 
 // ==========================================
 // TRANSPORT LAYER (Presentation)
@@ -12,7 +12,7 @@ pub struct SwimTransportActor;
 impl SwimTransportActor {
     pub async fn run(
         socket: UdpSocket,
-        to_actor: mpsc::Sender<SwimCommand>,
+        to_actor: SwimSender,
         mut from_actor: mpsc::Receiver<OutboundPacket>,
     ) {
         tracing::info!(

--- a/src/clusters/types/node.rs
+++ b/src/clusters/types/node.rs
@@ -8,11 +8,16 @@ use bincode::{Decode, Encode};
 use crate::clusters::BINCODE_CONFIG;
 use crate::clusters::SwimNodeState::Alive;
 
-// Used to decide what to say. You must include Dead/Suspect nodes in your messages so that other nodes learn about these failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+pub struct NodeAddress {
+    pub cluster_addr: SocketAddr,
+    pub client_addr: SocketAddr,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct SwimNode {
     pub node_id: NodeId,
-    pub addr: SocketAddr,
+    pub addr: NodeAddress,
     pub state: SwimNodeState,
     pub incarnation: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::fs::{self, OpenOptions};
 use clap::Parser;
 use uuid::Uuid;
 
-use crate::clusters::NodeId;
+use crate::clusters::{NodeAddress, NodeId};
 use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::swims::swim::Swim;
 use crate::clusters::swims::{Topology, TopologyConfig};
@@ -193,8 +193,10 @@ impl Environment {
     pub(crate) fn swim(&self, rng_seed: u64) -> Swim {
         Swim::new(
             NodeId::new(self.resolve_node_id()),
-            self.advertise_peer_addr(),
-            self.advertise_client_addr(),
+            NodeAddress {
+                cluster_addr: self.advertise_peer_addr(),
+                client_addr: self.advertise_client_addr(),
+            },
             Topology::new(
                 std::iter::empty(),
                 TopologyConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,8 +31,8 @@ pub struct Environment {
     #[arg(long = "node-id-prefix", env = "EASTGUARD_NODE_ID_PREFIX")]
     pub node_id_prefix: Option<String>,
 
-    #[arg(short, long, env = "EASTGUARD_PORT", default_value_t = 2921)]
-    pub port: u16,
+    #[arg(short = 'p', long = "client-port", env = "EASTGUARD_CLIENT_PORT", default_value_t = 2921)]
+    pub client_port: u16,
 
     #[arg(long, env = "EASTGUARD_CLUSTER_PORT", default_value_t = 2922)]
     pub cluster_port: u16,
@@ -88,6 +88,13 @@ impl Environment {
         // 1. Parse arguments from CLI and/or ENV vars
         let env = Environment::parse();
 
+        if env.client_port == env.cluster_port {
+            panic!(
+                "client_port ({}) and cluster_port ({}) must be different",
+                env.client_port, env.cluster_port
+            );
+        }
+
         // 2. Ensure data and meta directories exist and are writable
         for dir in [&env.data_dir, &env.meta_dir] {
             if let Err(e) = fs::create_dir_all(dir) {
@@ -110,7 +117,7 @@ impl Environment {
         env
     }
     pub(crate) fn bind_addr(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        format!("{}:{}", self.host, self.client_port)
     }
 
     pub(crate) fn raft_db_path(&self) -> std::path::PathBuf {
@@ -176,10 +183,18 @@ impl Environment {
             .collect()
     }
 
+    pub(crate) fn advertise_client_addr(&self) -> std::net::SocketAddr {
+        let host = self.advertise_host.as_deref().unwrap_or(&self.host);
+        format!("{}:{}", host, self.client_port)
+            .parse()
+            .expect("Invalid advertise client address")
+    }
+
     pub(crate) fn swim(&self, rng_seed: u64) -> Swim {
         Swim::new(
             NodeId::new(self.resolve_node_id()),
             self.advertise_peer_addr(),
+            self.advertise_client_addr(),
             Topology::new(
                 std::iter::empty(),
                 TopologyConfig {
@@ -206,7 +221,7 @@ mod tests {
             data_dir: "./eastguard/data".into(),
             meta_dir: "./eastguard/meta".into(),
             node_id_prefix: None,
-            port: 2921,
+            client_port: 2921,
             cluster_port: 2922,
             host: "127.0.0.1".into(),
             advertise_host: None,
@@ -222,7 +237,7 @@ mod tests {
     #[test]
     fn test_address_formatting() {
         let env = Environment {
-            port: 3000,
+            client_port: 3000,
             cluster_port: 3001,
             node_id_prefix: Some("node-1".into()),
             ..make_env()
@@ -243,7 +258,7 @@ mod tests {
         assert_eq!(env.data_dir, "./eastguard/data");
         assert_eq!(env.meta_dir, "./eastguard/meta");
         assert_eq!(env.node_id_prefix, None);
-        assert_eq!(env.port, 2921);
+        assert_eq!(env.client_port, 2921);
         assert_eq!(env.cluster_port, 2922);
         assert_eq!(env.host, "0.0.0.0");
         assert_eq!(env.vnodes_per_node, 256);
@@ -260,7 +275,7 @@ mod tests {
             "my-server",
             "--node-id-prefix",
             "node-1",
-            "--port",
+            "--client-port",
             "9999",
             "--host",
             "0.0.0.0",
@@ -273,7 +288,7 @@ mod tests {
         let env = Environment::try_parse_from(args).expect("Failed to parse flags");
 
         assert_eq!(env.node_id_prefix, Some("node-1".into()));
-        assert_eq!(env.port, 9999);
+        assert_eq!(env.client_port, 9999);
         assert_eq!(env.host, "0.0.0.0");
         assert_eq!(env.data_dir, "/tmp/test");
         assert_eq!(env.vnodes_per_node, 8);
@@ -293,7 +308,7 @@ mod tests {
 
         let env = Environment::try_parse_from(args).expect("Failed to parse flags");
 
-        assert_eq!(env.port, 9999);
+        assert_eq!(env.client_port, 9999);
         assert_eq!(env.host, "0.0.0.0");
         assert_eq!(env.data_dir, "/tmp/test");
     }
@@ -333,26 +348,26 @@ mod tests {
     fn test_env_vars_override() {
         unsafe {
             std::env::set_var("EASTGUARD_NODE_ID_PREFIX", "env-node-1");
-            std::env::set_var("EASTGUARD_PORT", "8888");
+            std::env::set_var("EASTGUARD_CLIENT_PORT", "8888");
             std::env::set_var("EASTGUARD_HOST", "0.0.0.0");
         }
 
         let env = Environment::try_parse_from(vec!["my-server"]).expect("Failed to parse env vars");
 
         assert_eq!(env.node_id_prefix, Some("env-node-1".into()));
-        assert_eq!(env.port, 8888);
+        assert_eq!(env.client_port, 8888);
         assert_eq!(env.host, "0.0.0.0");
 
         unsafe {
             std::env::remove_var("EASTGUARD_NODE_ID_PREFIX");
-            std::env::remove_var("EASTGUARD_PORT");
+            std::env::remove_var("EASTGUARD_CLIENT_PORT");
             std::env::remove_var("EASTGUARD_HOST");
         }
     }
 
     #[test]
     fn test_invalid_port_input() {
-        let args = vec!["my-server", "--port", "not-a-number"];
+        let args = vec!["my-server", "--client-port", "not-a-number"];
 
         // This should fail because clap validates u16 automatically
         let result = Environment::try_parse_from(args);

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -7,7 +7,9 @@ use crate::{
         raft::messages::ProposeError,
         swims::{ShardGroupId, SwimQueryCommand, actor::SwimSender},
     },
-    connections::request::{ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand},
+    connections::request::{
+        ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand, ShardInfoResponse,
+    },
     net::{OwnedReadHalf, OwnedWriteHalf, TcpStream},
 };
 use anyhow::bail;
@@ -50,8 +52,18 @@ impl ClientStreamWriter {
                     .await?;
 
                 let result = recv.await?;
-                self.write(&result).await.expect("Failed to write message");
-                Ok(())
+                self.write(&result).await
+            }
+            QueryCommand::GetShardInfo { key } => {
+                let response = swim_sender
+                    .get_shard_info(key)
+                    .await
+                    .map(|(group, leader)| ShardInfoResponse {
+                        shard_group_id: group.id.0,
+                        leader_node_id: leader.as_ref().map(|e| e.leader_node_id.to_string()),
+                        leader_addr: leader.map(|e| e.leader_addr),
+                    });
+                self.write(&response).await
             }
         }
     }

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -2,9 +2,9 @@ use std::{io::ErrorKind, net::SocketAddr};
 
 use crate::{
     clusters::{
-        NodeAddress, NodeId,
+        NodeId,
         raft::messages::{MultiRaftActorCommand, ProposeError},
-        swims::{ShardGroupId, ShardLeaderEntry, SwimQueryCommand, actor::SwimSender},
+        swims::{ShardGroupId, SwimQueryCommand, actor::SwimSender},
     },
     connections::request::{ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand},
     net::{OwnedReadHalf, OwnedWriteHalf, TcpStream},
@@ -109,47 +109,20 @@ impl ClientStreamWriter {
     ) -> ProposeResponse {
         // Try 1: use leader hint from Raft → resolve client_addr via SWIM member table
         if let Some(leader_id) = &leader_hint
-            && let Some(node_addr) = Self::resolve_address(swim_sender, leader_id.clone()).await
+            && let Some(node_addr) = swim_sender.resolve_address(leader_id.clone()).await
             && let Ok(response) = Self::forward_to_leader(node_addr.client_addr, &req).await
         {
             return response;
         }
 
         // Try 2: fall back to shard leader gossip (may have different/newer leader info)
-        if let Some(entry) = Self::resolve_shard_leader(swim_sender, shard_group_id).await
+        if let Some(entry) = swim_sender.resolve_shard_leader(shard_group_id).await
             && let Ok(response) = Self::forward_to_leader(entry.leader_addr.client_addr, &req).await
         {
             return response;
         }
 
         ProposeResponse::Error(ProposeError::NotLeader(leader_hint))
-    }
-
-    async fn resolve_address(swim_sender: &SwimSender, node_id: NodeId) -> Option<NodeAddress> {
-        let (send, recv) = tokio::sync::oneshot::channel();
-        swim_sender
-            .send(SwimQueryCommand::ResolveAddress {
-                node_id,
-                reply: send,
-            })
-            .await
-            .ok()?;
-        recv.await.ok()?
-    }
-
-    async fn resolve_shard_leader(
-        swim_sender: &SwimSender,
-        shard_group_id: ShardGroupId,
-    ) -> Option<ShardLeaderEntry> {
-        let (send, recv) = tokio::sync::oneshot::channel();
-        swim_sender
-            .send(SwimQueryCommand::ResolveShardLeader {
-                shard_group_id,
-                reply: send,
-            })
-            .await
-            .ok()?;
-        recv.await.ok()?
     }
 
     async fn forward_to_leader(

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -3,7 +3,8 @@ use std::{io::ErrorKind, net::SocketAddr};
 use crate::{
     clusters::{
         NodeId,
-        raft::messages::{MultiRaftActorCommand, ProposeError},
+        raft::actor::RaftSender,
+        raft::messages::ProposeError,
         swims::{ShardGroupId, SwimQueryCommand, actor::SwimSender},
     },
     connections::request::{ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand},
@@ -11,10 +12,7 @@ use crate::{
 };
 use anyhow::bail;
 use bytes::{Buf, BytesMut};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::mpsc::Sender,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::config::SERDE_CONFIG;
 
@@ -61,18 +59,13 @@ impl ClientStreamWriter {
     pub(crate) async fn handle_propose(
         &mut self,
         swim_sender: SwimSender,
-        raft_tx: Sender<MultiRaftActorCommand>,
+        raft_sender: RaftSender,
         req: ProposeRequest,
     ) -> anyhow::Result<()> {
-        let (send, recv) = tokio::sync::oneshot::channel();
-        swim_sender
-            .send(SwimQueryCommand::ResolveShardGroup {
-                key: req.resource_key.clone(),
-                reply: send,
-            })
-            .await?;
-
-        let Some(shard_group) = recv.await? else {
+        let Some(shard_group) = swim_sender
+            .resolve_shard_group(req.resource_key.clone())
+            .await
+        else {
             self.write(&ProposeResponse::Error(ProposeError::ShardNotFound))
                 .await?;
             return Ok(());
@@ -80,16 +73,13 @@ impl ClientStreamWriter {
 
         let raft_cmd = req.command.clone().into_raft_command(shard_group.members);
 
-        let (send, recv) = tokio::sync::oneshot::channel();
-        raft_tx
-            .send(MultiRaftActorCommand::Propose {
-                shard_group_id: shard_group.id,
-                command: raft_cmd,
-                reply: send,
-            })
-            .await?;
+        let Some(result) = raft_sender.propose(shard_group.id, raft_cmd).await else {
+            self.write(&ProposeResponse::Error(ProposeError::ShardNotFound))
+                .await?;
+            return Ok(());
+        };
 
-        let response = match recv.await? {
+        let response = match result {
             Ok(()) => ProposeResponse::Success,
             Err(ProposeError::NotLeader(ref hint)) if !req.forwarded => {
                 Self::try_forward(&swim_sender, hint.clone(), shard_group.id, req).await

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -1,9 +1,20 @@
-use std::io::ErrorKind;
+use std::{io::ErrorKind, net::SocketAddr};
 
-use crate::net::{OwnedReadHalf, OwnedWriteHalf};
+use crate::{
+    clusters::{
+        NodeAddress, NodeId,
+        raft::messages::{MultiRaftActorCommand, ProposeError},
+        swims::{ShardGroupId, ShardLeaderEntry, SwimCommand, SwimQueryCommand},
+    },
+    connections::request::{ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand},
+    net::{OwnedReadHalf, OwnedWriteHalf, TcpStream},
+};
 use anyhow::bail;
 use bytes::{Buf, BytesMut};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::mpsc::Sender,
+};
 
 use crate::config::SERDE_CONFIG;
 
@@ -26,6 +37,148 @@ impl ClientStreamWriter {
             .await
             .expect("write encoded failed");
         Ok(())
+    }
+
+    pub(crate) async fn handle_query(
+        &mut self,
+        swim_sender: Sender<SwimCommand>,
+        query_type: QueryCommand,
+    ) -> anyhow::Result<()> {
+        match query_type {
+            QueryCommand::GetMembers => {
+                let (send, recv) = tokio::sync::oneshot::channel();
+                swim_sender
+                    .send(SwimQueryCommand::GetMembers { reply: send }.into())
+                    .await?;
+
+                let result = recv.await?;
+                self.write(&result).await.expect("Failed to write message");
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) async fn handle_propose(
+        &mut self,
+        swim_sender: Sender<SwimCommand>,
+        raft_tx: Sender<MultiRaftActorCommand>,
+        req: ProposeRequest,
+    ) -> anyhow::Result<()> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        swim_sender
+            .send(
+                SwimQueryCommand::ResolveShardGroup {
+                    key: req.resource_key.clone(),
+                    reply: send,
+                }
+                .into(),
+            )
+            .await?;
+
+        let Some(shard_group) = recv.await? else {
+            self.write(&ProposeResponse::Error(ProposeError::ShardNotFound))
+                .await?;
+            return Ok(());
+        };
+
+        let raft_cmd = req.command.clone().into_raft_command(shard_group.members);
+
+        let (send, recv) = tokio::sync::oneshot::channel();
+        raft_tx
+            .send(MultiRaftActorCommand::Propose {
+                shard_group_id: shard_group.id,
+                command: raft_cmd,
+                reply: send,
+            })
+            .await?;
+
+        let response = match recv.await? {
+            Ok(()) => ProposeResponse::Success,
+            Err(ProposeError::NotLeader(ref hint)) if !req.forwarded => {
+                Self::try_forward(&swim_sender, hint.clone(), shard_group.id, req).await
+            }
+            Err(err) => ProposeResponse::Error(err),
+        };
+
+        self.write(&response).await?;
+        Ok(())
+    }
+
+    async fn try_forward(
+        swim_sender: &Sender<SwimCommand>,
+        leader_hint: Option<NodeId>,
+        shard_group_id: ShardGroupId,
+        req: ProposeRequest,
+    ) -> ProposeResponse {
+        // Try 1: use leader hint from Raft → resolve client_addr via SWIM member table
+        if let Some(leader_id) = &leader_hint
+            && let Some(node_addr) = Self::resolve_address(swim_sender, leader_id.clone()).await
+            && let Ok(response) = Self::forward_to_leader(node_addr.client_addr, &req).await
+        {
+            return response;
+        }
+
+        // Try 2: fall back to shard leader gossip (may have different/newer leader info)
+        if let Some(entry) = Self::resolve_shard_leader(swim_sender, shard_group_id).await
+            && let Ok(response) = Self::forward_to_leader(entry.leader_addr.client_addr, &req).await
+        {
+            return response;
+        }
+
+        ProposeResponse::Error(ProposeError::NotLeader(leader_hint))
+    }
+
+    async fn resolve_address(
+        swim_sender: &Sender<SwimCommand>,
+        node_id: NodeId,
+    ) -> Option<NodeAddress> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        swim_sender
+            .send(
+                SwimQueryCommand::ResolveAddress {
+                    node_id,
+                    reply: send,
+                }
+                .into(),
+            )
+            .await
+            .ok()?;
+        recv.await.ok()?
+    }
+
+    async fn resolve_shard_leader(
+        swim_sender: &Sender<SwimCommand>,
+        shard_group_id: ShardGroupId,
+    ) -> Option<ShardLeaderEntry> {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        swim_sender
+            .send(
+                SwimQueryCommand::ResolveShardLeader {
+                    shard_group_id,
+                    reply: send,
+                }
+                .into(),
+            )
+            .await
+            .ok()?;
+        recv.await.ok()?
+    }
+
+    async fn forward_to_leader(
+        addr: SocketAddr,
+        req: &ProposeRequest,
+    ) -> anyhow::Result<ProposeResponse> {
+        let stream = TcpStream::connect(addr).await?;
+        let (read_half, write_half) = stream.into_split();
+        let mut writer = ClientStreamWriter::new(write_half);
+        let mut reader = ClientStreamReader::new(read_half);
+
+        let forwarded_req = ConnectionRequests::Propose(ProposeRequest {
+            forwarded: true,
+            ..req.clone()
+        });
+        writer.write(&forwarded_req).await?;
+        reader.read_request().await
     }
 }
 

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -4,7 +4,7 @@ use crate::{
     clusters::{
         NodeAddress, NodeId,
         raft::messages::{MultiRaftActorCommand, ProposeError},
-        swims::{ShardGroupId, ShardLeaderEntry, SwimCommand, SwimQueryCommand},
+        swims::{ShardGroupId, ShardLeaderEntry, SwimQueryCommand, actor::SwimSender},
     },
     connections::request::{ConnectionRequests, ProposeRequest, ProposeResponse, QueryCommand},
     net::{OwnedReadHalf, OwnedWriteHalf, TcpStream},
@@ -41,14 +41,14 @@ impl ClientStreamWriter {
 
     pub(crate) async fn handle_query(
         &mut self,
-        swim_sender: Sender<SwimCommand>,
+        swim_sender: SwimSender,
         query_type: QueryCommand,
     ) -> anyhow::Result<()> {
         match query_type {
             QueryCommand::GetMembers => {
                 let (send, recv) = tokio::sync::oneshot::channel();
                 swim_sender
-                    .send(SwimQueryCommand::GetMembers { reply: send }.into())
+                    .send(SwimQueryCommand::GetMembers { reply: send })
                     .await?;
 
                 let result = recv.await?;
@@ -60,19 +60,16 @@ impl ClientStreamWriter {
 
     pub(crate) async fn handle_propose(
         &mut self,
-        swim_sender: Sender<SwimCommand>,
+        swim_sender: SwimSender,
         raft_tx: Sender<MultiRaftActorCommand>,
         req: ProposeRequest,
     ) -> anyhow::Result<()> {
         let (send, recv) = tokio::sync::oneshot::channel();
         swim_sender
-            .send(
-                SwimQueryCommand::ResolveShardGroup {
-                    key: req.resource_key.clone(),
-                    reply: send,
-                }
-                .into(),
-            )
+            .send(SwimQueryCommand::ResolveShardGroup {
+                key: req.resource_key.clone(),
+                reply: send,
+            })
             .await?;
 
         let Some(shard_group) = recv.await? else {
@@ -105,7 +102,7 @@ impl ClientStreamWriter {
     }
 
     async fn try_forward(
-        swim_sender: &Sender<SwimCommand>,
+        swim_sender: &SwimSender,
         leader_hint: Option<NodeId>,
         shard_group_id: ShardGroupId,
         req: ProposeRequest,
@@ -128,37 +125,28 @@ impl ClientStreamWriter {
         ProposeResponse::Error(ProposeError::NotLeader(leader_hint))
     }
 
-    async fn resolve_address(
-        swim_sender: &Sender<SwimCommand>,
-        node_id: NodeId,
-    ) -> Option<NodeAddress> {
+    async fn resolve_address(swim_sender: &SwimSender, node_id: NodeId) -> Option<NodeAddress> {
         let (send, recv) = tokio::sync::oneshot::channel();
         swim_sender
-            .send(
-                SwimQueryCommand::ResolveAddress {
-                    node_id,
-                    reply: send,
-                }
-                .into(),
-            )
+            .send(SwimQueryCommand::ResolveAddress {
+                node_id,
+                reply: send,
+            })
             .await
             .ok()?;
         recv.await.ok()?
     }
 
     async fn resolve_shard_leader(
-        swim_sender: &Sender<SwimCommand>,
+        swim_sender: &SwimSender,
         shard_group_id: ShardGroupId,
     ) -> Option<ShardLeaderEntry> {
         let (send, recv) = tokio::sync::oneshot::channel();
         swim_sender
-            .send(
-                SwimQueryCommand::ResolveShardLeader {
-                    shard_group_id,
-                    reply: send,
-                }
-                .into(),
-            )
+            .send(SwimQueryCommand::ResolveShardLeader {
+                shard_group_id,
+                reply: send,
+            })
             .await
             .ok()?;
         recv.await.ok()?

--- a/src/connections/request.rs
+++ b/src/connections/request.rs
@@ -19,18 +19,20 @@ pub struct ConnectionRequest {}
 #[derive(Decode, Encode)]
 pub struct SessionRequest {}
 
+// ! Do we need the following?
 #[derive(Decode, Encode)]
 pub enum QueryCommand {
     GetMembers,
 }
 
-#[derive(Decode, Encode)]
+#[derive(Decode, Encode, Clone)]
 pub struct ProposeRequest {
     pub resource_key: Vec<u8>,
     pub command: ClientCommand,
+    pub forwarded: bool,
 }
 
-#[derive(Decode, Encode)]
+#[derive(Clone, Decode, Encode)]
 pub enum ClientCommand {
     CreateTopic {
         name: String,
@@ -65,7 +67,7 @@ impl ClientCommand {
     }
 }
 
-#[derive(Decode, Encode)]
+#[derive(Debug, Decode, Encode)]
 pub enum ProposeResponse {
     Success,
     Error(ProposeError),

--- a/src/connections/request.rs
+++ b/src/connections/request.rs
@@ -1,5 +1,6 @@
 use bincode::{Decode, Encode};
 
+use crate::clusters::NodeAddress;
 use crate::clusters::NodeId;
 use crate::clusters::metadata::command::{CreateTopic, DeleteTopic};
 use crate::clusters::metadata::strategy::StoragePolicy;
@@ -19,10 +20,17 @@ pub struct ConnectionRequest {}
 #[derive(Decode, Encode)]
 pub struct SessionRequest {}
 
-// ! Do we need the following?
 #[derive(Decode, Encode)]
 pub enum QueryCommand {
     GetMembers,
+    GetShardInfo { key: Vec<u8> },
+}
+
+#[derive(Debug, Decode, Encode)]
+pub struct ShardInfoResponse {
+    pub shard_group_id: u64,
+    pub leader_node_id: Option<String>,
+    pub leader_addr: Option<NodeAddress>,
 }
 
 #[derive(Decode, Encode, Clone)]

--- a/src/connections/request.rs
+++ b/src/connections/request.rs
@@ -3,7 +3,7 @@ use bincode::{Decode, Encode};
 use crate::clusters::NodeId;
 use crate::clusters::metadata::command::{CreateTopic, DeleteTopic};
 use crate::clusters::metadata::strategy::StoragePolicy;
-use crate::clusters::raft::messages::RaftCommand;
+use crate::clusters::raft::messages::{ProposeError, RaftCommand};
 
 #[derive(Decode, Encode)]
 pub enum ConnectionRequests {
@@ -68,7 +68,5 @@ impl ClientCommand {
 #[derive(Decode, Encode)]
 pub enum ProposeResponse {
     Success,
-    NotLeader,
-    ShardNotFound,
-    Error(String),
+    Error(ProposeError),
 }

--- a/src/it/e2e_cluster.rs
+++ b/src/it/e2e_cluster.rs
@@ -8,13 +8,13 @@ use crate::net::TcpStream;
 use std::time::Duration;
 use turmoil::Builder;
 
-fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
+fn default_env(idx: u32, node_id: String, client_port: u16, cluster_port: u16) -> Environment {
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
-        port,
+        client_port,
         cluster_port,
         host: "0.0.0.0".into(),
         advertise_host: None,

--- a/src/it/leader_forwarding.rs
+++ b/src/it/leader_forwarding.rs
@@ -1,0 +1,131 @@
+use std::time::Duration;
+
+use turmoil::Builder;
+
+use crate::StartUp;
+use crate::clusters::metadata::strategy::{PartitionStrategy, StoragePolicy};
+use crate::clusters::raft::messages::ProposeError;
+use crate::config::Environment;
+use crate::connections::clients::{ClientStreamReader, ClientStreamWriter};
+use crate::connections::request::{
+    ClientCommand, ConnectionRequests, ProposeRequest, ProposeResponse,
+};
+use crate::net::TcpStream;
+
+fn default_env(idx: u32, node_id: String, client_port: u16, cluster_port: u16) -> Environment {
+    Environment {
+        config_dir: std::env::temp_dir()
+            .join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        data_dir: std::env::temp_dir()
+            .join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        meta_dir: std::env::temp_dir()
+            .join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        node_id_prefix: Some(node_id),
+        client_port,
+        cluster_port,
+        host: "0.0.0.0".into(),
+        advertise_host: None,
+        vnodes_per_node: 256,
+        join_seed_nodes: vec![],
+        join_initial_delay_ms: 1000,
+        join_interval_ms: 1000,
+        join_multiplier: 2,
+        join_max_attempts: 5,
+    }
+}
+
+fn test_propose_request(name: &str, forwarded: bool) -> ConnectionRequests {
+    ConnectionRequests::Propose(ProposeRequest {
+        resource_key: name.as_bytes().to_vec(),
+        command: ClientCommand::CreateTopic {
+            name: name.to_string(),
+            storage_policy: StoragePolicy {
+                retention_ms: 3_600_000,
+                replication_factor: 3,
+                partition_strategy: PartitionStrategy::AutoSplit,
+            },
+        },
+        forwarded,
+    })
+}
+
+async fn send_propose(host: &str, port: u16, req: ConnectionRequests) -> ProposeResponse {
+    let stream = TcpStream::connect((host, port)).await.unwrap();
+    let (read_half, write_half) = stream.into_split();
+    let mut writer = ClientStreamWriter::new(write_half);
+    let mut reader = ClientStreamReader::new(read_half);
+    writer.write(&req).await.unwrap();
+    reader.read_request().await.unwrap()
+}
+
+/// Propose with forwarded=true to a follower should return NotLeader
+/// without attempting to forward again.
+#[test]
+#[serial_test::serial]
+fn forwarded_request_not_forwarded_again() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(60))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    for (name, idx, cp, rp) in [
+        ("node-1", 1u32, 8081u16, 18001u16),
+        ("node-2", 2, 8082, 18002),
+        ("node-3", 3, 8083, 18003),
+    ] {
+        sim.host(name, move || async move {
+            let me = turmoil::lookup(name);
+            let seeds: Vec<String> = [("node-1", 18001u16), ("node-2", 18002), ("node-3", 18003)]
+                .iter()
+                .filter(|(n, _)| *n != name)
+                .map(|(n, p)| format!("{}:{}", turmoil::lookup(*n), p))
+                .collect();
+            let mut env = default_env(idx, name.to_string(), cp, rp);
+            env.advertise_host = Some(me.to_string());
+            env.join_seed_nodes = seeds;
+            StartUp::with_env(env, 0).run().await?;
+            Ok(())
+        });
+    }
+
+    sim.client("test-client", async {
+        tokio::time::sleep(Duration::from_secs(15)).await;
+
+        // Send forwarded=true to all nodes — followers should return NotLeader
+        // (not attempt forwarding), leader should succeed normally
+        let mut not_leader_count = 0;
+        for (host, port) in [("node-1", 8081), ("node-2", 8082), ("node-3", 8083)] {
+            let req = test_propose_request("test-topic-fwd", true);
+            let resp = send_propose(host, port, req).await;
+            match resp {
+                ProposeResponse::Error(ProposeError::NotLeader(_)) => {
+                    not_leader_count += 1;
+                }
+                ProposeResponse::Success => {}
+                other => panic!("Unexpected response from {}: {:?}", host, other),
+            }
+        }
+        // At least 2 of 3 nodes are followers and should return NotLeader
+        // without forwarding (since forwarded=true)
+        assert!(
+            not_leader_count >= 2,
+            "At least 2 followers should return NotLeader for forwarded=true, got {}",
+            not_leader_count
+        );
+
+        Ok(())
+    });
+
+    sim.run()
+}

--- a/src/it/mod.rs
+++ b/src/it/mod.rs
@@ -1,4 +1,5 @@
 mod e2e_cluster;
+mod leader_forwarding;
 mod raft_bridge;
 mod raft_election;
 mod raft_leader_event;

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -10,6 +10,7 @@ use crate::clusters::NodeAddress;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
+use crate::clusters::swims::actor::SwimActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
@@ -66,7 +67,7 @@ async fn start_raft_node(
     let (raft_tx, raft_mailbox) = mpsc::channel(100);
     let (transport_tx, transport_rx) = mpsc::channel(100);
     let (ticker_tx, ticker_rx) = mpsc::channel(64);
-    let (swim_tx, swim_rx) = mpsc::channel(64);
+    let (swim_tx, swim_rx) = SwimActor::channel(64);
 
     let ticker_force = ticker_tx.clone();
     let bind_addr: SocketAddr = format!("0.0.0.0:{}", cluster_port).parse().unwrap();

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -6,6 +6,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 use turmoil::Builder;
 
+use crate::clusters::NodeAddress;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
@@ -26,7 +27,10 @@ async fn mock_swim_handler(
 ) {
     while let Some(cmd) = rx.recv().await {
         if let SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
-            let _ = reply.send(address_map.get(&node_id).copied());
+            let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
+                cluster_addr: addr,
+                client_addr: addr,
+            }));
         }
     }
 }

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -9,6 +9,7 @@ use turmoil::Builder;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
+use crate::clusters::NodeAddress;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
@@ -26,7 +27,10 @@ async fn mock_swim_handler(
 ) {
     while let Some(cmd) = rx.recv().await {
         if let SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
-            let _ = reply.send(address_map.get(&node_id).copied());
+            let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
+                cluster_addr: addr,
+                client_addr: addr,
+            }));
         }
     }
 }

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -6,10 +6,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 use turmoil::Builder;
 
+use crate::clusters::NodeAddress;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
-use crate::clusters::NodeAddress;
+use crate::clusters::swims::actor::SwimActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
@@ -67,7 +68,7 @@ async fn run_raft_node(
     let (raft_tx, raft_mailbox) = mpsc::channel(100);
     let (transport_tx, transport_rx) = mpsc::channel(100);
     let (ticker_tx, ticker_rx) = mpsc::channel(64);
-    let (swim_tx, swim_rx) = mpsc::channel(64);
+    let (swim_tx, swim_rx) = SwimActor::channel(64);
 
     let ticker_force = ticker_tx.clone();
 

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -10,6 +10,7 @@ use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::LeaderChange;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
+use crate::clusters::NodeAddress;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
@@ -30,7 +31,10 @@ async fn swim_handler_with_leader_capture(
     while let Some(cmd) = rx.recv().await {
         match cmd {
             SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) => {
-                let _ = reply.send(address_map.get(&node_id).copied());
+                let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
+                    cluster_addr: addr,
+                    client_addr: addr,
+                }));
             }
             SwimCommand::AnnounceShardLeader(event) => {
                 let _ = leader_events_tx.send(event).await;

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -6,11 +6,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use turmoil::Builder;
 
+use crate::clusters::NodeAddress;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::LeaderChange;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
-use crate::clusters::NodeAddress;
+use crate::clusters::swims::actor::SwimActor;
 use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
@@ -92,7 +93,7 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                 let (raft_tx, raft_mailbox) = mpsc::channel(100);
                 let (transport_tx, transport_rx) = mpsc::channel(100);
                 let (ticker_tx, ticker_rx) = mpsc::channel(64);
-                let (swim_tx, swim_rx) = mpsc::channel(64);
+                let (swim_tx, swim_rx) = SwimActor::channel(64);
                 let (leader_events_tx, mut leader_events_rx) = mpsc::channel(64);
 
                 let ticker_force = ticker_tx.clone();

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -1,4 +1,3 @@
-
 /// Make sure to run the test using RUST_LOG=debug cargo test -- --nocapture
 use crate::StartUp;
 use crate::clusters::{SwimNode, SwimNodeState};
@@ -12,9 +11,18 @@ use turmoil::Builder;
 
 fn default_env(idx: u32, node_id: String, client_port: u16, cluster_port: u16) -> Environment {
     Environment {
-        config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-        data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
-        meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
+        config_dir: std::env::temp_dir()
+            .join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        data_dir: std::env::temp_dir()
+            .join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        meta_dir: std::env::temp_dir()
+            .join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
         node_id_prefix: Some(node_id),
         client_port,
         cluster_port,

--- a/src/it/simple.rs
+++ b/src/it/simple.rs
@@ -10,13 +10,13 @@ use crate::net::TcpStream;
 use std::time::Duration;
 use turmoil::Builder;
 
-fn default_env(idx: u32, node_id: String, port: u16, cluster_port: u16) -> Environment {
+fn default_env(idx: u32, node_id: String, client_port: u16, cluster_port: u16) -> Environment {
     Environment {
         config_dir: std::env::temp_dir().join(format!("eastguard-config-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         data_dir: std::env::temp_dir().join(format!("eastguard-data-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         meta_dir: std::env::temp_dir().join(format!("eastguard-meta-{}-{}", idx, uuid::Uuid::new_v4())).to_string_lossy().into_owned(),
         node_id_prefix: Some(node_id),
-        port,
+        client_port,
         cluster_port,
         host: "0.0.0.0".into(),
         advertise_host: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,7 @@ pub(crate) mod impls;
 mod it;
 pub(crate) mod macros;
 
-use crate::clusters::raft::actor::MultiRaftActor;
-use crate::clusters::raft::messages::MultiRaftActorCommand;
+use crate::clusters::raft::actor::{MultiRaftActor, RaftSender};
 use crate::clusters::raft::transport::RaftTransportActor;
 
 use crate::clusters::swims::actor::SwimSender;
@@ -32,7 +31,6 @@ use crate::{
 };
 use anyhow::Result;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::Sender;
 
 #[derive(Debug)]
 pub struct StartUp {
@@ -59,7 +57,7 @@ impl StartUp {
         let (swim_ticker_tx, swim_ticker_rx) = mpsc::channel(64);
 
         // Raft channels
-        let (raft_tx, raft_mailbox) = mpsc::channel(4096);
+        let (raft_tx, raft_mailbox) = MultiRaftActor::channel(4096);
         let (raft_transport_tx, raft_transport_rx) = mpsc::channel(100);
         let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel(self.env.vnodes_per_node as usize * 4);
 
@@ -78,7 +76,7 @@ impl StartUp {
             swim_sender.clone().into(),
             swim_ticker_rx,
         ));
-        tokio::spawn(run_scheduling_actor(raft_tx.clone(), raft_ticker_rx));
+        tokio::spawn(run_scheduling_actor(raft_tx.clone().into(), raft_ticker_rx));
         tokio::spawn(SwimTransportActor::run(
             udp_socket,
             swim_sender.clone(),
@@ -87,7 +85,7 @@ impl StartUp {
         tokio::spawn(RaftTransportActor::run(
             node_id.clone(),
             tcp_listener,
-            raft_tx.clone(),
+            raft_tx.clone().into(),
             raft_transport_rx,
             swim_sender.clone(),
         ));
@@ -97,7 +95,7 @@ impl StartUp {
             state,
             tx_outbound,
             swim_ticker_tx,
-            raft_tx.clone(),
+            raft_tx.clone().into(),
         ));
         let raft_db = MetadataStorage::open(self.env.raft_db_path());
         tokio::spawn(MultiRaftActor::run(
@@ -114,11 +112,7 @@ impl StartUp {
         Ok(())
     }
 
-    async fn receive_client_streams(
-        self,
-        swim_sender: SwimSender,
-        raft_tx: Sender<MultiRaftActorCommand>,
-    ) {
+    async fn receive_client_streams(self, swim_sender: SwimSender, raft_tx: RaftSender) {
         let addr = self.env.bind_addr();
         let listener = TcpListener::bind(&addr).await.unwrap();
         tracing::info!(
@@ -143,7 +137,7 @@ impl StartUp {
 async fn handle_client_stream(
     stream: TcpStream,
     swim_sender: SwimSender,
-    raft_tx: Sender<MultiRaftActorCommand>,
+    raft_sender: RaftSender,
 ) -> Result<()> {
     let (read_half, write_half) = stream.into_split();
     let mut stream_reader = ClientStreamReader::new(read_half);
@@ -157,7 +151,7 @@ async fn handle_client_stream(
         }
         ConnectionRequests::Propose(req) => {
             stream_writer
-                .handle_propose(swim_sender, raft_tx, req)
+                .handle_propose(swim_sender, raft_sender, req)
                 .await?
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,10 @@ mod it;
 pub(crate) mod macros;
 
 use crate::clusters::raft::actor::MultiRaftActor;
-use crate::clusters::raft::messages::{MultiRaftActorCommand, ProposeError};
+use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
-
-use crate::clusters::swims::{SwimCommand, SwimQueryCommand};
+use crate::clusters::swims::SwimCommand;
 use crate::config::Environment;
-use crate::connections::request::{ProposeRequest, ProposeResponse, QueryCommand};
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
@@ -145,82 +143,19 @@ async fn handle_client_stream(
 ) -> Result<()> {
     let (read_half, write_half) = stream.into_split();
     let mut stream_reader = ClientStreamReader::new(read_half);
-    let stream_writer = ClientStreamWriter::new(write_half);
+    let mut stream_writer = ClientStreamWriter::new(write_half);
     let request = stream_reader.read_request().await?;
 
     match request {
         ConnectionRequests::Connection(_request) => {}
         ConnectionRequests::Query(query_type) => {
-            handle_query(stream_writer, swim_sender, query_type).await?
+            stream_writer.handle_query(swim_sender, query_type).await?
         }
         ConnectionRequests::Propose(req) => {
-            handle_propose(stream_writer, swim_sender, raft_tx, req).await?
+            stream_writer
+                .handle_propose(swim_sender, raft_tx, req)
+                .await?
         }
     }
-    Ok(())
-}
-
-async fn handle_query(
-    mut writer: ClientStreamWriter,
-    swim_sender: Sender<SwimCommand>,
-    query_type: QueryCommand,
-) -> Result<()> {
-    match query_type {
-        QueryCommand::GetMembers => {
-            let (send, recv) = tokio::sync::oneshot::channel();
-            swim_sender
-                .send(SwimCommand::Query(SwimQueryCommand::GetMembers {
-                    reply: send,
-                }))
-                .await?;
-
-            let result = recv.await?;
-            writer
-                .write(&result)
-                .await
-                .expect("Failed to write message");
-            Ok(())
-        }
-    }
-}
-
-async fn handle_propose(
-    mut writer: ClientStreamWriter,
-    swim_sender: Sender<SwimCommand>,
-    raft_tx: Sender<MultiRaftActorCommand>,
-    req: ProposeRequest,
-) -> Result<()> {
-    let (send, recv) = tokio::sync::oneshot::channel();
-    swim_sender
-        .send(SwimCommand::Query(SwimQueryCommand::ResolveShardGroup {
-            key: req.resource_key,
-            reply: send,
-        }))
-        .await?;
-
-    let Some(shard_group) = recv.await? else {
-        writer
-            .write(&ProposeResponse::Error(ProposeError::ShardNotFound))
-            .await?;
-        return Ok(());
-    };
-
-    let raft_cmd = req.command.into_raft_command(shard_group.members);
-
-    let (send, recv) = tokio::sync::oneshot::channel();
-    raft_tx
-        .send(MultiRaftActorCommand::Propose {
-            shard_group_id: shard_group.id,
-            command: raft_cmd,
-            reply: send,
-        })
-        .await?;
-
-    let response = match recv.await? {
-        Ok(()) => ProposeResponse::Success,
-        Err(err) => ProposeResponse::Error(err),
-    };
-
-    writer.write(&response).await?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,9 @@ async fn handle_propose(
         .await?;
 
     let Some(shard_group) = recv.await? else {
-        writer.write(&ProposeResponse::ShardNotFound).await?;
+        writer
+            .write(&ProposeResponse::Error(ProposeError::ShardNotFound))
+            .await?;
         return Ok(());
     };
 
@@ -216,8 +218,7 @@ async fn handle_propose(
 
     let response = match recv.await? {
         Ok(()) => ProposeResponse::Success,
-        Err(ProposeError::NotLeader) => ProposeResponse::NotLeader,
-        Err(ProposeError::ShardNotFound) => ProposeResponse::ShardNotFound,
+        Err(err) => ProposeResponse::Error(err),
     };
 
     writer.write(&response).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ pub(crate) mod macros;
 use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
-use crate::clusters::swims::SwimCommand;
+
+use crate::clusters::swims::actor::SwimSender;
 use crate::config::Environment;
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
@@ -53,7 +54,7 @@ impl StartUp {
 
     pub async fn run(self) -> Result<()> {
         // SWIM channels
-        let (swim_sender, swim_mailbox) = mpsc::channel(100);
+        let (swim_sender, swim_mailbox) = SwimActor::channel(100);
         let (tx_outbound, rx_outbound) = mpsc::channel(100);
         let (swim_ticker_tx, swim_ticker_rx) = mpsc::channel(64);
 
@@ -73,7 +74,10 @@ impl StartUp {
         let tcp_listener = crate::net::TcpListener::bind(peer_bind_addr).await?;
 
         // Spawn actors (order: tickers → transports → protocols → client)
-        tokio::spawn(run_scheduling_actor(swim_sender.clone(), swim_ticker_rx));
+        tokio::spawn(run_scheduling_actor(
+            swim_sender.clone().into(),
+            swim_ticker_rx,
+        ));
         tokio::spawn(run_scheduling_actor(raft_tx.clone(), raft_ticker_rx));
         tokio::spawn(SwimTransportActor::run(
             udp_socket,
@@ -112,7 +116,7 @@ impl StartUp {
 
     async fn receive_client_streams(
         self,
-        swim_sender: Sender<SwimCommand>,
+        swim_sender: SwimSender,
         raft_tx: Sender<MultiRaftActorCommand>,
     ) {
         let addr = self.env.bind_addr();
@@ -138,7 +142,7 @@ impl StartUp {
 
 async fn handle_client_stream(
     stream: TcpStream,
-    swim_sender: Sender<SwimCommand>,
+    swim_sender: SwimSender,
     raft_tx: Sender<MultiRaftActorCommand>,
 ) -> Result<()> {
     let (read_half, write_half) = stream.into_split();


### PR DESCRIPTION
## Summary

Clients can discover shard → leader mappings.

### Leader Hint in ProposeError
- `ProposeError::NotLeader(Option<NodeId>)` carries leader hint when known
- `Raft::propose()` returns `NotLeader(self.current_leader.clone())`
- `ProposeResponse` simplified to `Success | Error(ProposeError)`

### NodeAddress + SWIM Leader Lookup
- `NodeAddress { cluster_addr, client_addr }` — first-class value object (`Copy`) used in `SwimNode.addr`, `ShardLeaderInfo`, `ShardLeaderEntry`, `Swim.self_addr`, `RaftWriters.addr_cache`
- `SwimQueryCommand::ResolveAddress` returns `Option<NodeAddress>`
- `SwimQueryCommand::ResolveShardLeader` added for shard leader lookup
- `port` renamed to `client_port` (`--client-port`, `EASTGUARD_CLIENT_PORT`). Port collision check in `init()`
- `SwimSender` wrapper with typed methods: `resolve_address()`, `resolve_shard_leader()`, `resolve_shard_group()`, `get_shard_info()`

### Leader Forwarding
- `ProposeRequest.forwarded: bool` — max 1 hop
- Two-strategy forwarding in `ClientStreamWriter::try_forward()`:
  1. Fast path: leader hint + `ResolveAddress` → `client_addr` (SWIM membership, ~2-3s)
  2. Slow path: `ResolveShardLeader` → shard leader gossip
- `RaftSender` wrapper with typed `propose()` method
- `MultiRaftActor::channel()` factory

### GetShardInfo Query
- `QueryCommand::GetShardInfo { key }` — single actor round-trip
- `SwimQueryCommand::GetShardInfo` resolves shard group + leader in one hop
- Returns `Option<ShardInfoResponse>` with `NodeAddress` for leader




