### PR TITLE
fix flaky test

### DIFF
--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -17,7 +17,6 @@ use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
 use crate::schedulers::actor::run_scheduling_actor;
-use crate::schedulers::ticker_message::TickerCommand;
 
 const CLUSTER_PORT: u16 = 19000;
 const RESULT_PORT: u16 = 39000;
@@ -96,7 +95,6 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                 let (swim_tx, swim_rx) = SwimActor::channel(64);
                 let (leader_events_tx, mut leader_events_rx) = mpsc::channel(64);
 
-                let ticker_force = ticker_tx.clone();
                 let bind_addr: SocketAddr =
                     format!("0.0.0.0:{}", CLUSTER_PORT + port).parse().unwrap();
                 let listener = TcpListener::bind(bind_addr).await?;
@@ -136,22 +134,20 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                     .await
                     .unwrap();
 
-                for _ in 0..10 {
-                    tokio::task::yield_now().await;
-                }
-
-                // Drive election
-                for _ in 0..200 {
-                    let _ = ticker_force.send(TickerCommand::ForceTick).await;
-                    tokio::task::yield_now().await;
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                    tokio::task::yield_now().await;
-                }
-
-                // Collect leader events (non-blocking drain)
+                // Let the scheduler's real interval (100 ms) drive the
+                // election naturally — no ForceTick, no channel pressure.
+                // 15 s = 150 interval ticks, well above the 50-70 tick
+                // election timeout.
                 let mut events = Vec::new();
-                while let Ok(event) = leader_events_rx.try_recv() {
-                    events.push(event);
+                for _ in 0..150 {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tokio::task::yield_now().await;
+                    while let Ok(event) = leader_events_rx.try_recv() {
+                        events.push(event);
+                    }
+                    if !events.is_empty() {
+                        break;
+                    }
                 }
 
                 // Serve result to checker via TCP


### PR DESCRIPTION
## Summary

Fix flaky `leader_election_emits_leader_change_event` integration test (~25% failure rate).

## Root Cause

Circular channel backpressure deadlock in turmoil simulation caused by `ForceTick` flooding:

1. Test floods `scheduler_tx` (cap 64) with ForceTick messages
2. Scheduler sends callbacks to `raft_tx` (cap 100) — blocks when full
3. RaftActor tries to send timer commands back to `scheduler_tx` during flush — blocks when full
4. Test blocks sending next ForceTick — can't reach `sleep()` — turmoil time freezes
5. No time advancement → no TCP delivery → election never completes

```
Scheduler ──blocked──> raft_tx (FULL)
    ^                       │
    │                       v
scheduler_tx <──blocked── RaftActor
(FULL)                    (flush)
    ^
    │ blocked
Test (ForceTick)  ← can't sleep() → time frozen
```

**Production unaffected** — uses real `tokio::time::interval(100ms)`, no external channel pressure. Verified 10/10 with real 3-node cluster.

## Fix

Removed `ForceTick` entirely. Let scheduler's real interval (100ms) drive election naturally in turmoil. Poll for `LeaderChange` events with early exit.

## Verification

- 50/50 passes (was ~38/50 before)
- 10/10 real 3-node cluster starts with 768 leader announcements each
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- Full `cargo test` (202 tests) passes