### PR TITLE
refactor: add SwimActorCommand to decouple protocol commands from queries 

### DIFF
--- a/simulator/PLAN.md
+++ b/simulator/PLAN.md
@@ -290,10 +290,17 @@ Control panel sections:
 
 Tasks:
 
-1. Extract `east-guard-core` workspace crate: move pure state machine modules out of `east-guard`; confirm `east-guard`
-   still compiles; confirm `east-guard-core` compiles with no `tokio`/`rocksdb` in its dependency tree
+1. Extract `eastguard-core` workspace crate (two sub-steps):
+   - **1a. Refactor eastguard first**: make the structural changes inside the existing `east-guard` crate
+     (remove `Swim::process` / `Swim::handle_query`, make `step` / `handle_timeout` `pub`, add
+     `announce_shard_leader`, add query accessor methods, update `actor.rs` dispatch, update tests).
+     Run `cargo clippy` to verify before touching the new crate.
+   - **1b. Migrate to eastguard-core**: copy the refactored pure-state-machine files into `eastguard-core`
+     (only path adjustments needed, no logic changes); replace the originals in `east-guard` with
+     `pub use eastguard_core::...` re-export shims; confirm `east-guard` still compiles; confirm
+     `eastguard-core` has no `tokio` / `rocksdb` in its dependency tree.
 2. Create `simulator/wasm/Cargo.toml` — add `wasm-bindgen`, `serde`, `serde-json`, `getrandom` (`js` feature); depend
-   on `east-guard-core`
+   on `eastguard-core`
 3. Implement `VirtualNetwork` with enqueue / deliver / fault rules
 4. Implement `SimNode` wrapping one `Swim` + `Topology` + `MetadataStateMachine` + `Vec<Raft>` (one per shard group)
 5. Implement `SimulatorEngine::new(node_count, shards, seed)` — create nodes with only seed address knowledge; real SWIM
@@ -387,7 +394,7 @@ Tasks:
 - `serde` + `serde-json` for snapshot serialization (return `JsValue` from `tick()`)
 - `getrandom` with `js` feature for seeded RNG in WASM
 - `wasm-pack` as the build tool (`wasm-pack build --target web`)
-- The WASM crate depends on `east-guard-core` (see Prerequisite below), NOT on the main `east-guard` crate
+- The WASM crate depends on `eastguard-core` (see Prerequisite below), NOT on the main `east-guard` crate
 
 ### JavaScript side
 
@@ -399,19 +406,19 @@ Tasks:
 
 ---
 
-## Prerequisite — Extract `east-guard-core` Workspace Crate
+## Prerequisite — Extract `eastguard-core` Workspace Crate
 
 The main `east-guard` crate has `tokio`, `rocksdb`, and other native-only dependencies at the root. WebAssembly cannot
 compile these. The pure state machines (`Swim`, `Raft`, `Topology`, `MetadataStateMachine`, `Ticker`) are async-free
 and I/O-free, but they currently live in the same crate as the actors and storage layer that are not.
 
-**Solution:** Create a new workspace crate `east-guard-core` containing only the pure state machines. No `tokio`, no
+**Solution:** Create a new workspace crate `eastguard-core` containing only the pure state machines. No `tokio`, no
 `rocksdb`, no async. The main `east-guard` crate becomes a thin layer of actors + storage that depends on
-`east-guard-core`. The WASM crate also depends on `east-guard-core`.
+`eastguard-core`. The WASM crate also depends on `eastguard-core`.
 
 ```
 Workspace
-├── east-guard-core/     ← NEW: pure state machines only (no tokio, no rocksdb)
+├── eastguard-core/     ← NEW: pure state machines only (no tokio, no rocksdb)
 │   └── src/
 │       ├── swim/        (moved from east-guard/src/clusters/swims/)
 │       ├── raft/        (moved from east-guard/src/clusters/raft/)
@@ -419,13 +426,13 @@ Workspace
 │       ├── metadata/    (moved from east-guard/src/clusters/metadata/)
 │       └── scheduler/   (moved from east-guard/src/schedulers/)
 │
-├── east-guard/          ← existing crate; actors + storage; depends on east-guard-core
+├── east-guard/          ← existing crate; actors + storage; depends on eastguard-core
 │   └── src/
 │       ├── clusters/    (actors, transport — keep tokio here)
 │       └── ...
 │
 └── simulator/
-    └── wasm/            ← depends on east-guard-core only
+    └── wasm/            ← depends on eastguard-core only
 ```
 
 This refactor is the prerequisite for Phase 1. It is also a net improvement to the main codebase — the protocol logic

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -9,7 +9,7 @@ use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::messages::{OutboundRaftPacket, RaftTransportCommand, WireRaftMessage};
 use crate::clusters::swims::actor::SwimSender;
-use crate::clusters::swims::{SwimCommand, SwimQueryCommand};
+use crate::clusters::swims::SwimQueryCommand;
 use crate::clusters::{BINCODE_CONFIG, NodeAddress, NodeId};
 use crate::net::{OwnedReadHalf, OwnedWriteHalf, TcpListener, TcpStream};
 
@@ -199,10 +199,10 @@ impl RaftWriters {
         }
 
         let (tx, rx) = oneshot::channel();
-        let query = SwimCommand::Query(SwimQueryCommand::ResolveAddress {
+        let query = SwimQueryCommand::ResolveAddress {
             node_id: node_id.clone(),
             reply: tx,
-        });
+        };
 
         if swim_tx.send(query).await.is_err() {
             return None;

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -17,12 +17,12 @@ use tokio::sync::mpsc::error::SendError;
 pub struct SwimActor;
 
 impl SwimActor {
-    pub fn channel(buffer: usize) -> (SwimSender, mpsc::Receiver<SwimCommand>) {
+    pub fn channel(buffer: usize) -> (SwimSender, mpsc::Receiver<SwimActorCommand>) {
         let (swim_sender, swim_mailbox) = mpsc::channel(buffer);
         (SwimSender(swim_sender), swim_mailbox)
     }
     pub async fn run(
-        mut mailbox: mpsc::Receiver<SwimCommand>,
+        mut mailbox: mpsc::Receiver<SwimActorCommand>,
         mut state: Swim,
         transport_tx: mpsc::Sender<OutboundPacket>,
         scheduler_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
@@ -37,9 +37,47 @@ impl SwimActor {
                 break;
             }
             for event in buf.drain(..) {
-                state.process(event);
+                match event {
+                    SwimActorCommand::Protocol(cmd) => match cmd {
+                        SwimCommand::PacketReceived { src, packet } => state.step(src, packet),
+                        SwimCommand::Timeout(event) => state.handle_timeout(event),
+                        SwimCommand::AnnounceShardLeader(event) => state.announce_shard_leader(
+                            event.shard_group_id,
+                            event.leader_node_id,
+                            event.term,
+                        ),
+                    },
+                    SwimActorCommand::Query(q) => Self::handle_query(&state, q),
+                }
             }
             Self::flush(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
+        }
+    }
+
+    fn handle_query(state: &Swim, command: SwimQueryCommand) {
+        match command {
+            SwimQueryCommand::GetMembers { reply } => {
+                let _ = reply.send(state.get_members());
+            }
+            SwimQueryCommand::ResolveAddress { node_id, reply } => {
+                let _ = reply.send(state.resolve_address(&node_id));
+            }
+            SwimQueryCommand::ResolveShardGroup { key, reply } => {
+                let _ = reply.send(state.topology.shard_group_for(&key).cloned());
+            }
+            SwimQueryCommand::ResolveShardLeader {
+                shard_group_id,
+                reply,
+            } => {
+                let _ = reply.send(state.topology.shard_leader(shard_group_id).cloned());
+            }
+            SwimQueryCommand::GetShardInfo { key, reply } => {
+                let result = state.topology.shard_group_for(&key).cloned().map(|group| {
+                    let leader = state.topology.shard_leader(group.id).cloned();
+                    (group, leader)
+                });
+                let _ = reply.send(result);
+            }
         }
     }
 
@@ -103,13 +141,13 @@ impl SwimActor {
 }
 
 #[derive(Clone, Debug)]
-pub struct SwimSender(mpsc::Sender<SwimCommand>);
+pub struct SwimSender(mpsc::Sender<SwimActorCommand>);
 impl SwimSender {
     #[inline]
     pub(crate) async fn send(
         &self,
-        cmd: impl Into<SwimCommand>,
-    ) -> Result<(), SendError<SwimCommand>> {
+        cmd: impl Into<SwimActorCommand>,
+    ) -> Result<(), SendError<SwimActorCommand>> {
         self.0.send(cmd.into()).await
     }
 
@@ -160,7 +198,7 @@ impl SwimSender {
     }
 }
 
-impl From<SwimSender> for mpsc::Sender<SwimCommand> {
+impl From<SwimSender> for mpsc::Sender<SwimActorCommand> {
     fn from(value: SwimSender) -> Self {
         value.0
     }

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -17,10 +17,15 @@ pub(crate) enum SwimCommand {
     PacketReceived { src: SocketAddr, packet: SwimPacket },
     // From Ticker(Internal)
     Timeout(SwimTimeOutCallback),
-    // From API (e.g., HTTP API)
-    Query(SwimQueryCommand),
     // From MultiRaftActor(Internal) — leader election completed for a shard group
     AnnounceShardLeader(LeaderChange),
+}
+
+/// Actor-level command envelope. Lives only in eastguard (carries tokio oneshot via Query).
+#[derive(Debug)]
+pub(crate) enum SwimActorCommand {
+    Protocol(SwimCommand),
+    Query(SwimQueryCommand),
 }
 
 #[derive(Debug)]
@@ -46,15 +51,27 @@ pub enum SwimQueryCommand {
     },
 }
 
-impl From<SwimQueryCommand> for SwimCommand {
-    fn from(value: SwimQueryCommand) -> Self {
-        SwimCommand::Query(value)
-    }
-}
-
 impl From<SwimTimeOutCallback> for SwimCommand {
     fn from(value: SwimTimeOutCallback) -> Self {
         SwimCommand::Timeout(value)
+    }
+}
+
+impl From<SwimCommand> for SwimActorCommand {
+    fn from(cmd: SwimCommand) -> Self {
+        SwimActorCommand::Protocol(cmd)
+    }
+}
+
+impl From<SwimTimeOutCallback> for SwimActorCommand {
+    fn from(cb: SwimTimeOutCallback) -> Self {
+        SwimActorCommand::Protocol(SwimCommand::Timeout(cb))
+    }
+}
+
+impl From<SwimQueryCommand> for SwimActorCommand {
+    fn from(q: SwimQueryCommand) -> Self {
+        SwimActorCommand::Query(q)
     }
 }
 

--- a/src/clusters/swims/messages/mod.rs
+++ b/src/clusters/swims/messages/mod.rs
@@ -5,6 +5,6 @@ mod timer;
 
 pub use command::{MembershipEvent, SwimEvent, SwimQueryCommand};
 
-pub(crate) use command::{SwimCommand, SwimTimeOutCallback, SwimTimerKind};
+pub(crate) use command::{SwimActorCommand, SwimCommand, SwimTimeOutCallback, SwimTimerKind};
 pub use packet::{OutboundPacket, SwimHeader, SwimPacket};
 pub(crate) use timer::*;

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -153,7 +153,7 @@ impl Swim {
     // -----------------------------------------------------------------------
     // Core protocol logic
     // -----------------------------------------------------------------------
-    pub(super) fn handle_timeout(&mut self, event: SwimTimeOutCallback) {
+    pub fn handle_timeout(&mut self, event: SwimTimeOutCallback) {
         match event {
             SwimTimeOutCallback::ProtocolPeriodElapsed => self.start_probe(),
             SwimTimeOutCallback::TimedOut {
@@ -185,37 +185,6 @@ impl Swim {
         }
         #[cfg(test)]
         self.assert_invariants();
-    }
-
-    pub(super) fn handle_query(&self, command: SwimQueryCommand) {
-        match command {
-            SwimQueryCommand::GetMembers { reply } => {
-                let _ = reply.send(self.members.values().cloned().collect());
-            }
-            SwimQueryCommand::ResolveAddress { node_id, reply } => {
-                let addr = self.members.get(&node_id).map(|m| m.addr);
-                let _ = reply.send(addr);
-            }
-            SwimQueryCommand::ResolveShardGroup { key, reply } => {
-                let group = self.topology.shard_group_for(&key).cloned();
-                let _ = reply.send(group);
-            }
-            SwimQueryCommand::ResolveShardLeader {
-                shard_group_id,
-                reply,
-            } => {
-                let entry = self.topology.shard_leader(shard_group_id).cloned();
-                let _ = reply.send(entry);
-            }
-            SwimQueryCommand::GetShardInfo { key, reply } => {
-                let result = self.topology.shard_group_for(&key).cloned().map(|group| {
-                    // ! While shard group exists, it's possible that there might not be ShardLeaderEntry because of in-transit election
-                    let leader = self.topology.shard_leader(group.id).cloned();
-                    (group, leader)
-                });
-                let _ = reply.send(result);
-            }
-        }
     }
 
     fn start_probe(&mut self) {
@@ -341,34 +310,39 @@ impl Swim {
             );
         }
     }
-    pub fn process(&mut self, event: SwimCommand) {
-        match event {
-            SwimCommand::PacketReceived { src, packet } => self.step(src, packet),
-            SwimCommand::Timeout(tick_event) => self.handle_timeout(tick_event),
-            SwimCommand::Query(command) => self.handle_query(command),
-            SwimCommand::AnnounceShardLeader(event) => {
-                tracing::info!(
-                    "[{}] Shard leader announced: group={:?} leader={} term={}",
-                    self.node_id,
-                    event.shard_group_id,
-                    event.leader_node_id,
-                    event.term
-                );
-
-                let info = ShardLeaderInfo {
-                    shard_group_id: event.shard_group_id,
-                    leader_node_id: event.leader_node_id,
-                    leader_addr: self.self_addr,
-                    term: event.term,
-                };
-                self.apply_shard_leader_update(&info);
-            }
-        }
+    pub fn announce_shard_leader(
+        &mut self,
+        shard_group_id: ShardGroupId,
+        leader_node_id: NodeId,
+        term: u64,
+    ) {
+        tracing::info!(
+            "[{}] Shard leader announced: group={:?} leader={} term={}",
+            self.node_id,
+            shard_group_id,
+            leader_node_id,
+            term
+        );
+        let info = ShardLeaderInfo {
+            shard_group_id,
+            leader_node_id,
+            leader_addr: self.self_addr,
+            term,
+        };
+        self.apply_shard_leader_update(&info);
         #[cfg(test)]
         self.assert_invariants();
     }
 
-    pub(super) fn step(&mut self, src: SocketAddr, packet: SwimPacket) {
+    pub fn get_members(&self) -> Vec<SwimNode> {
+        self.members.values().cloned().collect()
+    }
+
+    pub fn resolve_address(&self, node_id: &NodeId) -> Option<NodeAddress> {
+        self.members.get(node_id).map(|m| m.addr)
+    }
+
+    pub fn step(&mut self, src: SocketAddr, packet: SwimPacket) {
         // 1. Process Gossip (Piggybacked updates)
         for member in packet.gossip() {
             self.apply_membership_update(member.clone());
@@ -1510,7 +1484,6 @@ mod tests {
 
     mod shard_leader {
         use super::*;
-        use crate::clusters::raft::messages::LeaderChange;
         use crate::clusters::swims::messages::dissemination_buffer::ShardLeaderInfo;
         use crate::clusters::swims::swim::tests::{add_node_harness, ping};
         use crate::clusters::swims::topology::ShardGroupId;
@@ -1523,11 +1496,7 @@ mod tests {
             add_node_harness(&mut h, "node-b", b_addr, 1);
 
             h.protocol
-                .process(SwimCommand::AnnounceShardLeader(LeaderChange {
-                    shard_group_id: ShardGroupId(42),
-                    leader_node_id: NodeId::new("node-local"),
-                    term: 1,
-                }));
+                .announce_shard_leader(ShardGroupId(42), NodeId::new("node-local"), 1);
 
             let packets = h.protocol.take_packets();
             let has_leader_info = packets.iter().any(|p| {
@@ -1694,11 +1663,7 @@ mod tests {
             let _ = b.take_events();
 
             // A announces itself as leader of group 42
-            a.process(SwimCommand::AnnounceShardLeader(LeaderChange {
-                shard_group_id: ShardGroupId(42),
-                leader_node_id: NodeId::new("node-a"),
-                term: 1,
-            }));
+            a.announce_shard_leader(ShardGroupId(42), NodeId::new("node-a"), 1);
             let _ = a.take_events();
 
             // A pings B — packet should contain shard leader info
@@ -1735,11 +1700,7 @@ mod tests {
             let client_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
             h.protocol
-                .process(SwimCommand::AnnounceShardLeader(LeaderChange {
-                    shard_group_id: ShardGroupId(42),
-                    leader_node_id: NodeId::new("node-local"),
-                    term: 1,
-                }));
+                .announce_shard_leader(ShardGroupId(42), NodeId::new("node-local"), 1);
             let _ = h.protocol.take_events();
 
             let entry = h.protocol.topology.shard_leader(ShardGroupId(42));

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -8,8 +8,8 @@ use crate::clusters::swims::actor::SwimActor;
 use crate::clusters::swims::peer_discovery::JoinConfig;
 use crate::clusters::swims::swim::Swim;
 use crate::clusters::swims::{
-    DIRECT_ACK_TIMEOUT_TICKS, OutboundPacket, SwimCommand, SwimHeader, SwimPacket,
-    SwimQueryCommand, SwimTimer, Topology, TopologyConfig,
+    DIRECT_ACK_TIMEOUT_TICKS, OutboundPacket, SwimActorCommand, SwimCommand, SwimHeader,
+    SwimPacket, SwimQueryCommand, SwimTimer, Topology, TopologyConfig,
 };
 
 use crate::schedulers::actor::run_scheduling_actor;
@@ -23,7 +23,7 @@ use super::*;
 
 #[allow(dead_code)]
 struct TestHarness {
-    pub tx_in: mpsc::Sender<SwimCommand>,
+    pub tx_in: mpsc::Sender<SwimActorCommand>,
     pub tx_out: mpsc::Sender<OutboundPacket>,
     pub rx_out: Option<mpsc::Receiver<OutboundPacket>>,
     pub ticker_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
@@ -35,7 +35,7 @@ impl TestHarness {
     pub async fn query_topology_count(&self) -> usize {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.tx_in
-            .send(SwimCommand::Query(SwimQueryCommand::GetMembers {
+            .send(SwimActorCommand::Query(SwimQueryCommand::GetMembers {
                 reply: tx,
             }))
             .await
@@ -48,7 +48,7 @@ impl TestHarness {
     pub async fn query_topology_includes(&self, node_id: NodeId) -> bool {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.tx_in
-            .send(SwimCommand::Query(SwimQueryCommand::GetMembers {
+            .send(SwimActorCommand::Query(SwimQueryCommand::GetMembers {
                 reply: tx,
             }))
             .await
@@ -63,7 +63,7 @@ impl TestHarness {
 /// Routes `OutboundPacket`s between test harnesses, simulating a network.
 /// Call `add()` for every harness, then `spawn()` to start routing.
 struct NetworkBridge {
-    routes: HashMap<SocketAddr, mpsc::Sender<SwimCommand>>,
+    routes: HashMap<SocketAddr, mpsc::Sender<SwimActorCommand>>,
     inbounds: Vec<(SocketAddr, mpsc::Receiver<OutboundPacket>)>,
 }
 
@@ -90,10 +90,10 @@ impl NetworkBridge {
                 while let Some(pkt) = rx.recv().await {
                     if let Some(tx) = routes.get(&pkt.target) {
                         let _ = tx
-                            .send(SwimCommand::PacketReceived {
+                            .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
                                 src: sender_addr,
                                 packet: pkt.packet().clone(),
-                            })
+                            }))
                             .await;
                     }
                 }
@@ -180,10 +180,10 @@ async fn test_ping_response() {
 
     harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: remote_addr,
             packet: ping,
-        })
+        }))
         .await
         .unwrap();
 
@@ -228,10 +228,10 @@ async fn test_refutation_mechanism() {
 
     harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: remote_addr,
             packet: ping,
-        })
+        }))
         .await
         .unwrap();
 
@@ -273,7 +273,7 @@ async fn test_gossip_propagation() {
 
     harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: sender_addr,
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 300,
@@ -282,7 +282,7 @@ async fn test_gossip_propagation() {
                 gossip: vec![gossip_msg],
                 shard_leaders: vec![],
             }),
-        })
+        }))
         .await
         .unwrap();
 
@@ -294,7 +294,7 @@ async fn test_gossip_propagation() {
         // Send a fresh probe
         harness
             .tx_in
-            .send(SwimCommand::PacketReceived {
+            .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
                 src: probe_addr,
                 packet: SwimPacket::Ping(SwimHeader {
                     seq: 400 + i, // Increment seq to keep packets distinct
@@ -303,7 +303,7 @@ async fn test_gossip_propagation() {
                     gossip: vec![],
                     shard_leaders: vec![],
                 }),
-            })
+            }))
             .await
             .unwrap();
 
@@ -362,7 +362,7 @@ async fn test_indirect_ping_trigger() {
 
     harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: peer_1,
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 1,
@@ -371,7 +371,7 @@ async fn test_indirect_ping_trigger() {
                 gossip: vec![p1, p2],
                 shard_leaders: vec![],
             }),
-        })
+        }))
         .await
         .unwrap();
 
@@ -448,7 +448,7 @@ async fn test_alive_gossip_adds_node_to_topology() {
     let new_node: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let _ = harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: sender_addr,
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 1,
@@ -465,7 +465,7 @@ async fn test_alive_gossip_adds_node_to_topology() {
                 }],
                 shard_leaders: vec![],
             }),
-        })
+        }))
         .await;
 
     assert!(
@@ -484,7 +484,7 @@ async fn test_dead_gossip_removes_node_from_topology() {
         // Step 1: add the node via Alive gossip
         let _ = harness
             .tx_in
-            .send(SwimCommand::PacketReceived {
+            .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
                 src: sender_addr,
                 packet: SwimPacket::Ping(SwimHeader {
                     seq: 1,
@@ -501,7 +501,7 @@ async fn test_dead_gossip_removes_node_from_topology() {
                     }],
                     shard_leaders: vec![],
                 }),
-            })
+            }))
             .await;
     }
 
@@ -513,7 +513,7 @@ async fn test_dead_gossip_removes_node_from_topology() {
     // Step 2: mark the node as Dead via gossip
     let _ = harness
         .tx_in
-        .send(SwimCommand::PacketReceived {
+        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
             src: sender_addr,
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 2,
@@ -530,7 +530,7 @@ async fn test_dead_gossip_removes_node_from_topology() {
                 }],
                 shard_leaders: vec![],
             }),
-        })
+        }))
         .await;
 
     assert!(

--- a/src/it/raft_bridge.rs
+++ b/src/it/raft_bridge.rs
@@ -11,7 +11,7 @@ use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::actor::SwimActor;
-use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
+use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimActorCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
@@ -23,11 +23,11 @@ const QUERY_PORT: u16 = 29000;
 
 /// Mock SWIM handler — responds to ResolveAddress queries.
 async fn mock_swim_handler(
-    mut rx: mpsc::Receiver<SwimCommand>,
+    mut rx: mpsc::Receiver<SwimActorCommand>,
     address_map: HashMap<NodeId, SocketAddr>,
 ) {
     while let Some(cmd) = rx.recv().await {
-        if let SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
+        if let SwimActorCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
             let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
                 cluster_addr: addr,
                 client_addr: addr,

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -11,7 +11,7 @@ use crate::clusters::raft::actor::MultiRaftActor;
 use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::actor::SwimActor;
-use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
+use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimActorCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
@@ -23,11 +23,11 @@ const QUERY_PORT: u16 = 29000;
 
 /// Mock SWIM handler — only responds to ResolveAddress queries.
 async fn mock_swim_handler(
-    mut rx: mpsc::Receiver<SwimCommand>,
+    mut rx: mpsc::Receiver<SwimActorCommand>,
     address_map: HashMap<NodeId, SocketAddr>,
 ) {
     while let Some(cmd) = rx.recv().await {
-        if let SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
+        if let SwimActorCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) = cmd {
             let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
                 cluster_addr: addr,
                 client_addr: addr,

--- a/src/it/raft_leader_event.rs
+++ b/src/it/raft_leader_event.rs
@@ -12,7 +12,7 @@ use crate::clusters::raft::messages::LeaderChange;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::transport::RaftTransportActor;
 use crate::clusters::swims::actor::SwimActor;
-use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimCommand, SwimQueryCommand};
+use crate::clusters::swims::{ShardGroup, ShardGroupId, SwimActorCommand, SwimCommand, SwimQueryCommand};
 use crate::clusters::{BINCODE_CONFIG, NodeId};
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
@@ -24,19 +24,19 @@ const RESULT_PORT: u16 = 39000;
 /// Mock SWIM handler that responds to ResolveAddress queries and collects
 /// LeaderChangeEvents for later retrieval.
 async fn swim_handler_with_leader_capture(
-    mut rx: mpsc::Receiver<SwimCommand>,
+    mut rx: mpsc::Receiver<SwimActorCommand>,
     address_map: HashMap<NodeId, SocketAddr>,
     leader_events_tx: mpsc::Sender<LeaderChange>,
 ) {
     while let Some(cmd) = rx.recv().await {
         match cmd {
-            SwimCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) => {
+            SwimActorCommand::Query(SwimQueryCommand::ResolveAddress { node_id, reply }) => {
                 let _ = reply.send(address_map.get(&node_id).map(|&addr| NodeAddress {
                     cluster_addr: addr,
                     client_addr: addr,
                 }));
             }
-            SwimCommand::AnnounceShardLeader(event) => {
+            SwimActorCommand::Protocol(SwimCommand::AnnounceShardLeader(event)) => {
                 let _ = leader_events_tx.send(event).await;
             }
             _ => {}


### PR DESCRIPTION
### Why 

`SwimCommand` previously had a `Query(SwimQueryCommand)` variant which carries `tokio::sync::oneshot::Sender` fields, meaning the entire `SwimCommand` enum was depending on a tokio dependency. 

This matters because the next milestone is extracting a `eastguard-core` crate containing only the pure state machines(`Swim`, `Raft`, `Topology`, `MetadataStateMachine`) so they can compile to WebAssembly. Any file that transitively imports `SwimCommand` would pull tokio into the WASM build and fail to compile. 

### Changes 

- Added `SwimActorCommand` 
  - an actor level envelope that lives only in east-guard
- Removed `SwimCommand::Query` 
- Moved query dispatch under `SwimActor` 


### Result 

- `SwimCommand` is now WASM-safe. 