### PR TITLE
feat: hot range detection + auto-split/merge (Phase 6)

### DIFF
--- a/.claude/rules/metadata-state-machine.md
+++ b/.claude/rules/metadata-state-machine.md
@@ -33,7 +33,7 @@ Ownership expressed by nesting — no back-references. Parent always known from 
 | RaftCommand variant | Method | Effect |
 |---|---|---|
 | `CreateTopic` | `apply_create_topic()` | Creates topic + initial full-keyspace range + initial segment |
-| `SealSegment` | `apply_seal_segment()` | Seals active segment, creates next segment (segment roll) |
+| `RollSegment` | `apply_roll_segment()` | Seals active segment, creates next segment (segment roll) |
 | `SplitRange` | `apply_split_range()` | Seals parent range, creates two child ranges with new segments |
 | `MergeRange` | `apply_merge_range()` | Seals both source ranges, creates merged range with new segment |
 | `DeleteTopic` | `apply_delete_topic()` | Cascades Deleting state to all ranges and segments |
@@ -69,3 +69,7 @@ Ownership expressed by nesting — no back-references. Parent always known from 
 14. **Split point strictly interior.** `split_point` must satisfy `keyspace_start < split_point < keyspace_end`. Boundary values rejected.
 
 15. **Merge requires adjacency.** Only ranges with contiguous keyspaces (`r1.keyspace_end == r2.keyspace_start` or vice versa) can merge.
+
+16. **Seal history determinism.** `seal_history` on `RangeMeta` is updated only inside `apply_roll_segment()`, which runs on ALL replicas. `seal_timestamps` are monotonically ordered. No leader-only state leaks into `RangeSealHistory`. The split/merge *decision* is leader-only, but the data it reads is deterministic.
+
+17. **Split cooldown on children.** Child ranges created by `apply_split_range()` always have `seal_history.created_by_split_at` set to the split's `created_at` timestamp. This enforces `SPLIT_COOLDOWN_MS` before children can be re-split.

--- a/diagrams/metadata-management/metadata_management_roadmap.md
+++ b/diagrams/metadata-management/metadata_management_roadmap.md
@@ -354,7 +354,7 @@ Client SDK concern. Server-side signals available:
 
 ```rust
 struct RangeSealHistory {
-    seal_timestamps: Vec<u64>,         // recent seal times within measurement window
+    seal_timestamps: VecDeque<u64>,         // recent seal times within measurement window
     created_by_split_at: Option<u64>,  // cooldown anchor for child ranges
 }
 ```

--- a/diagrams/metadata-management/metadata_management_roadmap.md
+++ b/diagrams/metadata-management/metadata_management_roadmap.md
@@ -4,7 +4,7 @@ SWIM + MultiRaft infrastructure is drafted. This roadmap covers the path from th
 
 ---
 
-## Phase 1: Data Model + MetadataStateMachine
+## Phase 1: Data Model + MetadataStateMachine ✅
 
 **Goal:** Define metadata types and a pure in-memory state machine.
 
@@ -115,7 +115,7 @@ enum ProposeError {
 
 ---
 
-## Phase 3: Application State Machine Dispatch
+## Phase 3: Application State Machine Dispatch ✅
 
 **Goal:** `Raft` owns `MetadataStateMachine` and applies committed metadata commands inline.
 
@@ -169,7 +169,7 @@ For tests to query applied state.
 
 ---
 
-## Phase 4: Client → Raft Propose Pathway
+## Phase 4: Client → Raft Propose Pathway ✅
 
 **Goal:** Wire end-to-end path: Client → `MultiRaftActor` → hash(key) → propose to local Raft → commit → apply → respond.
 
@@ -340,7 +340,7 @@ Client SDK concern. Server-side signals available:
 
 ---
 
-## Phase 6: Hot Range Detection + Auto-Split/Merge 
+## Phase 6: Hot Range Detection + Auto-Split/Merge ✅
 
 **Goal:** MetadataStateMachine detects hot/cold ranges and proposes `SplitRange`/`MergeRange` automatically. Simplest viable approach — no probe protocol, no key histograms.
 
@@ -427,27 +427,26 @@ Stale proposals (e.g., merge proposed but range split before commit) are safe �
 - **Stale `RollSegment` is no-op, not error.** If `active_seg_id != cmd.segment_id`, returns `Ok(())` — expected during leader transitions, not worth error logging.
 
 **Depends on:** Phases 1-4 (needs working propose pathway + state machine dispatch). Phase 5 not required.
-**Status:** Implemented.
 
 ---
 
 ## Phase Dependency Graph
 
 ```
-Phase 1 (Data Model + MetadataStateMachine)
+Phase 1 (Data Model + MetadataStateMachine)              ✅
     │
     ▼
-Phase 2 (Extend RaftCommand)
+Phase 2 (Extend RaftCommand)                             ✅
     │
     ▼
-Phase 3 (Application State Machine Dispatch)
+Phase 3 (Application State Machine Dispatch)             ✅
     │
     ├──────────────────────────┐
     ▼                          ▼
-Phase 4 (Propose Pathway)   Phase 6 (Hot Range Detection)
-    │                          (needs Phase 4 for end-to-end,
-    ▼                           but core logic testable after Phase 3)
-Phase 5 (Leader Forwarding + Shard Discovery) ✅
+Phase 4 (Propose Pathway)   Phase 6 (Hot Range Detection) ✅
+    │                          ✅
+    ▼
+Phase 5 (Leader Forwarding + Shard Discovery)            ✅
 ```
 
 ---

--- a/diagrams/metadata-management/metadata_management_roadmap.md
+++ b/diagrams/metadata-management/metadata_management_roadmap.md
@@ -59,7 +59,7 @@ struct MetadataStateMachine {
 
 Flat maps for ranges/segments removed — they live nested inside `TopicMeta` and `RangeMeta` respectively.
 
-Pure functions: `apply_create_topic()`, `apply_split_range()`, `apply_seal_segment()`. No I/O, no async.
+Pure functions: `apply_create_topic()`, `apply_split_range()`, `apply_roll_segment()`. No I/O, no async.
 
 See `diagrams/metadata-management/data-model.md` for full entity relationships, state transitions, cascading effects, and invariants.
 
@@ -88,7 +88,7 @@ enum RaftCommand {
 ```rust
 enum MetadataCommand {
     CreateTopic(CreateTopic),
-    SealSegment(SealSegment),
+    RollSegment(RollSegment),
     SplitRange(SplitRange),
     MergeRange(MergeRange),
     DeleteTopic(DeleteTopic),
@@ -340,110 +340,94 @@ Client SDK concern. Server-side signals available:
 
 ---
 
-## Phase 6: Hot Range Detection + Auto-Split/Merge
+## Phase 6: Hot Range Detection + Auto-Split/Merge 
 
 **Goal:** MetadataStateMachine detects hot/cold ranges and proposes `SplitRange`/`MergeRange` automatically. Simplest viable approach — no probe protocol, no key histograms.
 
 ### Core Insight
 
-`MetadataStateMachine` already sees every `SealSegment` commit. A segment seals when it reaches ~1GB. If a range's segments seal frequently, that range is hot. No external metrics pipeline needed — the Raft log IS the signal.
+`MetadataStateMachine` already sees every `RollSegment` commit. A segment seals when it reaches ~1GB. If a range's segments seal frequently, that range is hot. No external metrics pipeline needed — the Raft log IS the signal.
 
 ### 6a. Per-Range Seal Tracker
 
-Add to `RangeMeta`:
+`RangeSealHistory` on `RangeMeta`:
 
 ```rust
 struct RangeSealHistory {
-    last_seal_at: u64,          // monotonic timestamp of most recent seal
-    seal_count_in_window: u32,  // seals within sliding window
-    window_start: u64,          // start of current measurement window
-    cooldown_until: u64,        // no split before this time (post-split cooldown)
+    seal_timestamps: Vec<u64>,         // recent seal times within measurement window
+    created_by_split_at: Option<u64>,  // cooldown anchor for child ranges
 }
-
-// In RangeMeta:
-seal_history: RangeSealHistory,
 ```
 
 Lives inside `RangeMeta` — no separate tracker map needed. Naturally scoped to the range, cleaned up when range is deleted.
 
-Updated inside `apply_seal_segment()` — pure, deterministic, replicated on every node.
+Updated inside `RangeMeta::roll_segment()` via `record_seal()` — pure, deterministic, replicated on every node. Old timestamps pruned on each seal (sliding window).
 
 ### 6b. Split Decision Logic
 
-After each `apply_seal_segment()`, MetadataStateMachine (leader only) evaluates:
+`RangeMeta::roll_segment()` returns `should_split` bool. `MetadataStateMachine::roll_segment()` checks the return value (leader-only evaluation via `pending_proposals` buffer):
 
 ```rust
-fn should_split(topic: &TopicMeta, range_id: RangeId, now: u64) -> bool {
-    let range = topic.ranges.get(&range_id);
+// RangeSealHistory::should_split():
+seal_count >= SPLIT_SEAL_THRESHOLD
+    && (no split cooldown OR cooldown expired)
 
-    range.state == Active
-        && now > range.seal_history.cooldown_until
-        && range.keyspace_width() > MIN_RANGE_WIDTH
-        && range.seal_history.seal_count_in_window >= SPLIT_SEAL_THRESHOLD
-}
+// RangeMeta::roll_segment() returns should_split
+// MetadataStateMachine checks: can_split && should_split && valid_split_point(midpoint)
 ```
 
-Split point = midpoint of keyspace. Simple, no key distribution data needed.
+Split point = midpoint of keyspace (`RangeMeta::compute_midpoint()`). `valid_split_point()` guards against ranges too narrow to split (integer truncation makes midpoint equal to start).
 
-**Constants (initial, tunable):**
+**Constants:**
 
 | Constant | Value | Meaning |
 |---|---|---|
 | `SPLIT_SEAL_THRESHOLD` | 3 | Seals within window to trigger split |
 | `MEASUREMENT_WINDOW_MS` | 300_000 (5 min) | Sliding window for counting seals |
 | `SPLIT_COOLDOWN_MS` | 300_000 (5 min) | No re-split after recent split |
-| `MIN_RANGE_WIDTH` | 256 bytes | Minimum keyspace to prevent fragmentation |
+| `MERGE_SEAL_THRESHOLD` | 0 | Both ranges must be idle (no seals in window) |
 
 ### 6c. Merge Decision Logic
 
-Periodic check by MetadataStateMachine leader (on a timer, not per-event):
+Periodic check by leader via `MergeCheckTimeout` timer (not per-event):
 
 ```rust
-fn should_merge(topic: &TopicMeta, r1: RangeId, r2: RangeId, now: u64) -> bool {
-    let range1 = topic.ranges.get(&r1);
-    let range2 = topic.ranges.get(&r2);
-
-    are_buddies(range1, range2)
-        && range1.state == Active && range2.state == Active
-        && range1.seal_history.seal_count_in_window <= MERGE_SEAL_THRESHOLD
-        && range2.seal_history.seal_count_in_window <= MERGE_SEAL_THRESHOLD
-        && now > range1.seal_history.cooldown_until
-        && now > range2.seal_history.cooldown_until
-}
+// MetadataStateMachine::evaluate_merges(now):
+// For each topic with AutoSplit strategy and 2+ active ranges:
+//   Walk adjacent pairs in active_ranges (sorted by keyspace_start)
+//   If both ranges have recent_seal_count(now) == MERGE_SEAL_THRESHOLD:
+//     Propose MergeRange, break (one merge per topic per evaluation)
 ```
 
-| Constant | Value | Meaning |
-|---|---|---|
-| `MERGE_SEAL_THRESHOLD` | 0 | Both ranges must be idle (no seals in window) |
-| `MERGE_CHECK_INTERVAL_MS` | 600_000 (10 min) | How often leader scans for merge candidates |
+`RangeMeta::mergeable_with()` checks both ranges are cold. Hysteresis built in: split at 3 seals/window, merge at 0. No oscillation.
 
-Hysteresis built in: split at 3 seals/window, merge at 0. No oscillation.
+### 6d. Proposal Path — Lazy Execution
 
-### 6d. Proposal Path
+Auto-proposals flow through a two-level buffer:
 
-Split/merge decisions happen in `MultiRaftActor` after applying entries (Phase 3 dispatch):
+1. `MetadataStateMachine::pending_proposals` — populated during `apply()` (deterministic on all replicas, but only leader drains them)
+2. `Raft::pending_proposals` — leader wraps in `RaftCommand::Metadata(...)`, drained by `MultiRaft::flush()`
 
-```rust
-// After apply_seal_segment():
-if should_split(&topic, range_id, now) {
-    let mid = topic.ranges.get(&range_id).midpoint();
-    shard.raft.propose(RaftCommand::SplitRange { topic_id, range_id, split_point: mid });
-}
+**Lazy execution:** `MultiRaft::flush()` drains `pending_proposals` at the **start** of the next flush cycle, proposing them as regular entries. They are persisted in the same batch — no second persist pass. ~100ms latency (one tick) is negligible for decisions based on 5-minute windows.
 
-// On periodic timer:
-for (topic_id, r1, r2) in shard.state_machine.merge_candidates(now) {
-    shard.raft.propose(RaftCommand::MergeRange { topic_id, range_id_1: r1, range_id_2: r2 });
-}
-```
+**Anti-recursion:** `apply_committed_entries()` never calls `propose()`. Auto-proposals are buffered, not acted on inline. `SplitRange` apply does not generate further proposals (children start with empty seal history). Max depth: 1 level.
 
-Leader-only — followers apply committed decisions but never propose. Stale proposals rejected by `apply_split_range()` / `apply_merge_range()` precondition checks.
+Stale proposals (e.g., merge proposed but range split before commit) are safe — `apply_split_range()` / `apply_merge_range()` precondition checks reject them. `RollSegment` with wrong segment ID is a no-op (stale seal).
 
-### 6e. New Timer
+### 6e. MergeCheck Timer
 
-Add `MergeCheck` variant to `RaftTimer` for periodic merge scanning. Fires every `MERGE_CHECK_INTERVAL_MS`. Leader-only — set on `become_leader()`, cancelled on stepdown.
+`RaftTimerKind::MergeCheck` variant, `MERGE_CHECK_INTERVAL_TICKS = 6000` (10 min at 100ms/tick). Set on `become_leader()`, cancelled on stepdown via `cancel_all_timers()`. On timeout, leader calls `evaluate_merges()` with wall-clock time and reschedules.
+
+### 6f. Key Design Decisions
+
+- **`RangeSealHistory` uses timestamp Vec, not counter+window.** Pruning on each seal keeps the Vec bounded. `recent_seal_count(now)` re-evaluates against current time for merge checks.
+- **Split logic lives on `RangeMeta`.** `roll_segment()`, `split()`, `merge()`, `compute_midpoint()`, `mergeable_with()` are methods on `RangeMeta` — state machine dispatches, range owns the logic.
+- **`TimerSeqs` struct groups timer seq values.** Avoids too-many-arguments on `Raft::new()`.
+- **Child ranges get `created_by_split_at` via `with_split_origin()` builder.** Enforces cooldown without adding parameters to `RangeMeta::new()`.
+- **Stale `RollSegment` is no-op, not error.** If `active_seg_id != cmd.segment_id`, returns `Ok(())` — expected during leader transitions, not worth error logging.
 
 **Depends on:** Phases 1-4 (needs working propose pathway + state machine dispatch). Phase 5 not required.
-**Scope:** 2-3 PRs.
+**Status:** Implemented.
 
 ---
 
@@ -526,7 +510,7 @@ Ranges nested inside `TopicMeta`, segments nested inside `RangeMeta`. ID counter
 `start_offset` / `end_offset` on `SegmentMeta`, `next_offset` on `RangeMeta`. Consumer knows "done with sealed range" when position reaches last segment's `end_offset`. On split/merge, child ranges start at offset 0 — clean break. Consumer protocol (backlog) uses these fields plus `merged_into`/`split_into` lineage to navigate range transitions.
 
 **8. Seal frequency as hot range signal — no external metrics pipeline.**
-`SealSegment` commits are already in the Raft log. Counting seal frequency per range gives a load signal for free. No probe protocol, no data plane → MetadataStateMachine reporting, no key histograms. Midpoint split. Accuracy is good enough for Phase 6 — optimization is backlog.
+`RollSegment` commits are already in the Raft log. Counting seal frequency per range gives a load signal for free. No probe protocol, no data plane → MetadataStateMachine reporting, no key histograms. Midpoint split. Accuracy is good enough for Phase 6 — optimization is backlog.
 
 ---
 

--- a/src/clusters/metadata/command.rs
+++ b/src/clusters/metadata/command.rs
@@ -17,7 +17,7 @@ pub struct CreateTopic {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-pub struct SealSegment {
+pub struct RollSegment {
     pub topic_id: TopicId,
     pub range_id: RangeId,
     pub segment_id: SegmentId,
@@ -52,7 +52,7 @@ pub struct DeleteTopic {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum MetadataCommand {
     CreateTopic(CreateTopic),
-    SealSegment(SealSegment),
+    RollSegment(RollSegment),
     SplitRange(SplitRange),
     MergeRange(MergeRange),
     DeleteTopic(DeleteTopic),
@@ -61,7 +61,7 @@ pub enum MetadataCommand {
 impl_from_variant!(
     MetadataCommand,
     CreateTopic,
-    SealSegment,
+    RollSegment,
     SplitRange,
     MergeRange,
     DeleteTopic
@@ -70,7 +70,7 @@ impl_from_variant!(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApplyResult {
     TopicCreated(TopicId),
-    SegmentSealed,
+    SegmentRolled,
     RangeSplit(RangeId, RangeId),
     RangeMerged(RangeId),
     TopicDeleted,

--- a/src/clusters/metadata/mod.rs
+++ b/src/clusters/metadata/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use command::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode)]
 pub struct TopicId(pub u64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode, PartialOrd, Ord)]
 pub struct RangeId(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode)]

--- a/src/clusters/metadata/state_machine.rs
+++ b/src/clusters/metadata/state_machine.rs
@@ -1,6 +1,6 @@
 use super::command::*;
 use super::types::*;
-use crate::clusters::metadata::{RangeId, SegmentId, TopicId, error::MetadataError};
+use crate::clusters::metadata::{RangeId, TopicId, error::MetadataError};
 
 use MetadataError::*;
 use std::collections::HashMap;
@@ -10,6 +10,7 @@ pub struct MetadataStateMachine {
     topics: HashMap<TopicId, TopicMeta>,
     topic_name_index: HashMap<String, TopicId>,
     next_topic_id: u64,
+    pending_proposals: Vec<MetadataCommand>,
 }
 
 impl MetadataStateMachine {
@@ -27,11 +28,15 @@ impl MetadataStateMachine {
         self.topics.len()
     }
 
+    pub(crate) fn take_pending_proposals(&mut self) -> Vec<MetadataCommand> {
+        std::mem::take(&mut self.pending_proposals)
+    }
+
     pub(crate) fn apply(&mut self, command: MetadataCommand) -> Result<ApplyResult, MetadataError> {
         use MetadataCommand::*;
         let result = match command {
             CreateTopic(cmd) => self.create_topic(cmd).map(ApplyResult::TopicCreated),
-            SealSegment(cmd) => self.seal_segment(cmd).map(|()| ApplyResult::SegmentSealed),
+            RollSegment(cmd) => self.roll_segment(cmd).map(|()| ApplyResult::SegmentRolled),
             SplitRange(cmd) => self
                 .split_range(cmd)
                 .map(|(c1, c2)| ApplyResult::RangeSplit(c1, c2)),
@@ -61,39 +66,40 @@ impl MetadataStateMachine {
         Ok(topic_id)
     }
 
-    fn seal_segment(&mut self, cmd: SealSegment) -> Result<(), MetadataError> {
+    fn roll_segment(&mut self, cmd: RollSegment) -> Result<(), MetadataError> {
         let topic = self
             .topics
             .get_mut(&cmd.topic_id)
             .ok_or(TopicNotFound(cmd.topic_id))?;
         topic.validate_active()?;
+        let can_split = topic.can_split();
 
         let range = topic.ranges.get_mut(&cmd.range_id).ok_or(RangeNotFound)?;
         let active_seg_id = range.validate_active()?;
-
         if active_seg_id != cmd.segment_id {
-            return Err(SegmentNotActive);
+            return Ok(());
         }
-        let segment = range
-            .segments
-            .get_mut(&cmd.segment_id)
-            .ok_or(SegmentNotFound)?;
-        segment.seal(range.next_offset.saturating_sub(1), cmd.sealed_at)?;
 
-        let new_segment_id = SegmentId(range.next_segment_id);
-        range.next_segment_id += 1;
-        let new_segment = SegmentMeta {
-            segment_id: new_segment_id,
-            state: SegmentState::Active,
-            replica_set: cmd.new_replica_set,
-            size_bytes: 0,
-            start_offset: range.next_offset,
-            end_offset: None,
-            created_at: cmd.sealed_at,
-            sealed_at: None,
-        };
-        range.segments.insert(new_segment_id, new_segment);
-        range.active_segment = Some(new_segment_id);
+        let should_split =
+            range.roll_segment(cmd.segment_id, cmd.new_replica_set.clone(), cmd.sealed_at)?;
+
+        if can_split && should_split {
+            // The following guards against ranges too narrow to split. When keyspace_start and keyspace_end are 1 unit apart (e.g., [0x40] and [0x41]),
+            // integer division truncates: (0x40 + 0x41) / 2 = 0x40, which equals keyspace_start.
+            // That fails valid_split_point (requires strictly between), so the split is skipped.
+            let mid = range.compute_midpoint();
+            if range.valid_split_point(&mid) {
+                self.pending_proposals
+                    .push(MetadataCommand::SplitRange(SplitRange {
+                        topic_id: cmd.topic_id,
+                        range_id: cmd.range_id,
+                        split_point: mid,
+                        created_at: cmd.sealed_at,
+                        left_replica_set: cmd.new_replica_set.clone(),
+                        right_replica_set: cmd.new_replica_set,
+                    }));
+            }
+        }
         Ok(())
     }
 
@@ -102,46 +108,19 @@ impl MetadataStateMachine {
             .topics
             .get_mut(&cmd.topic_id)
             .ok_or(TopicNotFound(cmd.topic_id))?;
-
         topic.validate_active()?;
-
         if !topic.can_split() {
             return Err(SplitNotAllowed(cmd.topic_id));
         }
-
-        let range = topic.ranges.get_mut(&cmd.range_id).ok_or(RangeNotFound)?;
-
-        if !range.valid_split_point(&cmd.split_point) {
-            return Err(InvalidSplitPoint);
-        }
-        let _ = range.validate_active()?;
-        range.seal(cmd.created_at)?;
-
         let left_id = RangeId(topic.next_range_id);
-        topic.next_range_id += 1;
-        let right_id = RangeId(topic.next_range_id);
-        topic.next_range_id += 1;
+        let right_id = RangeId(topic.next_range_id + 1);
+        let range = topic.ranges.get_mut(&cmd.range_id).ok_or(RangeNotFound)?;
+        let (left, right) = range.split(cmd, left_id, right_id)?;
 
-        range.split_into = Some([left_id, right_id]);
-
-        let left = RangeMeta::new(
-            left_id,
-            range.keyspace_start.clone(),
-            cmd.split_point.clone(),
-            cmd.left_replica_set,
-            cmd.created_at,
-        );
-        let right = RangeMeta::new(
-            right_id,
-            cmd.split_point,
-            range.keyspace_end.clone(),
-            cmd.right_replica_set,
-            cmd.created_at,
-        );
+        topic.next_range_id += 2;
+        topic.active_ranges.retain(|id| *id != range.range_id);
         topic.ranges.insert(left_id, left);
         topic.ranges.insert(right_id, right);
-
-        topic.active_ranges.retain(|id| *id != cmd.range_id);
         topic.insert_range_sorted(left_id);
         topic.insert_range_sorted(right_id);
         Ok((left_id, right_id))
@@ -154,46 +133,71 @@ impl MetadataStateMachine {
             .ok_or(TopicNotFound(cmd.topic_id))?;
 
         topic.validate_active()?;
-
-        let r1 = topic.ranges.get(&cmd.range_id_1).ok_or(RangeNotFound)?;
-        let r2 = topic.ranges.get(&cmd.range_id_2).ok_or(RangeNotFound)?;
-        r1.validate_active()?;
-        r2.validate_active()?;
-
-        if !r1.is_next_to(r2) {
-            return Err(RangesNotAdjacent);
-        }
-
-        let (merged_start, merged_end) = if r1.keyspace_start <= r2.keyspace_start {
-            (r1.keyspace_start.clone(), r2.keyspace_end.clone())
-        } else {
-            (r2.keyspace_start.clone(), r1.keyspace_end.clone())
-        };
         let merged_id = RangeId(topic.next_range_id);
-        topic.next_range_id += 1;
-
-        for id in [cmd.range_id_1, cmd.range_id_2] {
-            topic.seal_range(id, cmd.created_at)?;
-            // SAFETY : Safe to unwrap since we confirmed these IDs exist above
-            topic.ranges.get_mut(&id).unwrap().merged_into = Some(merged_id);
-        }
-
-        let mut merged = RangeMeta::new(
-            merged_id,
-            merged_start,
-            merged_end,
-            cmd.merged_replica_set,
-            cmd.created_at,
-        );
-        merged.merged_from = Some([cmd.range_id_1, cmd.range_id_2]);
+        let [r1, r2] = topic.get_ranges_mut([&cmd.range_id_1, &cmd.range_id_2])?;
+        let merged = r1.merge(r2, merged_id, cmd.merged_replica_set, cmd.created_at)?;
         topic.ranges.insert(merged_id, merged);
-
         topic
             .active_ranges
             .retain(|id| *id != cmd.range_id_1 && *id != cmd.range_id_2);
         topic.insert_range_sorted(merged_id);
+        topic.next_range_id += 1;
 
         Ok(merged_id)
+    }
+
+    // ! SAFETY: When the loop evaluates the [1, 2] pair and decides it is mergeable,
+    // ! it generates the event and immediately stops looking at the rest of that topic's ranges
+    // !
+    // ! However, we still have an asynchronous race condition to worry about.
+    // ! Take the following example:
+    // !    1. the following method proposes merging (1, 2).
+    // !    2. The MergeRange command goes into a queue (or a Raft log) to be processed.
+    // !    3. Before the command is executed, range 2 receives a massive burst of traffic and splits into 2A and 2B.
+    // !    4. The MergeRange(1, 2) command is finally executed by your merge function.
+    // ! By the time the command executes, range 2 might be split, already sealed, or completely deleted
+    pub(crate) fn evaluate_merges(&self, now: u64) -> Vec<MetadataCommand> {
+        let mut proposals = Vec::new();
+
+        for topic in self.topics.values() {
+            if topic.validate_active().is_err() {
+                continue;
+            }
+            if !topic.can_split() {
+                continue;
+            }
+            if topic.active_ranges.len() < 2 {
+                continue;
+            }
+
+            for pair in topic.active_ranges.windows(2) {
+                let (r1, r2) = (&topic.ranges[&pair[0]], &topic.ranges[&pair[1]]);
+                if r1.state != RangeState::Active || r2.state != RangeState::Active {
+                    continue;
+                }
+
+                if r1.mergeable_with(r2, now) {
+                    let replica_set = r1
+                        .active_segment
+                        .and_then(|sid| r1.segments.get(&sid))
+                        // ? why taking replicaset from r1 - what about r2?
+                        .map(|s| s.replica_set.clone())
+                        .unwrap_or_default();
+
+                    proposals.push(MetadataCommand::MergeRange(MergeRange {
+                        topic_id: topic.id,
+                        range_id_1: r1.range_id,
+                        range_id_2: r2.range_id,
+                        created_at: now,
+                        merged_replica_set: replica_set,
+                    }));
+
+                    break;
+                }
+            }
+        }
+
+        proposals
     }
 
     fn delete_topic(&mut self, cmd: DeleteTopic) -> Result<(), MetadataError> {
@@ -319,6 +323,27 @@ impl MetadataStateMachine {
                     range.split_into.is_none() || range.merged_into.is_none(),
                     "range both split and merged"
                 );
+
+                // Invariant 16: seal_history timestamps are monotonically ordered
+                for w in range.seal_history.seal_timestamps.windows(2) {
+                    assert!(w[0] <= w[1], "seal_history timestamps not sorted");
+                }
+
+                // Invariant 17: split children have created_by_split_at set
+                if let Some([left, right]) = range.split_into {
+                    if let Some(left_range) = topic.ranges.get(&left) {
+                        assert!(
+                            left_range.seal_history.created_by_split_at.is_some(),
+                            "split child missing created_by_split_at"
+                        );
+                    }
+                    if let Some(right_range) = topic.ranges.get(&right) {
+                        assert!(
+                            right_range.seal_history.created_by_split_at.is_some(),
+                            "split child missing created_by_split_at"
+                        );
+                    }
+                }
             }
         }
     }
@@ -329,7 +354,10 @@ mod tests {
     use super::*;
     use crate::clusters::{
         NodeId,
-        metadata::strategy::{PartitionStrategy, StoragePolicy},
+        metadata::{
+            SegmentId,
+            strategy::{PartitionStrategy, StoragePolicy},
+        },
     };
 
     fn default_policy() -> StoragePolicy {
@@ -369,21 +397,21 @@ mod tests {
         }
     }
 
-    fn seal_segment(
+    fn roll_segment(
         sm: &mut MetadataStateMachine,
         topic_id: TopicId,
         range_id: RangeId,
         segment_id: SegmentId,
         sealed_at: u64,
     ) {
-        let result = sm.apply(MetadataCommand::SealSegment(SealSegment {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             topic_id,
             range_id,
             segment_id,
             sealed_at,
             new_replica_set: replica_set(),
         }));
-        assert_eq!(result.unwrap(), ApplyResult::SegmentSealed);
+        assert_eq!(result.unwrap(), ApplyResult::SegmentRolled);
     }
 
     fn split_range(
@@ -495,14 +523,14 @@ mod tests {
         assert!(sm.get_topic_by_name("red").is_none());
     }
 
-    // --- SealSegment ---
+    // --- RollSegment ---
 
     #[test]
-    fn seal_segment_creates_next() {
+    fn roll_segment_creates_next() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
-        seal_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
         assert_eq!(range.active_segment, Some(SegmentId(1)));
@@ -510,12 +538,12 @@ mod tests {
     }
 
     #[test]
-    fn seal_segment_increments_segment_id() {
+    fn roll_segment_increments_segment_id() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
-        seal_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
-        seal_segment(&mut sm, tid, RangeId(0), SegmentId(1), 3000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(1), 3000);
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
         assert_eq!(range.active_segment, Some(SegmentId(2)));
@@ -524,9 +552,9 @@ mod tests {
     }
 
     #[test]
-    fn seal_segment_bad_topic() {
+    fn roll_segment_bad_topic() {
         let mut sm = MetadataStateMachine::default();
-        let result = sm.apply(MetadataCommand::SealSegment(SealSegment {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             topic_id: TopicId(99),
             range_id: RangeId(0),
             segment_id: SegmentId(0),
@@ -537,11 +565,11 @@ mod tests {
     }
 
     #[test]
-    fn seal_segment_bad_range() {
+    fn roll_segment_bad_range() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
-        let result = sm.apply(MetadataCommand::SealSegment(SealSegment {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             topic_id: tid,
             range_id: RangeId(99),
             segment_id: SegmentId(0),
@@ -552,18 +580,22 @@ mod tests {
     }
 
     #[test]
-    fn seal_segment_wrong_active_segment() {
+    fn roll_segment_stale_is_noop() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
-        let result = sm.apply(MetadataCommand::SealSegment(SealSegment {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             topic_id: tid,
             range_id: RangeId(0),
             segment_id: SegmentId(99),
             sealed_at: 2000,
             new_replica_set: replica_set(),
         }));
-        assert_eq!(result, Err(SegmentNotActive));
+        assert_eq!(result, Ok(ApplyResult::SegmentRolled));
+
+        let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
+        assert_eq!(range.active_segment, Some(SegmentId(0)));
+        assert_eq!(range.segments.len(), 1);
     }
 
     // --- SplitRange ---
@@ -793,7 +825,7 @@ mod tests {
         let tid = create_topic(&mut sm, "blue");
         let (c1, _c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
-        seal_segment(&mut sm, tid, c1, SegmentId(0), 3000);
+        roll_segment(&mut sm, tid, c1, SegmentId(0), 3000);
 
         let child = &sm.get_topic(&tid).unwrap().ranges[&c1];
         assert_eq!(child.active_segment, Some(SegmentId(1)));
@@ -834,19 +866,212 @@ mod tests {
     // --- Invariant: Segment immutability after seal ---
 
     #[test]
-    fn seal_already_sealed_segment_rejected() {
+    fn roll_already_rolled_segment_is_noop() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
-        seal_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
 
-        let result = sm.apply(MetadataCommand::SealSegment(SealSegment {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             topic_id: tid,
             range_id: RangeId(0),
             segment_id: SegmentId(0),
             sealed_at: 3000,
             new_replica_set: replica_set(),
         }));
-        assert_eq!(result, Err(SegmentNotActive));
+        assert_eq!(result, Ok(ApplyResult::SegmentRolled));
+
+        let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
+        assert_eq!(range.active_segment, Some(SegmentId(1)));
+        assert_eq!(range.segments.len(), 2);
+    }
+
+    // --- Hot Range Detection ---
+
+    #[test]
+    fn seal_history_records_timestamps() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 1000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(1), 2000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(2), 3000);
+
+        let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
+        assert_eq!(range.seal_history.seal_count(), 3);
+    }
+
+    #[test]
+    fn seal_history_prunes_old_entries() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 1000);
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(1), 2000);
+        // Jump far beyond the window — both old entries pruned
+        let far_future = 2000 + MEASUREMENT_WINDOW_MS + 1;
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(2), far_future);
+
+        let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
+        assert_eq!(range.seal_history.seal_count(), 1);
+    }
+
+    #[test]
+    fn should_split_threshold_met() {
+        let mut history = RangeSealHistory::default();
+        history.record_seal(1000);
+        history.record_seal(2000);
+        history.record_seal(3000);
+
+        assert!(history.should_split(3000));
+    }
+
+    #[test]
+    fn should_split_below_threshold() {
+        let mut history = RangeSealHistory::default();
+        history.record_seal(1000);
+        history.record_seal(2000);
+
+        assert!(!history.should_split(2000));
+    }
+
+    #[test]
+    fn should_split_cooldown_blocks() {
+        let mut history = RangeSealHistory {
+            seal_timestamps: Vec::new(),
+            created_by_split_at: Some(1000),
+        };
+        history.record_seal(1100);
+        history.record_seal(1200);
+        history.record_seal(1300);
+
+        // Within cooldown — blocked
+        assert!(!history.should_split(1300));
+
+        // After cooldown — allowed
+        assert!(history.should_split(1000 + SPLIT_COOLDOWN_MS));
+    }
+
+    #[test]
+    fn auto_proposal_on_hot_range() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+
+        for i in 0..SPLIT_SEAL_THRESHOLD {
+            roll_segment(
+                &mut sm,
+                tid,
+                RangeId(0),
+                SegmentId(i as u64),
+                1000 * (i as u64 + 1),
+            );
+        }
+
+        let proposals = sm.take_pending_proposals();
+        assert_eq!(proposals.len(), 1);
+        assert!(matches!(proposals[0], MetadataCommand::SplitRange(_)));
+    }
+
+    #[test]
+    fn no_auto_proposal_below_threshold() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+
+        for i in 0..(SPLIT_SEAL_THRESHOLD - 1) {
+            roll_segment(
+                &mut sm,
+                tid,
+                RangeId(0),
+                SegmentId(i as u64),
+                1000 * (i as u64 + 1),
+            );
+        }
+
+        let proposals = sm.take_pending_proposals();
+        assert!(proposals.is_empty());
+    }
+
+    #[test]
+    fn no_auto_proposal_for_fixed_strategy() {
+        let mut sm = MetadataStateMachine::default();
+        let result = sm.apply(MetadataCommand::CreateTopic(CreateTopic {
+            name: "ordered".to_string(),
+            storage_policy: fixed_policy(),
+            replica_set: replica_set(),
+            created_at: 1000,
+        }));
+        let tid = match result.unwrap() {
+            ApplyResult::TopicCreated(id) => id,
+            other => panic!("expected TopicCreated, got {:?}", other),
+        };
+
+        for i in 0..SPLIT_SEAL_THRESHOLD {
+            roll_segment(
+                &mut sm,
+                tid,
+                RangeId(0),
+                SegmentId(i as u64),
+                2000 * (i as u64 + 1),
+            );
+        }
+
+        let proposals = sm.take_pending_proposals();
+        assert!(proposals.is_empty());
+    }
+
+    #[test]
+    fn evaluate_merges_cold_adjacent() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+        split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
+
+        // Both children are cold (no seals)
+        let proposals = sm.evaluate_merges(2000 + SPLIT_COOLDOWN_MS + 1);
+        assert_eq!(proposals.len(), 1);
+        assert!(matches!(proposals[0], MetadataCommand::MergeRange(_)));
+    }
+
+    #[test]
+    fn evaluate_merges_one_hot() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+        let (c1, _c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
+        sm.take_pending_proposals(); // discard any split proposals
+
+        // Seal one child — makes it hot
+        roll_segment(&mut sm, tid, c1, SegmentId(0), 3000);
+
+        let proposals = sm.evaluate_merges(3000);
+        assert!(proposals.is_empty());
+    }
+
+    #[test]
+    fn split_clears_seal_history() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+
+        roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
+        let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 3000);
+
+        let topic = sm.get_topic(&tid).unwrap();
+        assert!(topic.ranges[&c1].seal_history.seal_timestamps.is_empty());
+        assert!(topic.ranges[&c2].seal_history.seal_timestamps.is_empty());
+    }
+
+    #[test]
+    fn split_sets_cooldown() {
+        let mut sm = MetadataStateMachine::default();
+        let tid = create_topic(&mut sm, "blue");
+        let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
+
+        let topic = sm.get_topic(&tid).unwrap();
+        assert_eq!(
+            topic.ranges[&c1].seal_history.created_by_split_at,
+            Some(2000)
+        );
+        assert_eq!(
+            topic.ranges[&c2].seal_history.created_by_split_at,
+            Some(2000)
+        );
     }
 }

--- a/src/clusters/metadata/state_machine.rs
+++ b/src/clusters/metadata/state_machine.rs
@@ -149,13 +149,13 @@ impl MetadataStateMachine {
     // ! SAFETY: When the loop evaluates the [1, 2] pair and decides it is mergeable,
     // ! it generates the event and immediately stops looking at the rest of that topic's ranges
     // !
-    // ! However, we still have an asynchronous race condition to worry about.
-    // ! Take the following example:
+    // ! Caution on race condition. Take the following example:
     // !    1. the following method proposes merging (1, 2).
     // !    2. The MergeRange command goes into a queue (or a Raft log) to be processed.
     // !    3. Before the command is executed, range 2 receives a massive burst of traffic and splits into 2A and 2B.
     // !    4. The MergeRange(1, 2) command is finally executed by your merge function.
     // ! By the time the command executes, range 2 might be split, already sealed, or completely deleted
+    // * This is already safe as the 'stale' proposal fails gracefully at apply time, following "stale proposals are safe" invariant
     pub(crate) fn evaluate_merges(&self, now: u64) -> Vec<MetadataCommand> {
         let mut proposals = Vec::new();
 
@@ -180,7 +180,8 @@ impl MetadataStateMachine {
                     let replica_set = r1
                         .active_segment
                         .and_then(|sid| r1.segments.get(&sid))
-                        // ? why taking replicaset from r1 - what about r2?
+                        // ? Why replica set from r1?
+                        // Arbitrary: both ranges are cold (idle) and likely have the same replica set since they were created by the same split
                         .map(|s| s.replica_set.clone())
                         .unwrap_or_default();
 

--- a/src/clusters/metadata/state_machine.rs
+++ b/src/clusters/metadata/state_machine.rs
@@ -326,8 +326,9 @@ impl MetadataStateMachine {
                 );
 
                 // Invariant 16: seal_history timestamps are monotonically ordered
-                for w in range.seal_history.seal_timestamps.windows(2) {
-                    assert!(w[0] <= w[1], "seal_history timestamps not sorted");
+                let ts = &range.seal_history.seal_timestamps;
+                for i in 1..ts.len() {
+                    assert!(ts[i - 1] <= ts[i], "seal_history timestamps not sorted");
                 }
 
                 // Invariant 17: split children have created_by_split_at set
@@ -353,6 +354,8 @@ impl MetadataStateMachine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+
     use crate::clusters::{
         NodeId,
         metadata::{
@@ -939,7 +942,7 @@ mod tests {
     #[test]
     fn should_split_cooldown_blocks() {
         let mut history = RangeSealHistory {
-            seal_timestamps: Vec::new(),
+            seal_timestamps: VecDeque::new(),
             created_by_split_at: Some(1000),
         };
         history.record_seal(1100);

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -5,7 +5,7 @@ use bincode::{Decode, Encode};
 use crate::clusters::{
     NodeId,
     metadata::{
-        RangeId, SegmentId, TopicId,
+        RangeId, SegmentId, SplitRange, TopicId,
         error::MetadataError,
         strategy::{PartitionStrategy, StoragePolicy},
     },
@@ -46,6 +46,23 @@ pub struct SegmentMeta {
 }
 
 impl SegmentMeta {
+    pub(crate) fn new(
+        segment_id: SegmentId,
+        replica_set: Vec<NodeId>,
+        start_offset: u64,
+        created_at: u64,
+    ) -> Self {
+        SegmentMeta {
+            segment_id,
+            state: SegmentState::Active,
+            replica_set: replica_set,
+            size_bytes: 0,
+            start_offset,
+            end_offset: None,
+            created_at,
+            sealed_at: None,
+        }
+    }
     pub(crate) fn seal(&mut self, end_offset: u64, sealed_at: u64) -> Result<(), MetadataError> {
         if self.state != SegmentState::Active {
             return Err(MetadataError::SegmentNotActive);
@@ -72,6 +89,7 @@ pub struct RangeMeta {
     pub split_into: Option<[RangeId; 2]>,
     pub merged_into: Option<RangeId>,
     pub merged_from: Option<[RangeId; 2]>,
+    pub seal_history: RangeSealHistory,
 }
 
 impl RangeMeta {
@@ -83,16 +101,7 @@ impl RangeMeta {
         created_at: u64,
     ) -> Self {
         let segment_id = SegmentId(0);
-        let segment = SegmentMeta {
-            segment_id,
-            state: SegmentState::Active,
-            replica_set,
-            size_bytes: 0,
-            start_offset: 0,
-            end_offset: None,
-            created_at,
-            sealed_at: None,
-        };
+        let segment = SegmentMeta::new(segment_id, replica_set, 0, created_at);
 
         RangeMeta {
             range_id,
@@ -106,7 +115,50 @@ impl RangeMeta {
             split_into: None,
             merged_into: None,
             merged_from: None,
+            seal_history: RangeSealHistory::default(),
         }
+    }
+
+    pub(crate) fn split(
+        &mut self,
+        cmd: SplitRange,
+        left_id: RangeId,
+        right_id: RangeId,
+    ) -> Result<(RangeMeta, RangeMeta), MetadataError> {
+        if !self.valid_split_point(&cmd.split_point) {
+            return Err(MetadataError::InvalidSplitPoint);
+        }
+        let _ = self.validate_active()?;
+
+        self.seal(cmd.created_at)?;
+        self.split_into = Some([left_id, right_id]);
+        let left = RangeMeta::new(
+            left_id,
+            self.keyspace_start.clone(),
+            cmd.split_point.clone(),
+            cmd.left_replica_set,
+            cmd.created_at,
+        )
+        .with_split_origin(cmd.created_at);
+
+        let right = RangeMeta::new(
+            right_id,
+            cmd.split_point,
+            self.keyspace_end.clone(),
+            cmd.right_replica_set,
+            cmd.created_at,
+        )
+        .with_split_origin(cmd.created_at);
+
+        Ok((left, right))
+    }
+
+    fn with_split_origin(mut self, created_at: u64) -> Self {
+        self.seal_history = RangeSealHistory {
+            seal_timestamps: Vec::new(),
+            created_by_split_at: Some(created_at),
+        };
+        self
     }
     pub(crate) fn validate_active(&self) -> Result<SegmentId, MetadataError> {
         if self.state != RangeState::Active {
@@ -117,6 +169,74 @@ impl RangeMeta {
 
     pub(crate) fn valid_split_point(&self, split_point: &Vec<u8>) -> bool {
         split_point > &self.keyspace_start && split_point < &self.keyspace_end
+    }
+    pub(crate) fn roll_segment(
+        &mut self,
+        segment_to_seal: SegmentId,
+        replica_set: Vec<NodeId>,
+        requested_at: u64,
+    ) -> Result<bool, MetadataError> {
+        let segment = self
+            .segments
+            .get_mut(&segment_to_seal)
+            .ok_or(MetadataError::SegmentNotFound)?;
+        segment.seal(self.next_offset.saturating_sub(1), requested_at)?;
+
+        let new_segment_id = SegmentId(self.next_segment_id);
+        let new_segment = SegmentMeta::new(
+            new_segment_id,
+            replica_set.clone(),
+            self.next_offset,
+            requested_at,
+        );
+
+        self.segments.insert(new_segment_id, new_segment);
+        self.active_segment = Some(new_segment_id);
+        self.seal_history.record_seal(requested_at);
+        self.next_segment_id += 1;
+
+        Ok(self.seal_history.should_split(requested_at))
+    }
+
+    pub(crate) fn merge(
+        &mut self,
+        other: &mut RangeMeta,
+        merged_id: RangeId,
+        replica_set: Vec<NodeId>,
+        requested_at: u64,
+    ) -> Result<RangeMeta, MetadataError> {
+        if !self.is_next_to(other) {
+            return Err(MetadataError::RangesNotAdjacent);
+        }
+
+        let (merged_start, merged_end) = if self.keyspace_start <= other.keyspace_start {
+            (self.keyspace_start.clone(), other.keyspace_end.clone())
+        } else {
+            (other.keyspace_start.clone(), self.keyspace_end.clone())
+        };
+
+        self.seal(requested_at)?;
+        other.seal(requested_at)?;
+        self.merged_into = Some(merged_id);
+        other.merged_into = Some(merged_id);
+        let mut merged = RangeMeta::new(
+            merged_id,
+            merged_start,
+            merged_end,
+            replica_set,
+            requested_at,
+        );
+
+        // To make sure of determinsim
+        let merged_from = if self.range_id < other.range_id {
+            [self.range_id, other.range_id]
+        } else {
+            [other.range_id, self.range_id]
+        };
+
+        merged.merged_from = Some(merged_from);
+
+        Ok(merged)
     }
 
     pub(crate) fn seal(&mut self, created_at: u64) -> Result<(), MetadataError> {
@@ -141,6 +261,37 @@ impl RangeMeta {
             segment.state = SegmentState::Deleting;
         }
     }
+
+    /// Compute the midpoint of two byte-slice keyspace bounds.
+    pub fn compute_midpoint(&self) -> Vec<u8> {
+        let len = self
+            .keyspace_start
+            .len()
+            .max(self.keyspace_end.len())
+            .max(1);
+
+        let mut s = vec![0u8; len];
+        let mut e = vec![0u8; len];
+        s[..self.keyspace_start.len()].copy_from_slice(&self.keyspace_start);
+        e[..self.keyspace_end.len()].copy_from_slice(&self.keyspace_end);
+
+        let mut result = vec![0u8; len];
+        let mut carry = 0u16;
+        for i in 0..len {
+            let val = carry * 256 + s[i] as u16 + e[i] as u16;
+            result[i] = (val / 2) as u8;
+            carry = val % 2;
+        }
+
+        result
+    }
+
+    pub(crate) fn mergeable_with(&self, r2: &RangeMeta, now: u64) -> bool {
+        let r1_recent = self.seal_history.recent_seal_count(now);
+        let r2_recent = r2.seal_history.recent_seal_count(now);
+
+        r1_recent == MERGE_SEAL_THRESHOLD && r2_recent == MERGE_SEAL_THRESHOLD
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -162,32 +313,13 @@ impl TopicMeta {
         storage_policy: StoragePolicy,
     ) -> Self {
         let range_id = RangeId(0);
-        let segment_id = SegmentId(0);
-
-        let segment = SegmentMeta {
-            segment_id,
-            state: SegmentState::Active,
-            replica_set,
-            size_bytes: 0,
-            start_offset: 0,
-            end_offset: None,
-            created_at,
-            sealed_at: None,
-        };
-
-        let range = RangeMeta {
+        let range = RangeMeta::new(
             range_id,
-            keyspace_start: KEYSPACE_MIN.to_vec(),
-            keyspace_end: KEYSPACE_MAX.to_vec(),
-            state: RangeState::Active,
-            active_segment: Some(segment_id),
-            segments: HashMap::from([(segment_id, segment)]),
-            next_segment_id: 1,
-            next_offset: 0,
-            split_into: None,
-            merged_into: None,
-            merged_from: None,
-        };
+            KEYSPACE_MIN.to_vec(),
+            KEYSPACE_MAX.to_vec(),
+            replica_set,
+            created_at,
+        );
 
         TopicMeta {
             id,
@@ -198,6 +330,22 @@ impl TopicMeta {
             ranges: HashMap::from([(range_id, range)]),
             next_range_id: 1,
         }
+    }
+
+    pub(crate) fn get_ranges_mut<const N: usize>(
+        &mut self,
+        ranges: [&RangeId; N],
+    ) -> Result<[&mut RangeMeta; N], MetadataError> {
+        let options = self.ranges.get_disjoint_mut(ranges);
+
+        let vec_ranges: Vec<&mut RangeMeta> = options
+            .into_iter()
+            .map(|opt| opt.ok_or(MetadataError::RangeNotFound)) // Bubble up the error
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // ! SAFETY: We can safely unwrap() here because we know the Vec was built
+        // ! from an array of exactly size N, so it will never fail.
+        Ok(vec_ranges.try_into().unwrap())
     }
 
     pub(crate) fn validate_active(&self) -> Result<(), MetadataError> {
@@ -244,6 +392,45 @@ impl TopicMeta {
 }
 
 // --- Keyspace Constants ---
-
 pub const KEYSPACE_MIN: &[u8] = &[];
 pub const KEYSPACE_MAX: &[u8] = &[0xFF];
+
+// --- Hot Range Detection Constants ---
+pub const SPLIT_SEAL_THRESHOLD: usize = 3;
+pub const MEASUREMENT_WINDOW_MS: u64 = 300_000;
+pub const SPLIT_COOLDOWN_MS: u64 = 300_000;
+pub const MERGE_SEAL_THRESHOLD: usize = 0;
+
+// TODO : range will have many different kinds of split strategy which is ideally configurable.
+#[derive(Default, Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct RangeSealHistory {
+    pub seal_timestamps: Vec<u64>,
+    pub created_by_split_at: Option<u64>,
+}
+
+impl RangeSealHistory {
+    pub fn record_seal(&mut self, sealed_at: u64) {
+        self.seal_timestamps.push(sealed_at);
+        let cutoff = sealed_at.saturating_sub(MEASUREMENT_WINDOW_MS);
+        self.seal_timestamps.retain(|&t| t > cutoff);
+    }
+
+    pub fn seal_count(&self) -> usize {
+        self.seal_timestamps.len()
+    }
+
+    pub fn should_split(&self, now: u64) -> bool {
+        if self.seal_count() < SPLIT_SEAL_THRESHOLD {
+            return false;
+        }
+        match self.created_by_split_at {
+            Some(split_at) => now.saturating_sub(split_at) >= SPLIT_COOLDOWN_MS,
+            None => true,
+        }
+    }
+
+    pub fn recent_seal_count(&self, now: u64) -> usize {
+        let cutoff = now.saturating_sub(MEASUREMENT_WINDOW_MS);
+        self.seal_timestamps.iter().filter(|&&t| t > cutoff).count()
+    }
+}

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use bincode::{Decode, Encode};
 
@@ -155,7 +155,7 @@ impl RangeMeta {
 
     fn with_split_origin(mut self, created_at: u64) -> Self {
         self.seal_history = RangeSealHistory {
-            seal_timestamps: Vec::new(),
+            seal_timestamps: VecDeque::new(),
             created_by_split_at: Some(created_at),
         };
         self
@@ -404,15 +404,17 @@ pub const MERGE_SEAL_THRESHOLD: usize = 0;
 // TODO : range will have many different kinds of split strategy which is ideally configurable.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct RangeSealHistory {
-    pub seal_timestamps: Vec<u64>,
+    pub seal_timestamps: VecDeque<u64>,
     pub created_by_split_at: Option<u64>,
 }
 
 impl RangeSealHistory {
     pub fn record_seal(&mut self, sealed_at: u64) {
-        self.seal_timestamps.push(sealed_at);
+        self.seal_timestamps.push_back(sealed_at);
         let cutoff = sealed_at.saturating_sub(MEASUREMENT_WINDOW_MS);
-        self.seal_timestamps.retain(|&t| t > cutoff);
+        while self.seal_timestamps.front().is_some_and(|&t| t <= cutoff) {
+            self.seal_timestamps.pop_front();
+        }
     }
 
     pub fn seal_count(&self) -> usize {

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -55,7 +55,7 @@ impl SegmentMeta {
         SegmentMeta {
             segment_id,
             state: SegmentState::Active,
-            replica_set: replica_set,
+            replica_set,
             size_bytes: 0,
             start_offset,
             end_offset: None,

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -392,14 +392,18 @@ impl TopicMeta {
 }
 
 // --- Keyspace Constants ---
+// Full partition-key space covered by a topic's ranges. Lexicographic ordering on Vec<u8>.
+// [0xFF] is a 1-byte placeholder — production should use &[0xFF; 32] for a 256-bit ring.
 pub const KEYSPACE_MIN: &[u8] = &[];
 pub const KEYSPACE_MAX: &[u8] = &[0xFF];
 
 // --- Hot Range Detection Constants ---
+// Seal frequency is the load signal: split when >= SPLIT_SEAL_THRESHOLD seals, SPLIT_SEAL_THRESHOLD min window, merge when 0.
+// Hysteresis (split = SPLIT_SEAL_THRESHOLD, merge = MERGE_SEAL_THRESHOLD) prevents oscillation. Cooldown blocks re-splitting children.
 pub const SPLIT_SEAL_THRESHOLD: usize = 3;
-pub const MEASUREMENT_WINDOW_MS: u64 = 300_000;
-pub const SPLIT_COOLDOWN_MS: u64 = 300_000;
-pub const MERGE_SEAL_THRESHOLD: usize = 0;
+pub const MEASUREMENT_WINDOW_MS: u64 = 300_000; // 5 min sliding window
+pub const SPLIT_COOLDOWN_MS: u64 = 300_000; // 5 min cooldown after a split
+pub const MERGE_SEAL_THRESHOLD: usize = 0; // both ranges must be fully idle
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct RangeSealHistory {

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -401,7 +401,6 @@ pub const MEASUREMENT_WINDOW_MS: u64 = 300_000;
 pub const SPLIT_COOLDOWN_MS: u64 = 300_000;
 pub const MERGE_SEAL_THRESHOLD: usize = 0;
 
-// TODO : range will have many different kinds of split strategy which is ideally configurable.
 #[derive(Default, Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct RangeSealHistory {
     pub seal_timestamps: VecDeque<u64>,

--- a/src/clusters/raft/messages/timer.rs
+++ b/src/clusters/raft/messages/timer.rs
@@ -3,6 +3,7 @@ use crate::schedulers::timer::TTimer;
 
 const ELECTION_TIMEOUT_BASE_TICKS: u32 = 50; // 5s base (+ jitter)
 const HEARTBEAT_INTERVAL_TICKS: u32 = 10; // 1s
+const MERGE_CHECK_INTERVAL_TICKS: u32 = 6_000; // 10 minutes
 
 #[derive(Debug)]
 pub struct RaftTimer {
@@ -15,6 +16,7 @@ pub struct RaftTimer {
 pub enum RaftTimerKind {
     Election,
     Heartbeat,
+    MergeCheck,
 }
 
 #[derive(Debug, Default)]
@@ -25,6 +27,9 @@ pub enum RaftTimeoutCallback {
         shard_group_id: ShardGroupId,
     },
     HeartbeatTimeout {
+        shard_group_id: ShardGroupId,
+    },
+    MergeCheckTimeout {
         shard_group_id: ShardGroupId,
     },
 }
@@ -43,6 +48,9 @@ impl TTimer for RaftTimer {
                 shard_group_id: self.shard_group_id,
             },
             RaftTimerKind::Heartbeat => RaftTimeoutCallback::HeartbeatTimeout {
+                shard_group_id: self.shard_group_id,
+            },
+            RaftTimerKind::MergeCheck => RaftTimeoutCallback::MergeCheckTimeout {
                 shard_group_id: self.shard_group_id,
             },
         }
@@ -68,6 +76,14 @@ impl RaftTimer {
             shard_group_id,
             kind: RaftTimerKind::Heartbeat,
             ticks_remaining: HEARTBEAT_INTERVAL_TICKS,
+        }
+    }
+
+    pub fn merge_check(shard_group_id: ShardGroupId) -> Self {
+        Self {
+            shard_group_id,
+            kind: RaftTimerKind::MergeCheck,
+            ticks_remaining: MERGE_CHECK_INTERVAL_TICKS,
         }
     }
 }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -210,6 +210,19 @@ impl MultiRaft {
         let mut mutations: Vec<(ShardGroupId, LogMutation)> = vec![];
         let mut last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
 
+        // Drain auto-proposals from previous flush and propose them.
+        // They become regular log entries, persisted in the same batch below.
+        for id in &dirty {
+            let Some(raft) = self.groups.get_mut(id) else {
+                continue;
+            };
+            for cmd in raft.take_pending_proposals() {
+                if let Err(e) = raft.propose(cmd) {
+                    tracing::warn!("Auto-proposal rejected for {:?}: {:?}", id, e);
+                }
+            }
+        }
+
         for id in &dirty {
             let Some(raft) = self.groups.get_mut(id) else {
                 continue;
@@ -228,40 +241,6 @@ impl MultiRaft {
             for (id, last_log_index) in &last_indices {
                 if let Some(raft) = self.groups.get_mut(id) {
                     raft.advance_stabled_index(*last_log_index)
-                }
-            }
-        }
-
-        // ! TODO lazy execution?
-        // Drain auto-proposals generated during apply_committed_entries()
-        let mut auto_mutations: Vec<(ShardGroupId, LogMutation)> = vec![];
-        let mut auto_last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
-
-        for id in &dirty {
-            let Some(raft) = self.groups.get_mut(id) else {
-                continue;
-            };
-            let proposals = raft.take_pending_proposals();
-            if proposals.is_empty() {
-                continue;
-            }
-            for cmd in proposals {
-                if let Err(e) = raft.propose(cmd) {
-                    tracing::warn!("Auto-proposal rejected for {:?}: {:?}", id, e);
-                }
-            }
-            auto_last_indices.insert(*id, raft.log_last_index());
-            for log in raft.take_log_mutations() {
-                auto_mutations.push((*id, log));
-            }
-            self.pending_events.extend(raft.take_events());
-        }
-
-        if !auto_mutations.is_empty() {
-            self.storage.persist_mutations(auto_mutations);
-            for (id, last_log_index) in auto_last_indices {
-                if let Some(raft) = self.groups.get_mut(&id) {
-                    raft.advance_stabled_index(last_log_index)
                 }
             }
         }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -6,7 +6,7 @@ use crate::clusters::raft::messages::{
     LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
     RaftTimeoutCallback,
 };
-use crate::clusters::raft::state::Raft;
+use crate::clusters::raft::state::{Raft, TimerSeqs};
 
 use crate::clusters::raft::storage::RaftStorage;
 use crate::clusters::swims::{ShardGroup, ShardGroupId};
@@ -99,6 +99,7 @@ impl MultiRaft {
 
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
+        let merge_check_seq = self.seq_counter.generate();
 
         let persistent = self.storage.load_state(group.id.0);
 
@@ -108,8 +109,11 @@ impl MultiRaft {
             persistent,
             jitter,
             group.id,
-            election_seq,
-            heartbeat_seq,
+            TimerSeqs {
+                election: election_seq,
+                heartbeat: heartbeat_seq,
+                merge_check: merge_check_seq,
+            },
         );
 
         tracing::info!(
@@ -145,8 +149,9 @@ impl MultiRaft {
     fn handle_timeout(&mut self, cb: RaftTimeoutCallback) {
         let shard_id = match &cb {
             RaftTimeoutCallback::Ignored => return,
-            RaftTimeoutCallback::ElectionTimeout { shard_group_id } => *shard_group_id,
-            RaftTimeoutCallback::HeartbeatTimeout { shard_group_id } => *shard_group_id,
+            RaftTimeoutCallback::ElectionTimeout { shard_group_id }
+            | RaftTimeoutCallback::HeartbeatTimeout { shard_group_id }
+            | RaftTimeoutCallback::MergeCheckTimeout { shard_group_id } => *shard_group_id,
         };
         if let Some(raft) = self.groups.get_mut(&shard_id) {
             raft.handle_timeout(cb);
@@ -220,7 +225,41 @@ impl MultiRaft {
         if !mutations.is_empty() {
             self.storage.persist_mutations(mutations);
 
-            for (id, last_log_index) in last_indices {
+            for (id, last_log_index) in &last_indices {
+                if let Some(raft) = self.groups.get_mut(id) {
+                    raft.advance_stabled_index(*last_log_index)
+                }
+            }
+        }
+
+        // ! TODO lazy execution?
+        // Drain auto-proposals generated during apply_committed_entries()
+        let mut auto_mutations: Vec<(ShardGroupId, LogMutation)> = vec![];
+        let mut auto_last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
+
+        for id in &dirty {
+            let Some(raft) = self.groups.get_mut(id) else {
+                continue;
+            };
+            let proposals = raft.take_pending_proposals();
+            if proposals.is_empty() {
+                continue;
+            }
+            for cmd in proposals {
+                if let Err(e) = raft.propose(cmd) {
+                    tracing::warn!("Auto-proposal rejected for {:?}: {:?}", id, e);
+                }
+            }
+            auto_last_indices.insert(*id, raft.log_last_index());
+            for log in raft.take_log_mutations() {
+                auto_mutations.push((*id, log));
+            }
+            self.pending_events.extend(raft.take_events());
+        }
+
+        if !auto_mutations.is_empty() {
+            self.storage.persist_mutations(auto_mutations);
+            for (id, last_log_index) in auto_last_indices {
                 if let Some(raft) = self.groups.get_mut(&id) {
                     raft.advance_stabled_index(last_log_index)
                 }
@@ -666,11 +705,7 @@ mod tests {
 
         let g2 = store.groups.get(&ShardGroupId(2)).unwrap();
         assert_eq!(g2.current_term(), 0, "group 2 term must be unaffected");
-        assert_eq!(
-            g2.log_last_index(),
-            0,
-            "group 2 log must be empty"
-        );
+        assert_eq!(g2.log_last_index(), 0, "group 2 log must be empty");
     }
 
     #[test]

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -688,8 +688,6 @@ impl Raft {
                         }
                     }
 
-                    // OPTION 1: take proposal here, and discard if not leader(as follows, with cons being creation of unused data)
-                    // OPTION 2: don't raise a proposal - which will require state_machine to be aware of the role.
                     let proposals = self.state_machine.take_pending_proposals();
                     if self.role == Role::Leader {
                         for cmd in proposals {

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -60,9 +60,15 @@ pub struct Raft {
     // LEADER-ONLY volatile state
     peer_states: HashMap<NodeId, PeerState>,
     state_machine: MetadataStateMachine,
+    pending_proposals: Vec<RaftCommand>,
     election_jitter: u32,
-    election_seq: u32,
-    heartbeat_seq: u32,
+    timer_seqs: TimerSeqs,
+}
+
+pub(crate) struct TimerSeqs {
+    pub election: u32,
+    pub heartbeat: u32,
+    pub merge_check: u32,
 }
 
 impl Raft {
@@ -72,8 +78,7 @@ impl Raft {
         persistent: RaftPersistentState,
         election_jitter: u32,
         shard_group_id: ShardGroupId,
-        election_seq: u32,
-        heartbeat_seq: u32,
+        timer_seqs: TimerSeqs,
     ) -> Self {
         let mut raft = Self {
             node_id,
@@ -90,17 +95,17 @@ impl Raft {
             role: Role::Follower,
             current_leader: None,
             state_machine: MetadataStateMachine::default(),
+            pending_proposals: Vec::new(),
             peer_states: HashMap::new(),
             election_jitter,
-            election_seq,
-            heartbeat_seq,
+            timer_seqs,
         };
         raft.reset_election_timer();
         raft
     }
 
     pub(crate) fn heartbeat_seq(&self) -> u32 {
-        self.heartbeat_seq
+        self.timer_seqs.heartbeat
     }
 
     #[cfg(test)]
@@ -114,6 +119,10 @@ impl Raft {
 
     pub fn take_log_mutations(&mut self) -> Vec<LogMutation> {
         std::mem::take(&mut self.pending_log_mutations)
+    }
+
+    pub(crate) fn take_pending_proposals(&mut self) -> Vec<RaftCommand> {
+        std::mem::take(&mut self.pending_proposals)
     }
 
     // -------------------------------------------------------------------
@@ -216,6 +225,9 @@ impl Raft {
             }
             RaftTimeoutCallback::HeartbeatTimeout { .. } => {
                 self.send_heartbeats();
+            }
+            RaftTimeoutCallback::MergeCheckTimeout { .. } => {
+                self.evaluate_merges();
             }
         }
         #[cfg(test)]
@@ -355,9 +367,10 @@ impl Raft {
             .into(),
         );
 
-        // Cancel election timer, start heartbeat timer.
+        // Cancel election timer, start heartbeat + merge check timers.
         self.cancel_all_timers();
         self.schedule_heartbeat_timer();
+        self.schedule_merge_check_timer();
 
         // next_index is set *before* the noop is appended, so it points
         // at the noop's index — causing the first AppendEntries to carry it.
@@ -655,24 +668,35 @@ impl Raft {
             };
             match entry.command {
                 RaftCommand::Noop => {}
-                RaftCommand::Metadata(cmd) => match self.state_machine.apply(cmd) {
-                    Ok(result) => {
-                        tracing::debug!(
-                            "[{}] Applied metadata at index {}: {:?}",
-                            self.node_id,
-                            entry.index,
-                            result
-                        );
+                RaftCommand::Metadata(cmd) => {
+                    match self.state_machine.apply(cmd) {
+                        Ok(result) => {
+                            tracing::debug!(
+                                "[{}] Applied metadata at index {}: {:?}",
+                                self.node_id,
+                                entry.index,
+                                result
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "[{}] Metadata apply error at index {}: {:?}",
+                                self.node_id,
+                                entry.index,
+                                e
+                            );
+                        }
                     }
-                    Err(e) => {
-                        tracing::error!(
-                            "[{}] Metadata apply error at index {}: {:?}",
-                            self.node_id,
-                            entry.index,
-                            e
-                        );
+
+                    // OPTION 1: take proposal here, and discard if not leader(as follows, with cons being creation of unused data)
+                    // OPTION 2: don't raise a proposal - which will require state_machine to be aware of the role.
+                    let proposals = self.state_machine.take_pending_proposals();
+                    if self.role == Role::Leader {
+                        for cmd in proposals {
+                            self.pending_proposals.push(RaftCommand::Metadata(cmd));
+                        }
                     }
-                },
+                }
             }
         }
     }
@@ -747,11 +771,11 @@ impl Raft {
     fn reset_election_timer(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: self.election_seq,
+                seq: self.timer_seqs.election,
             }));
         self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
-                seq: self.election_seq,
+                seq: self.timer_seqs.election,
                 timer: RaftTimer::election(self.election_jitter, self.shard_group_id),
             }));
     }
@@ -759,19 +783,49 @@ impl Raft {
     fn schedule_heartbeat_timer(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
-                seq: self.heartbeat_seq,
+                seq: self.timer_seqs.heartbeat,
                 timer: RaftTimer::heartbeat(self.shard_group_id),
             }));
+    }
+
+    fn schedule_merge_check_timer(&mut self) {
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::SetSchedule {
+                seq: self.timer_seqs.merge_check,
+                timer: RaftTimer::merge_check(self.shard_group_id),
+            }));
+    }
+
+    fn evaluate_merges(&mut self) {
+        if self.role != Role::Leader {
+            return;
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let merge_proposals = self.state_machine.evaluate_merges(now);
+        for cmd in merge_proposals {
+            self.pending_proposals.push(RaftCommand::Metadata(cmd));
+        }
+
+        self.schedule_merge_check_timer();
     }
 
     pub(crate) fn cancel_all_timers(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: self.election_seq,
+                seq: self.timer_seqs.election,
             }));
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: self.heartbeat_seq,
+                seq: self.timer_seqs.heartbeat,
+            }));
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
+                seq: self.timer_seqs.merge_check,
             }));
     }
 
@@ -820,6 +874,14 @@ mod tests {
         raft.take_events();
     }
 
+    fn test_timer_seqs() -> TimerSeqs {
+        TimerSeqs {
+            election: 0,
+            heartbeat: 1,
+            merge_check: 2,
+        }
+    }
+
     fn single_node_raft() -> Raft {
         Raft::new(
             node("node-1"),
@@ -827,8 +889,7 @@ mod tests {
             RaftPersistentState::default(),
             0,
             TEST_SHARD,
-            0,
-            1,
+            test_timer_seqs(),
         )
     }
 
@@ -841,8 +902,7 @@ mod tests {
             RaftPersistentState::default(),
             0,
             TEST_SHARD,
-            0,
-            1,
+            test_timer_seqs(),
         )
     }
 
@@ -1565,8 +1625,7 @@ mod tests {
                 RaftPersistentState::default(),
                 0,
                 TEST_SHARD,
-                0,
-                1,
+                test_timer_seqs(),
             );
 
             assert_eq!(


### PR DESCRIPTION
## Summary

- **Hot range detection via seal frequency.** `RangeSealHistory` on `RangeMeta` tracks segment seal timestamps within a sliding window (5 min). When a range seals 3+ segments within the window, the leader auto-proposes a `SplitRange` at the keyspace midpoint.
- **Cold range merge detection.** Periodic `MergeCheck` timer (10 min) scans adjacent active ranges. If both have zero seals within the measurement window, the leader proposes `MergeRange`. One merge per topic per evaluation to avoid overlapping merges.
- **Lazy auto-proposal execution.** Auto-proposals buffer in `Raft::pending_proposals`, drained at the start of the next `MultiRaft::flush()` cycle. Single persist pass — no double-write. ~100ms latency is negligible for decisions based on 5-minute windows.

## Key design decisions

- `SealSegment` renamed to `RollSegment` — reflects actual behavior (seal current + create next)
- Stale `RollSegment` (wrong segment ID) is a no-op, not an error
- Split/merge logic lives on `RangeMeta` (`roll_segment()`, `split()`, `merge()`, `compute_midpoint()`, `mergeable_with()`)
- `TimerSeqs` struct groups election/heartbeat/merge_check seq values to avoid parameter bloat on `Raft::new()`
- `TopicMeta::get_ranges_mut()` uses `get_disjoint_mut()` for safe double mutable borrow during merge
- Split cooldown on child ranges via `created_by_split_at` — prevents re-split within `SPLIT_COOLDOWN_MS`
- Hysteresis: split at 3 seals/window, merge at 0 — no oscillation

## New invariants

- **Invariant 16:** `seal_history` updated deterministically on all replicas. Timestamps monotonically ordered.
- **Invariant 17:** Split children always have `created_by_split_at` set.

