### PR TITLE
code convention rule, refactoring

### DIFF
--- a/.claude/rules/code-convention.md
+++ b/.claude/rules/code-convention.md
@@ -1,0 +1,34 @@
+# Code Convention
+
+## Encapsulation
+
+Functions taking `&self`, `&mut self`, or a reference to a struct as their first argument must be methods on that struct. Free functions with `&SomeStruct` as first arg are never acceptable — add them as `impl SomeStruct` methods instead.
+
+## Result over Option for observability
+
+Prefer `Result<T, E>` over `Option<T>` when `None` represents a failure condition that an operator or developer would want to diagnose. Silent `None` returns hide *why* something didn't happen — use `Result` so the error is observable via logging or propagation.
+
+Legitimate `Option` uses: simple lookups where "not found" is the only possible reason (e.g., `HashMap::get`, `Vec::first`).
+
+## Propagate errors, don't swallow them
+
+- Use `?` to propagate errors up the call chain. Don't match on `Result` just to convert `Err` to `None` or `Ok(())`.
+- When `.ok()` is necessary at a boundary (e.g., best-effort forwarding), log the error at `debug!` or `warn!` level before discarding it.
+- Never use `Result<Option<T>>` when the `None` case can be expressed as an error variant. The double-unwrap ceremony at call sites is a sign the API is wrong.
+
+## Avoid boolean flags as function parameters
+
+Don't pass `bool` parameters to control method behavior. Instead, have the caller check the condition and only call the method when appropriate. Boolean parameters hide branching from the call site and make APIs harder to read.
+
+## Compile-time exhaustiveness over runtime defaults
+
+Never use wildcard `_ => {}` or `_ => unreachable!()` in match arms for enum dispatch. List all variants explicitly so the compiler catches new variants at compile time. When splitting a match across sub-functions, the "already handled" arms should be listed explicitly (e.g., `VariantA { .. } | VariantB { .. } => {}`).
+
+## Temporal coupling in error propagation
+
+When a method performs mutation followed by a fallible read-only operation, consider that propagating the read-only error with `?` implies the entire operation failed — but the mutation already happened.
+
+In such cases:
+- Log the read-only failure instead of propagating it, if the mutation was the primary intent and succeeded.
+- Or restructure so that the fallible read-only check runs *before* the mutation.
+- Never let a post-mutation diagnostic failure abort the operation that already committed.

--- a/.claude/skills/build-actor/SKILL.md
+++ b/.claude/skills/build-actor/SKILL.md
@@ -223,7 +223,7 @@ impl YourActor {
 
 **Critical: flush must happen after draining all pending events.** Output buffers accumulate across multiple `process()` calls, so one flush handles the entire batch. `process()` lives on the state machine when dispatch is pure sync (no I/O). If command handling requires async I/O (e.g. sending transport commands), keep it as an actor associated fn instead. Branch that skips flush = side effects silently lost.
 
-**Translation in flush**: If events need transformation before routing (e.g. membership events → raft commands, timer seq namespacing), extract a helper method rather than inlining complex logic in the match arm. See `SwimActor::to_raft_command()` and `RaftGroups::translate_timer_seq()`.
+**Translation in flush**: If events need transformation before routing (e.g. membership events → raft commands, timer seq namespacing), extract a helper method rather than inlining complex logic in the match arm. See `MembershipEvent::into_raft_command()` and `RaftGroups::translate_timer_seq()`.
 
 ### Multiplexing pattern (like MultiRaftActor)
 

--- a/src/clusters/metadata/error.rs
+++ b/src/clusters/metadata/error.rs
@@ -13,4 +13,5 @@ pub enum MetadataError {
     SplitNotAllowed(TopicId),
     RangesNotAdjacent,
     InvalidSplitPoint,
+    StaleSegment,
 }

--- a/src/clusters/metadata/state_machine.rs
+++ b/src/clusters/metadata/state_machine.rs
@@ -73,34 +73,30 @@ impl MetadataStateMachine {
             .ok_or(TopicNotFound(cmd.topic_id))?;
         topic.validate_active()?;
         let can_split = topic.can_split();
-
         let range = topic.ranges.get_mut(&cmd.range_id).ok_or(RangeNotFound)?;
         let active_seg_id = range.validate_active()?;
         if active_seg_id != cmd.segment_id {
-            return Ok(());
+            return Err(StaleSegment);
         }
-
         let should_split =
             range.roll_segment(cmd.segment_id, cmd.new_replica_set.clone(), cmd.sealed_at)?;
-
-        if can_split && should_split {
-            // The following guards against ranges too narrow to split. When keyspace_start and keyspace_end are 1 unit apart (e.g., [0x40] and [0x41]),
-            // integer division truncates: (0x40 + 0x41) / 2 = 0x40, which equals keyspace_start.
-            // That fails valid_split_point (requires strictly between), so the split is skipped.
-            let mid = range.compute_midpoint();
-            if range.valid_split_point(&mid) {
-                self.pending_proposals
-                    .push(MetadataCommand::SplitRange(SplitRange {
-                        topic_id: cmd.topic_id,
-                        range_id: cmd.range_id,
-                        split_point: mid,
-                        created_at: cmd.sealed_at,
-                        left_replica_set: cmd.new_replica_set.clone(),
-                        right_replica_set: cmd.new_replica_set,
-                    }));
+        if should_split && can_split {
+            match range.build_split_proposal(&cmd) {
+                Ok(proposal) => self.pending_proposals.push(proposal),
+                Err(e) => tracing::debug!(
+                    "Split proposal skipped for range {:?}: {:?}",
+                    cmd.range_id,
+                    e
+                ),
             }
         }
         Ok(())
+    }
+
+    fn get_active_topic_mut(&mut self, id: TopicId) -> Result<&mut TopicMeta, MetadataError> {
+        let topic = self.topics.get_mut(&id).ok_or(TopicNotFound(id))?;
+        topic.validate_active()?;
+        Ok(topic)
     }
 
     fn split_range(&mut self, cmd: SplitRange) -> Result<(RangeId, RangeId), MetadataError> {
@@ -112,18 +108,7 @@ impl MetadataStateMachine {
         if !topic.can_split() {
             return Err(SplitNotAllowed(cmd.topic_id));
         }
-        let left_id = RangeId(topic.next_range_id);
-        let right_id = RangeId(topic.next_range_id + 1);
-        let range = topic.ranges.get_mut(&cmd.range_id).ok_or(RangeNotFound)?;
-        let (left, right) = range.split(cmd, left_id, right_id)?;
-
-        topic.next_range_id += 2;
-        topic.active_ranges.retain(|id| *id != range.range_id);
-        topic.ranges.insert(left_id, left);
-        topic.ranges.insert(right_id, right);
-        topic.insert_range_sorted(left_id);
-        topic.insert_range_sorted(right_id);
-        Ok((left_id, right_id))
+        topic.execute_split(cmd)
     }
 
     fn merge_range(&mut self, cmd: MergeRange) -> Result<RangeId, MetadataError> {
@@ -157,48 +142,10 @@ impl MetadataStateMachine {
     // ! By the time the command executes, range 2 might be split, already sealed, or completely deleted
     // * This is already safe as the 'stale' proposal fails gracefully at apply time, following "stale proposals are safe" invariant
     pub(crate) fn evaluate_merges(&self, now: u64) -> Vec<MetadataCommand> {
-        let mut proposals = Vec::new();
-
-        for topic in self.topics.values() {
-            if topic.validate_active().is_err() {
-                continue;
-            }
-            if !topic.can_split() {
-                continue;
-            }
-            if topic.active_ranges.len() < 2 {
-                continue;
-            }
-
-            for pair in topic.active_ranges.windows(2) {
-                let (r1, r2) = (&topic.ranges[&pair[0]], &topic.ranges[&pair[1]]);
-                if r1.state != RangeState::Active || r2.state != RangeState::Active {
-                    continue;
-                }
-
-                if r1.mergeable_with(r2, now) {
-                    let replica_set = r1
-                        .active_segment
-                        .and_then(|sid| r1.segments.get(&sid))
-                        // ? Why replica set from r1?
-                        // Arbitrary: both ranges are cold (idle) and likely have the same replica set since they were created by the same split
-                        .map(|s| s.replica_set.clone())
-                        .unwrap_or_default();
-
-                    proposals.push(MetadataCommand::MergeRange(MergeRange {
-                        topic_id: topic.id,
-                        range_id_1: r1.range_id,
-                        range_id_2: r2.range_id,
-                        created_at: now,
-                        merged_replica_set: replica_set,
-                    }));
-
-                    break;
-                }
-            }
-        }
-
-        proposals
+        self.topics
+            .values()
+            .filter_map(|topic| topic.find_mergeable_pair(now))
+            .collect()
     }
 
     fn delete_topic(&mut self, cmd: DeleteTopic) -> Result<(), MetadataError> {
@@ -218,7 +165,15 @@ impl MetadataStateMachine {
 
     #[cfg(test)]
     fn assert_invariants(&self) {
-        // Invariant 12: topic_name_index and topics always in sync
+        self.assert_name_index_sync();
+        self.assert_topic_id_monotonicity();
+        for topic in self.topics.values() {
+            topic.assert_invariants();
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_name_index_sync(&self) {
         assert_eq!(
             self.topic_name_index.len(),
             self.topics
@@ -234,119 +189,12 @@ impl MetadataStateMachine {
                 .expect("name index points to missing topic");
             assert_eq!(&topic.name, name);
         }
+    }
 
-        // Invariant 6: ID monotonicity
+    #[cfg(test)]
+    fn assert_topic_id_monotonicity(&self) {
         for id in self.topics.keys() {
             assert!(id.0 < self.next_topic_id, "topic ID >= next_topic_id");
-        }
-
-        for topic in self.topics.values() {
-            // Invariant 6: range ID monotonicity
-            for rid in topic.ranges.keys() {
-                assert!(rid.0 < topic.next_range_id, "range ID >= next_range_id");
-            }
-
-            if topic.state == TopicState::Active {
-                // Invariant 1: keyspace coverage — active ranges cover full keyspace
-                if !topic.active_ranges.is_empty() {
-                    let ranges: Vec<&RangeMeta> = topic
-                        .active_ranges
-                        .iter()
-                        .map(|id| &topic.ranges[id])
-                        .collect();
-
-                    assert_eq!(
-                        ranges[0].keyspace_start, KEYSPACE_MIN,
-                        "first range must start at MIN"
-                    );
-                    assert_eq!(
-                        ranges.last().unwrap().keyspace_end,
-                        KEYSPACE_MAX,
-                        "last range must end at MAX"
-                    );
-                    for w in ranges.windows(2) {
-                        assert_eq!(
-                            w[0].keyspace_end, w[1].keyspace_start,
-                            "keyspace gap between active ranges"
-                        );
-                    }
-                }
-            }
-
-            for range in topic.ranges.values() {
-                match range.state {
-                    RangeState::Active => {
-                        // Invariant 2: single active segment per active range
-                        assert!(
-                            range.active_segment.is_some(),
-                            "active range missing active_segment"
-                        );
-                        let seg_id = range.active_segment.unwrap();
-                        let seg = range
-                            .segments
-                            .get(&seg_id)
-                            .expect("active_segment points to missing segment");
-                        assert_eq!(
-                            seg.state,
-                            SegmentState::Active,
-                            "active_segment not in Active state"
-                        );
-                    }
-                    RangeState::Sealed | RangeState::Deleting => {
-                        assert!(
-                            range.active_segment.is_none(),
-                            "sealed/deleting range has active_segment"
-                        );
-                    }
-                }
-
-                // Invariant 6: segment ID monotonicity
-                for sid in range.segments.keys() {
-                    assert!(
-                        sid.0 < range.next_segment_id,
-                        "segment ID >= next_segment_id"
-                    );
-                }
-
-                // Invariant 3: sealed segments have end_offset set
-                for seg in range.segments.values() {
-                    if seg.state == SegmentState::Sealed {
-                        assert!(
-                            seg.end_offset.is_some(),
-                            "sealed segment missing end_offset"
-                        );
-                        assert!(seg.sealed_at.is_some(), "sealed segment missing sealed_at");
-                    }
-                }
-
-                // Invariant 4: lineage consistency — cannot be both split and merged
-                assert!(
-                    range.split_into.is_none() || range.merged_into.is_none(),
-                    "range both split and merged"
-                );
-
-                // Invariant 16: seal_history timestamps are monotonically ordered
-                let ts = &range.seal_history.seal_timestamps;
-                for i in 1..ts.len() {
-                    assert!(ts[i - 1] <= ts[i], "seal_history timestamps not sorted");
-                }
-
-                // Invariant 17: split children have created_by_split_at set
-                if let Some([left, right]) = range.split_into {
-                    if let Some(left_range) = topic.ranges.get(&left) {
-                        assert!(
-                            left_range.seal_history.created_by_split_at.is_some(),
-                            "split child missing created_by_split_at"
-                        );
-                    }
-                    if let Some(right_range) = topic.ranges.get(&right) {
-                        assert!(
-                            right_range.seal_history.created_by_split_at.is_some(),
-                            "split child missing created_by_split_at"
-                        );
-                    }
-                }
-            }
         }
     }
 }
@@ -584,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn roll_segment_stale_is_noop() {
+    fn roll_segment_stale_is_rejected() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
@@ -595,7 +443,7 @@ mod tests {
             sealed_at: 2000,
             new_replica_set: replica_set(),
         }));
-        assert_eq!(result, Ok(ApplyResult::SegmentRolled));
+        assert_eq!(result, Err(MetadataError::StaleSegment));
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
         assert_eq!(range.active_segment, Some(SegmentId(0)));
@@ -870,7 +718,7 @@ mod tests {
     // --- Invariant: Segment immutability after seal ---
 
     #[test]
-    fn roll_already_rolled_segment_is_noop() {
+    fn roll_already_rolled_segment_is_stale() {
         let mut sm = MetadataStateMachine::default();
         let tid = create_topic(&mut sm, "blue");
 
@@ -883,7 +731,7 @@ mod tests {
             sealed_at: 3000,
             new_replica_set: replica_set(),
         }));
-        assert_eq!(result, Ok(ApplyResult::SegmentRolled));
+        assert_eq!(result, Err(MetadataError::StaleSegment));
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
         assert_eq!(range.active_segment, Some(SegmentId(1)));

--- a/src/clusters/metadata/types.rs
+++ b/src/clusters/metadata/types.rs
@@ -6,6 +6,7 @@ use crate::clusters::{
     NodeId,
     metadata::{
         RangeId, SegmentId, SplitRange, TopicId,
+        command::{MergeRange, MetadataCommand, RollSegment},
         error::MetadataError,
         strategy::{PartitionStrategy, StoragePolicy},
     },
@@ -170,6 +171,25 @@ impl RangeMeta {
     pub(crate) fn valid_split_point(&self, split_point: &Vec<u8>) -> bool {
         split_point > &self.keyspace_start && split_point < &self.keyspace_end
     }
+
+    pub(crate) fn build_split_proposal(
+        &self,
+        cmd: &RollSegment,
+    ) -> Result<MetadataCommand, MetadataError> {
+        let mid = self.compute_midpoint();
+        if !self.valid_split_point(&mid) {
+            return Err(MetadataError::InvalidSplitPoint);
+        }
+        Ok(MetadataCommand::SplitRange(SplitRange {
+            topic_id: cmd.topic_id,
+            range_id: cmd.range_id,
+            split_point: mid,
+            created_at: cmd.sealed_at,
+            left_replica_set: cmd.new_replica_set.clone(),
+            right_replica_set: cmd.new_replica_set.clone(),
+        }))
+    }
+
     pub(crate) fn roll_segment(
         &mut self,
         segment_to_seal: SegmentId,
@@ -208,13 +228,10 @@ impl RangeMeta {
         if !self.is_next_to(other) {
             return Err(MetadataError::RangesNotAdjacent);
         }
+        self.validate_sealable()?;
+        other.validate_sealable()?;
 
-        let (merged_start, merged_end) = if self.keyspace_start <= other.keyspace_start {
-            (self.keyspace_start.clone(), other.keyspace_end.clone())
-        } else {
-            (other.keyspace_start.clone(), self.keyspace_end.clone())
-        };
-
+        let (merged_start, merged_end) = self.merged_keyspace(other);
         self.seal(requested_at)?;
         other.seal(requested_at)?;
         self.merged_into = Some(merged_id);
@@ -226,17 +243,30 @@ impl RangeMeta {
             replica_set,
             requested_at,
         );
-
-        // To make sure of determinsim
-        let merged_from = if self.range_id < other.range_id {
-            [self.range_id, other.range_id]
-        } else {
-            [other.range_id, self.range_id]
-        };
-
-        merged.merged_from = Some(merged_from);
-
+        merged.merged_from = Some(Self::ordered_pair(self.range_id, other.range_id));
         Ok(merged)
+    }
+
+    fn merged_keyspace(&self, other: &RangeMeta) -> (Vec<u8>, Vec<u8>) {
+        if self.keyspace_start <= other.keyspace_start {
+            (self.keyspace_start.clone(), other.keyspace_end.clone())
+        } else {
+            (other.keyspace_start.clone(), self.keyspace_end.clone())
+        }
+    }
+
+    fn ordered_pair(a: RangeId, b: RangeId) -> [RangeId; 2] {
+        if a < b { [a, b] } else { [b, a] }
+    }
+
+    fn validate_sealable(&self) -> Result<(), MetadataError> {
+        if let Some(seg_id) = self.active_segment
+            && let Some(seg) = self.segments.get(&seg_id)
+            && seg.state != SegmentState::Active
+        {
+            return Err(MetadataError::SegmentNotActive);
+        }
+        Ok(())
     }
 
     pub(crate) fn seal(&mut self, created_at: u64) -> Result<(), MetadataError> {
@@ -291,6 +321,72 @@ impl RangeMeta {
         let r2_recent = r2.seal_history.recent_seal_count(now);
 
         r1_recent == MERGE_SEAL_THRESHOLD && r2_recent == MERGE_SEAL_THRESHOLD
+    }
+
+    #[cfg(test)]
+    fn assert_invariants(&self) {
+        self.assert_active_segment_state();
+        for sid in self.segments.keys() {
+            assert!(
+                sid.0 < self.next_segment_id,
+                "segment ID >= next_segment_id"
+            );
+        }
+        self.assert_sealed_segments();
+        assert!(
+            self.split_into.is_none() || self.merged_into.is_none(),
+            "range both split and merged"
+        );
+        self.assert_seal_history();
+    }
+
+    #[cfg(test)]
+    fn assert_active_segment_state(&self) {
+        match self.state {
+            RangeState::Active => {
+                assert!(
+                    self.active_segment.is_some(),
+                    "active range missing active_segment"
+                );
+                let seg_id = self.active_segment.unwrap();
+                let seg = self
+                    .segments
+                    .get(&seg_id)
+                    .expect("active_segment points to missing segment");
+                assert_eq!(
+                    seg.state,
+                    SegmentState::Active,
+                    "active_segment not in Active state"
+                );
+            }
+            RangeState::Sealed | RangeState::Deleting => {
+                assert!(
+                    self.active_segment.is_none(),
+                    "sealed/deleting range has active_segment"
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_sealed_segments(&self) {
+        for seg in self.segments.values() {
+            if seg.state == SegmentState::Sealed {
+                assert!(
+                    seg.end_offset.is_some(),
+                    "sealed segment missing end_offset"
+                );
+                assert!(seg.sealed_at.is_some(), "sealed segment missing sealed_at");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_seal_history(&self) {
+        let ts = &self.seal_history.seal_timestamps;
+        for i in 1..ts.len() {
+            assert!(ts[i - 1] <= ts[i], "seal_history timestamps not sorted");
+        }
     }
 }
 
@@ -353,8 +449,63 @@ impl TopicMeta {
             .then_some(())
             .ok_or(MetadataError::TopicNotActive(self.id))
     }
+    pub(crate) fn is_merge_eligible(&self) -> bool {
+        self.state == TopicState::Active && self.can_split() && self.active_ranges.len() >= 2
+    }
+
     pub(crate) fn can_split(&self) -> bool {
         self.storage_policy.partition_strategy != PartitionStrategy::Fixed
+    }
+
+    pub(crate) fn find_mergeable_pair(&self, now: u64) -> Option<MetadataCommand> {
+        if !self.is_merge_eligible() {
+            return None;
+        }
+        self.active_ranges.windows(2).find_map(|pair| {
+            self.try_merge_pair(&self.ranges[&pair[0]], &self.ranges[&pair[1]], now)
+        })
+    }
+
+    fn try_merge_pair(&self, r1: &RangeMeta, r2: &RangeMeta, now: u64) -> Option<MetadataCommand> {
+        if r1.state != RangeState::Active || r2.state != RangeState::Active {
+            return None;
+        }
+        if !r1.mergeable_with(r2, now) {
+            return None;
+        }
+        let replica_set = r1
+            .active_segment
+            .and_then(|sid| r1.segments.get(&sid))
+            .map(|s| s.replica_set.clone())
+            .unwrap_or_default();
+        Some(MetadataCommand::MergeRange(MergeRange {
+            topic_id: self.id,
+            range_id_1: r1.range_id,
+            range_id_2: r2.range_id,
+            created_at: now,
+            merged_replica_set: replica_set,
+        }))
+    }
+
+    pub(crate) fn execute_split(
+        &mut self,
+        cmd: SplitRange,
+    ) -> Result<(RangeId, RangeId), MetadataError> {
+        let left_id = RangeId(self.next_range_id);
+        let right_id = RangeId(self.next_range_id + 1);
+        let range = self
+            .ranges
+            .get_mut(&cmd.range_id)
+            .ok_or(MetadataError::RangeNotFound)?;
+        let (left, right) = range.split(cmd, left_id, right_id)?;
+        let parent_range_id = range.range_id;
+        self.next_range_id += 2;
+        self.active_ranges.retain(|id| *id != parent_range_id);
+        self.ranges.insert(left_id, left);
+        self.ranges.insert(right_id, right);
+        self.insert_range_sorted(left_id);
+        self.insert_range_sorted(right_id);
+        Ok((left_id, right_id))
     }
 
     pub(crate) fn insert_range_sorted(&mut self, range_id: RangeId) {
@@ -387,6 +538,66 @@ impl TopicMeta {
 
         for range in self.ranges.values_mut() {
             range.delete();
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn assert_invariants(&self) {
+        for rid in self.ranges.keys() {
+            assert!(rid.0 < self.next_range_id, "range ID >= next_range_id");
+        }
+        if self.state == TopicState::Active {
+            self.assert_keyspace_coverage();
+        }
+        for range in self.ranges.values() {
+            range.assert_invariants();
+            self.assert_split_children_cooldown(range);
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_keyspace_coverage(&self) {
+        if self.active_ranges.is_empty() {
+            return;
+        }
+        let ranges: Vec<&RangeMeta> = self
+            .active_ranges
+            .iter()
+            .map(|id| &self.ranges[id])
+            .collect();
+        assert_eq!(
+            ranges[0].keyspace_start, KEYSPACE_MIN,
+            "first range must start at MIN"
+        );
+        assert_eq!(
+            ranges.last().unwrap().keyspace_end,
+            KEYSPACE_MAX,
+            "last range must end at MAX"
+        );
+        for w in ranges.windows(2) {
+            assert_eq!(
+                w[0].keyspace_end, w[1].keyspace_start,
+                "keyspace gap between active ranges"
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_split_children_cooldown(&self, range: &RangeMeta) {
+        let Some([left, right]) = range.split_into else {
+            return;
+        };
+        if let Some(left_range) = self.ranges.get(&left) {
+            assert!(
+                left_range.seal_history.created_by_split_at.is_some(),
+                "split child missing created_by_split_at"
+            );
+        }
+        if let Some(right_range) = self.ranges.get(&right) {
+            assert!(
+                right_range.seal_history.created_by_split_at.is_some(),
+                "split child missing created_by_split_at"
+            );
         }
     }
 }

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -32,23 +32,16 @@ impl MultiRaftActor {
     ) {
         let mut store = MultiRaft::new(node_id, storage);
         let mut buf = Vec::with_capacity(64);
-        let mut deferred: Vec<Box<dyn FnOnce() + Send>> = Vec::with_capacity(64);
 
         loop {
             if mailbox.recv_many(&mut buf, 64).await == 0 {
                 break;
             }
-
             for cmd in buf.drain(..) {
-                let (store_cmd, on_reply) = cmd.split();
-                let reply = store.handle_command(store_cmd);
-                if let Some(cb) = on_reply {
-                    deferred.push(Box::new(move || cb(reply)));
-                }
+                store.process(cmd);
             }
 
             let mut packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>> = HashMap::new();
-
             for event in store.flush() {
                 match event {
                     RaftEvent::OutboundRaftPacket(pkt) => {
@@ -70,14 +63,11 @@ impl MultiRaftActor {
                     }
                 }
             }
-
-            for (_, packets) in packets_by_target {
+            for packets in packets_by_target.into_values() {
                 let _ = transport_tx.send(RaftTransportCommand::Send(packets)).await;
             }
 
-            for cb in deferred.drain(..) {
-                cb();
-            }
+            store.fire_deferred();
         }
     }
 }

--- a/src/clusters/raft/messages/actor.rs
+++ b/src/clusters/raft/messages/actor.rs
@@ -3,7 +3,7 @@ use tokio::sync::oneshot;
 use crate::clusters::NodeId;
 use crate::clusters::swims::ShardGroupId;
 
-use super::command::{MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand};
+use super::command::{MultiRaftCommand, ProposeError, RaftCommand};
 use super::timer::RaftTimeoutCallback;
 
 /// Commands received by the MultiRaftActor from external sources (tokio-dependent).
@@ -36,35 +36,7 @@ impl From<RaftTimeoutCallback> for MultiRaftActorCommand {
     }
 }
 
-pub type OnReply = Box<dyn FnOnce(MultiRaftReply) + Send>;
-
-impl MultiRaftActorCommand {
-    pub(crate) fn split(self) -> (MultiRaftCommand, Option<OnReply>) {
-        match self {
-            Self::Command(cmd) => (cmd, None),
-            Self::GetLeader { group_id, reply } => (
-                MultiRaftCommand::GetLeader { group_id },
-                Some(Box::new(move |r| {
-                    if let MultiRaftReply::GetLeader(v) = r {
-                        let _ = reply.send(v);
-                    }
-                })),
-            ),
-            Self::Propose {
-                shard_group_id,
-                command,
-                reply,
-            } => (
-                MultiRaftCommand::Propose {
-                    shard_group_id,
-                    command,
-                },
-                Some(Box::new(move |r| {
-                    if let MultiRaftReply::Propose(v) = r {
-                        let _ = reply.send(v);
-                    }
-                })),
-            ),
-        }
-    }
+pub(crate) enum DeferredReply {
+    GetLeader(oneshot::Sender<Option<NodeId>>, Option<NodeId>),
+    Propose(oneshot::Sender<Result<(), ProposeError>>, Result<(), ProposeError>),
 }

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -3,8 +3,8 @@ use std::hash::{Hash, Hasher};
 
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::{
-    LogMutation, MultiRaftCommand, MultiRaftReply, ProposeError, RaftCommand, RaftEvent, RaftRpc,
-    RaftTimeoutCallback,
+    DeferredReply, LogMutation, MultiRaftActorCommand, MultiRaftCommand, MultiRaftReply,
+    ProposeError, RaftCommand, RaftEvent, RaftRpc, RaftTimeoutCallback,
 };
 use crate::clusters::raft::state::{Raft, TimerSeqs};
 
@@ -19,6 +19,7 @@ pub(crate) struct MultiRaft {
     seq_counter: RaftTimerTokenGenerator,
     dirty: HashSet<ShardGroupId>,
     pending_events: Vec<RaftEvent>,
+    deferred: Vec<DeferredReply>,
 }
 
 impl MultiRaft {
@@ -30,6 +31,40 @@ impl MultiRaft {
             seq_counter: RaftTimerTokenGenerator::default(),
             dirty: HashSet::new(),
             pending_events: Vec::new(),
+            deferred: Vec::new(),
+        }
+    }
+
+    pub(crate) fn process(&mut self, cmd: MultiRaftActorCommand) {
+        match cmd {
+            MultiRaftActorCommand::Command(c) => {
+                self.handle_command(c);
+            }
+            MultiRaftActorCommand::GetLeader { group_id, reply } => {
+                let result = self.get_leader(group_id);
+                self.deferred.push(DeferredReply::GetLeader(reply, result));
+            }
+            MultiRaftActorCommand::Propose {
+                shard_group_id,
+                command,
+                reply,
+            } => {
+                let result = self.propose(shard_group_id, command);
+                self.deferred.push(DeferredReply::Propose(reply, result));
+            }
+        }
+    }
+
+    pub(crate) fn fire_deferred(&mut self) {
+        for reply in self.deferred.drain(..) {
+            match reply {
+                DeferredReply::GetLeader(sender, v) => {
+                    let _ = sender.send(v);
+                }
+                DeferredReply::Propose(sender, v) => {
+                    let _ = sender.send(v);
+                }
+            }
         }
     }
 
@@ -175,15 +210,22 @@ impl MultiRaft {
     }
 
     fn add_node(&mut self, node_id: NodeId, affected_groups: Vec<ShardGroup>) {
-        for group in &affected_groups {
+        self.add_peer_to_existing_groups(&node_id, &affected_groups);
+        self.ensure_new_groups(affected_groups);
+    }
+
+    fn add_peer_to_existing_groups(&mut self, node_id: &NodeId, groups: &[ShardGroup]) {
+        for group in groups {
             if let Some(raft) = self.groups.get_mut(&group.id)
-                && !raft.has_peer(&node_id)
+                && !raft.has_peer(node_id)
             {
                 raft.add_peer(node_id.clone());
             }
         }
+    }
 
-        for group in affected_groups {
+    fn ensure_new_groups(&mut self, groups: Vec<ShardGroup>) {
+        for group in groups {
             if !self.groups.contains_key(&group.id) && group.members.contains(&self.node_id) {
                 self.add_group(group);
             }
@@ -207,12 +249,14 @@ impl MultiRaft {
 
     pub(crate) fn flush(&mut self) -> Vec<RaftEvent> {
         let dirty: Vec<ShardGroupId> = std::mem::take(&mut self.dirty).into_iter().collect();
-        let mut mutations: Vec<(ShardGroupId, LogMutation)> = vec![];
-        let mut last_indices: HashMap<ShardGroupId, u64> = HashMap::new();
+        self.flush_auto_proposals(&dirty);
+        let (mutations, last_indices) = self.collect_mutations(&dirty);
+        self.persist_and_advance(mutations, last_indices);
+        std::mem::take(&mut self.pending_events)
+    }
 
-        // Drain auto-proposals from previous flush and propose them.
-        // They become regular log entries, persisted in the same batch below.
-        for id in &dirty {
+    fn flush_auto_proposals(&mut self, dirty: &[ShardGroupId]) {
+        for id in dirty {
             let Some(raft) = self.groups.get_mut(id) else {
                 continue;
             };
@@ -222,30 +266,41 @@ impl MultiRaft {
                 }
             }
         }
+    }
 
-        for id in &dirty {
+    fn collect_mutations(
+        &mut self,
+        dirty: &[ShardGroupId],
+    ) -> (Vec<(ShardGroupId, LogMutation)>, HashMap<ShardGroupId, u64>) {
+        let mut mutations = vec![];
+        let mut last_indices = HashMap::new();
+        for id in dirty {
             let Some(raft) = self.groups.get_mut(id) else {
                 continue;
             };
-
             last_indices.insert(*id, raft.log_last_index());
             for log in raft.take_log_mutations() {
                 mutations.push((*id, log));
             }
             self.pending_events.extend(raft.take_events());
         }
+        (mutations, last_indices)
+    }
 
-        if !mutations.is_empty() {
-            self.storage.persist_mutations(mutations);
-
-            for (id, last_log_index) in &last_indices {
-                if let Some(raft) = self.groups.get_mut(id) {
-                    raft.advance_stabled_index(*last_log_index)
-                }
+    fn persist_and_advance(
+        &mut self,
+        mutations: Vec<(ShardGroupId, LogMutation)>,
+        last_indices: HashMap<ShardGroupId, u64>,
+    ) {
+        if mutations.is_empty() {
+            return;
+        }
+        self.storage.persist_mutations(mutations);
+        for (id, last_log_index) in last_indices {
+            if let Some(raft) = self.groups.get_mut(&id) {
+                raft.advance_stabled_index(last_log_index);
             }
         }
-
-        std::mem::take(&mut self.pending_events)
     }
 }
 

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -313,21 +313,24 @@ impl Raft {
         );
     }
 
-    // ! SAFETY: only candidates count votes.
     fn handle_request_vote_response(&mut self, resp: RequestVoteResponse) {
         if resp.term > self.current_term {
             self.step_down(resp.term);
             return;
         }
+        self.count_vote_if_eligible(resp);
+    }
 
-        if let Role::Candidate { votes_received } = &mut self.role
-            && resp.term == self.current_term
-            && resp.vote_granted
-        {
-            *votes_received += 1;
-            if *votes_received >= self.quorum() {
-                self.become_leader();
-            }
+    fn count_vote_if_eligible(&mut self, resp: RequestVoteResponse) {
+        let Role::Candidate { votes_received } = &mut self.role else {
+            return;
+        };
+        if resp.term != self.current_term || !resp.vote_granted {
+            return;
+        }
+        *votes_received += 1;
+        if *votes_received >= self.quorum() {
+            self.become_leader();
         }
     }
 
@@ -462,35 +465,45 @@ impl Raft {
     // ! - Candidates step down on same term : because receiving entries while being a candidate means another node already won.
     // ! - Followers process normally. All roles must respond.
     fn handle_append_entries(&mut self, from: NodeId, req: AppendEntries) {
-        // Stale term: reject.
         if req.term < self.current_term {
-            self.send_append_entries_response(from.clone(), false);
+            self.reject_append_entries(from);
             return;
         }
 
-        // If term is current or newer, recognize leader and reset to follower.
+        // ! recognizing leader must happen regardless of whether the log entries are accepted
+        // ! Even if the log consistency check fails and entries are rejected, the follower should not start a new election.
+        self.recognize_leader(&req);
+
+        if !self.check_log_consistency(req.prev_log_index, req.prev_log_term) {
+            self.reject_append_entries(from);
+            return;
+        }
+        self.replicate_entries(req.entries);
+        self.advance_follower_commit(req.leader_commit);
+        self.accept_append_entries(from);
+    }
+
+    fn recognize_leader(&mut self, req: &AppendEntries) {
         if req.term > self.current_term {
             self.step_down(req.term);
         } else if self.role != Role::Follower {
-            // Same term but we're candidate — step down.
             self.role = Role::Follower;
             self.peer_states.clear();
         }
-
         self.current_leader = Some(req.leader_id.clone());
         self.reset_election_timer();
+    }
 
-        // Log consistency check: prev_log_index must exist with matching term.
-        if req.prev_log_index > 0 {
-            let local_term = self.log_term_at(req.prev_log_index);
-            if local_term == 0 || local_term != req.prev_log_term {
-                self.send_append_entries_response(from, false);
-                return;
-            }
+    fn check_log_consistency(&self, prev_log_index: u64, prev_log_term: u64) -> bool {
+        if prev_log_index == 0 {
+            return true;
         }
+        let local_term = self.log_term_at(prev_log_index);
+        local_term != 0 && local_term == prev_log_term
+    }
 
-        // Append entries (truncate conflicting suffix first).
-        for entry in req.entries {
+    fn replicate_entries(&mut self, entries: Vec<LogEntry>) {
+        for entry in entries {
             let existing_term = self.log_term_at(entry.index);
             if existing_term != 0 && existing_term != entry.term {
                 self.log_truncate_from(entry.index);
@@ -499,14 +512,13 @@ impl Raft {
                 self.log_append(entry);
             }
         }
+    }
 
-        // Advance commit index.
-        if req.leader_commit > self.commit_index {
-            self.commit_index = req.leader_commit.min(self.log_last_index());
+    fn advance_follower_commit(&mut self, leader_commit: u64) {
+        if leader_commit > self.commit_index {
+            self.commit_index = leader_commit.min(self.log_last_index());
             self.apply_committed_entries();
         }
-
-        self.send_append_entries_response(from, true);
     }
 
     // ! SAFETY
@@ -539,6 +551,14 @@ impl Raft {
                 self.send_append_entries(resp.node_id);
             }
         }
+    }
+
+    fn accept_append_entries(&mut self, target: NodeId) {
+        self.send_append_entries_response(target, true);
+    }
+
+    fn reject_append_entries(&mut self, target: NodeId) {
+        self.send_append_entries_response(target, false);
     }
 
     fn send_append_entries_response(&mut self, target: NodeId, success: bool) {
@@ -655,46 +675,43 @@ impl Raft {
     fn apply_committed_entries(&mut self) {
         while self.last_applied_index < self.commit_index.min(self.stabled_index) {
             self.last_applied_index += 1;
-            let entry = match self.log_get(self.last_applied_index) {
-                Some(e) => e.clone(),
-                None => {
-                    tracing::error!(
-                        "[{}] committed entry at index {} missing from log",
-                        self.node_id,
-                        self.last_applied_index
-                    );
-                    break;
-                }
+            let Some(entry) = self.log_get(self.last_applied_index).cloned() else {
+                tracing::error!(
+                    "[{}] committed entry at index {} missing from log",
+                    self.node_id,
+                    self.last_applied_index
+                );
+                break;
             };
             match entry.command {
                 RaftCommand::Noop => {}
-                RaftCommand::Metadata(cmd) => {
-                    match self.state_machine.apply(cmd) {
-                        Ok(result) => {
-                            tracing::debug!(
-                                "[{}] Applied metadata at index {}: {:?}",
-                                self.node_id,
-                                entry.index,
-                                result
-                            );
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "[{}] Metadata apply error at index {}: {:?}",
-                                self.node_id,
-                                entry.index,
-                                e
-                            );
-                        }
-                    }
+                RaftCommand::Metadata(cmd) => self.apply_metadata_entry(cmd, entry.index),
+            }
+        }
+    }
 
-                    let proposals = self.state_machine.take_pending_proposals();
-                    if self.role == Role::Leader {
-                        for cmd in proposals {
-                            self.pending_proposals.push(RaftCommand::Metadata(cmd));
-                        }
-                    }
-                }
+    fn apply_metadata_entry(
+        &mut self,
+        cmd: crate::clusters::metadata::command::MetadataCommand,
+        index: u64,
+    ) {
+        match self.state_machine.apply(cmd) {
+            Ok(result) => tracing::debug!(
+                "[{}] Applied metadata at index {}: {:?}",
+                self.node_id,
+                index,
+                result
+            ),
+            Err(e) => tracing::error!(
+                "[{}] Metadata apply error at index {}: {:?}",
+                self.node_id,
+                index,
+                e
+            ),
+        }
+        if self.role == Role::Leader {
+            for cmd in self.state_machine.take_pending_proposals() {
+                self.pending_proposals.push(RaftCommand::Metadata(cmd));
             }
         }
     }

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -3,55 +3,59 @@
 use std::collections::{HashMap, HashSet};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use crate::clusters::raft::messages::MultiRaftActorCommand;
 use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::raft::messages::{OutboundRaftPacket, RaftTransportCommand, WireRaftMessage};
 use crate::clusters::swims::actor::SwimSender;
-use crate::clusters::swims::SwimQueryCommand;
 use crate::clusters::{BINCODE_CONFIG, NodeAddress, NodeId};
 use crate::net::{OwnedReadHalf, OwnedWriteHalf, TcpListener, TcpStream};
 
 struct RaftReader(OwnedReadHalf);
 
 impl RaftReader {
-    async fn read_node_id(&mut self) -> Option<NodeId> {
-        let len = self.0.read_u32().await.ok()? as usize;
-        if len > 1024 {
-            return None;
-        }
+    async fn read_node_id(&mut self) -> anyhow::Result<NodeId> {
+        let len = self.0.read_u32().await? as usize;
+        anyhow::ensure!(len <= 1024, "NodeId frame too large: {len} bytes");
         let mut buf = vec![0u8; len];
-        self.0.read_exact(&mut buf).await.ok()?;
-        bincode::decode_from_slice::<NodeId, _>(&buf, BINCODE_CONFIG)
-            .ok()
-            .map(|(id, _)| id)
+        self.0.read_exact(&mut buf).await?;
+        let (id, _) = bincode::decode_from_slice::<NodeId, _>(&buf, BINCODE_CONFIG)?;
+        Ok(id)
     }
 
-    async fn read_message(&mut self) -> Option<WireRaftMessage> {
-        let len = self.0.read_u32().await.ok()? as usize;
-        if len > 4 * 1024 * 1024 {
-            return None;
-        }
+    async fn read_message(&mut self) -> anyhow::Result<WireRaftMessage> {
+        let len = self.0.read_u32().await? as usize;
+        anyhow::ensure!(
+            len <= 4 * 1024 * 1024,
+            "Raft message frame too large: {len} bytes"
+        );
         let mut buf = vec![0u8; len];
-        self.0.read_exact(&mut buf).await.ok()?;
-        bincode::decode_from_slice::<WireRaftMessage, _>(&buf, BINCODE_CONFIG)
-            .ok()
-            .map(|(msg, _)| msg)
+        self.0.read_exact(&mut buf).await?;
+        let (msg, _) = bincode::decode_from_slice::<WireRaftMessage, _>(&buf, BINCODE_CONFIG)?;
+        Ok(msg)
     }
 
     async fn run(mut self, tx: mpsc::Sender<MultiRaftActorCommand>) {
-        while let Some(msg) = self.read_message().await {
-            let _ = tx
-                .send(
-                    MultiRaftCommand::PacketReceived {
-                        shard_group_id: msg.shard_group_id,
-                        from: msg.sender,
-                        rpc: msg.rpc,
-                    }
-                    .into(),
-                )
-                .await;
+        loop {
+            match self.read_message().await {
+                Ok(msg) => {
+                    let _ = tx
+                        .send(
+                            MultiRaftCommand::PacketReceived {
+                                shard_group_id: msg.shard_group_id,
+                                from: msg.sender,
+                                rpc: msg.rpc,
+                            }
+                            .into(),
+                        )
+                        .await;
+                }
+                Err(e) => {
+                    tracing::debug!("RaftReader connection closed: {e}");
+                    break;
+                }
+            }
         }
     }
 }
@@ -88,7 +92,8 @@ impl RaftWriters {
         let (read_half, write_half) = stream.into_split();
         let mut reader = RaftReader(read_half);
 
-        let Some(peer_id) = reader.read_node_id().await else {
+        let Ok(peer_id) = reader.read_node_id().await else {
+            tracing::error!("Failed to read peer NodeId during accept");
             return;
         };
 
@@ -100,15 +105,22 @@ impl RaftWriters {
         tokio::spawn(reader.run(raft_tx.clone()));
     }
 
-    /// Send a batch of outbound packets, grouping by target NodeId.
-    /// Encodes all messages per target into a single buffer, writes once.
     async fn send(
         &mut self,
         packets: Vec<OutboundRaftPacket>,
         raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
         swim_tx: &SwimSender,
     ) {
-        // Group by target — flush_dirty already groups, but be defensive.
+        let by_target = self.group_packets(packets);
+        for (target_id, msgs) in by_target {
+            self.send_to_target(target_id, msgs, raft_tx, swim_tx).await;
+        }
+    }
+
+    fn group_packets(
+        &self,
+        packets: Vec<OutboundRaftPacket>,
+    ) -> HashMap<NodeId, Vec<WireRaftMessage>> {
         let mut by_target: HashMap<NodeId, Vec<WireRaftMessage>> = HashMap::new();
         for pkt in packets {
             if self.dead_peers.contains(&pkt.target) {
@@ -123,59 +135,69 @@ impl RaftWriters {
                     rpc: pkt.rpc,
                 });
         }
+        by_target
+    }
 
-        for (target_id, msgs) in by_target {
-            // Try existing writer
-            if self.writers.contains_key(&target_id)
-                && self.write_messages_to(&target_id, &msgs).await.is_ok()
-            {
-                continue;
-            }
-
-            // Establish new connection
-            let Some(node_addr) = self.resolve_address(&target_id, swim_tx).await else {
-                tracing::warn!(
-                    "[{}] Cannot resolve address for {:?}",
-                    self.node_id,
-                    target_id
-                );
-                continue;
-            };
-
-            let Ok(stream) = TcpStream::connect(node_addr.cluster_addr).await else {
-                tracing::warn!(
-                    "[{}] Failed to connect to {} ({:?})",
-                    self.node_id,
-                    node_addr.cluster_addr,
-                    target_id
-                );
-                continue;
-            };
-
-            let (read_half, write_half) = stream.into_split();
-            self.writers.insert(target_id.clone(), write_half);
-
-            if let Err(e) = self.handshake(&target_id).await {
-                tracing::warn!(
-                    "[{}] Handshake with {:?} failed: {e}",
-                    self.node_id,
-                    target_id
-                );
-                continue;
-            }
-
-            if let Err(e) = self.write_messages_to(&target_id, &msgs).await {
-                tracing::warn!(
-                    "[{}] Write {} msgs to {:?} failed: {e}",
-                    self.node_id,
-                    msgs.len(),
-                    target_id
-                );
-                continue;
-            }
-
-            tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
+    async fn send_to_target(
+        &mut self,
+        target_id: NodeId,
+        msgs: Vec<WireRaftMessage>,
+        raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
+        swim_tx: &SwimSender,
+    ) {
+        if self.writers.contains_key(&target_id)
+            && self.write_messages_to(&target_id, &msgs).await.is_ok()
+        {
+            return;
         }
+        self.connect_and_send(target_id, msgs, raft_tx, swim_tx)
+            .await;
+    }
+
+    async fn connect_and_send(
+        &mut self,
+        target_id: NodeId,
+        msgs: Vec<WireRaftMessage>,
+        raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
+        swim_tx: &SwimSender,
+    ) {
+        let Some(node_addr) = self.resolve_address(&target_id, swim_tx).await else {
+            tracing::warn!(
+                "[{}] Cannot resolve address for {:?}",
+                self.node_id,
+                target_id
+            );
+            return;
+        };
+        let Ok(stream) = TcpStream::connect(node_addr.cluster_addr).await else {
+            tracing::warn!(
+                "[{}] Failed to connect to {} ({:?})",
+                self.node_id,
+                node_addr.cluster_addr,
+                target_id
+            );
+            return;
+        };
+        let (read_half, write_half) = stream.into_split();
+        self.writers.insert(target_id.clone(), write_half);
+        if let Err(e) = self.handshake(&target_id).await {
+            tracing::warn!(
+                "[{}] Handshake with {:?} failed: {e}",
+                self.node_id,
+                target_id
+            );
+            return;
+        }
+        if let Err(e) = self.write_messages_to(&target_id, &msgs).await {
+            tracing::warn!(
+                "[{}] Write {} msgs to {:?} failed: {e}",
+                self.node_id,
+                msgs.len(),
+                target_id
+            );
+            return;
+        }
+        tokio::spawn(RaftReader(read_half).run(raft_tx.clone()));
     }
 
     fn disconnect(&mut self, peer_id: NodeId) {
@@ -197,22 +219,16 @@ impl RaftWriters {
         if let Some(&addr) = self.addr_cache.get(node_id) {
             return Some(addr);
         }
-
-        let (tx, rx) = oneshot::channel();
-        let query = SwimQueryCommand::ResolveAddress {
-            node_id: node_id.clone(),
-            reply: tx,
-        };
-
-        if swim_tx.send(query).await.is_err() {
-            return None;
-        }
-
-        if let Ok(Some(node_addr)) = rx.await {
-            self.addr_cache.insert(node_id.clone(), node_addr);
-            Some(node_addr)
-        } else {
-            None
+        match swim_tx.resolve_address(node_id.clone()).await {
+            Ok(Some(node_addr)) => {
+                self.addr_cache.insert(node_id.clone(), node_addr);
+                Some(node_addr)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                tracing::debug!("Resolve address for {:?} failed: {e}", node_id);
+                None
+            }
         }
     }
 
@@ -490,5 +506,4 @@ mod tests {
 
         sim.run()
     }
-
 }

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::clusters::NodeAddress;
 use crate::clusters::NodeId;
 use crate::clusters::raft::messages::MultiRaftActorCommand;
-use crate::clusters::raft::messages::MultiRaftCommand;
 use crate::clusters::swims::swim::Swim;
 use crate::schedulers::ticker_message::TickerCommand;
 
@@ -21,6 +20,7 @@ impl SwimActor {
         let (swim_sender, swim_mailbox) = mpsc::channel(buffer);
         (SwimSender(swim_sender), swim_mailbox)
     }
+
     pub async fn run(
         mut mailbox: mpsc::Receiver<SwimActorCommand>,
         mut state: Swim,
@@ -29,59 +29,21 @@ impl SwimActor {
         raft_tx: mpsc::Sender<MultiRaftActorCommand>,
     ) {
         tracing::info!("[{}] SwimActor started.", state.node_id);
-        Self::flush(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
 
         let mut buf = Vec::with_capacity(64);
         loop {
+            Self::flush_events(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
+
             if mailbox.recv_many(&mut buf, 64).await == 0 {
                 break;
             }
             for event in buf.drain(..) {
-                match event {
-                    SwimActorCommand::Protocol(cmd) => match cmd {
-                        SwimCommand::PacketReceived { src, packet } => state.step(src, packet),
-                        SwimCommand::Timeout(event) => state.handle_timeout(event),
-                        SwimCommand::AnnounceShardLeader(event) => state.announce_shard_leader(
-                            event.shard_group_id,
-                            event.leader_node_id,
-                            event.term,
-                        ),
-                    },
-                    SwimActorCommand::Query(q) => Self::handle_query(&state, q),
-                }
-            }
-            Self::flush(&mut state, &transport_tx, &scheduler_tx, &raft_tx).await;
-        }
-    }
-
-    fn handle_query(state: &Swim, command: SwimQueryCommand) {
-        match command {
-            SwimQueryCommand::GetMembers { reply } => {
-                let _ = reply.send(state.get_members());
-            }
-            SwimQueryCommand::ResolveAddress { node_id, reply } => {
-                let _ = reply.send(state.resolve_address(&node_id));
-            }
-            SwimQueryCommand::ResolveShardGroup { key, reply } => {
-                let _ = reply.send(state.topology.shard_group_for(&key).cloned());
-            }
-            SwimQueryCommand::ResolveShardLeader {
-                shard_group_id,
-                reply,
-            } => {
-                let _ = reply.send(state.topology.shard_leader(shard_group_id).cloned());
-            }
-            SwimQueryCommand::GetShardInfo { key, reply } => {
-                let result = state.topology.shard_group_for(&key).cloned().map(|group| {
-                    let leader = state.topology.shard_leader(group.id).cloned();
-                    (group, leader)
-                });
-                let _ = reply.send(result);
+                state.dispatch(event);
             }
         }
     }
 
-    async fn flush(
+    async fn flush_events(
         state: &mut Swim,
         transport_tx: &mpsc::Sender<OutboundPacket>,
         scheduler_tx: &mpsc::Sender<TickerCommand<SwimTimer>>,
@@ -96,45 +58,10 @@ impl SwimActor {
                     let _ = scheduler_tx.send(cmd.into()).await;
                 }
                 SwimEvent::Membership(m) => {
-                    if let Some(cmd) = Self::to_raft_command(state, m) {
+                    if let Some(cmd) = state.to_raft_command(m) {
                         let _ = raft_tx.send(cmd).await;
                     }
                 }
-            }
-        }
-    }
-
-    /// Translate a membership event into a MultiRaftActor command.
-    /// Returns `None` for self-events and nodes with no shard groups.
-    fn to_raft_command(state: &Swim, event: MembershipEvent) -> Option<MultiRaftActorCommand> {
-        if *event.node_id() == state.node_id {
-            return None;
-        }
-
-        match event {
-            MembershipEvent::NodeDead { node_id } => Some(
-                MultiRaftCommand::HandleNodeDeath {
-                    dead_node_id: node_id,
-                }
-                .into(),
-            ),
-            MembershipEvent::NodeAlive { node_id, .. } => {
-                let affected_groups: Vec<_> = state
-                    .topology
-                    .shard_groups_for_node(&node_id)
-                    .into_iter()
-                    .cloned()
-                    .collect();
-                if affected_groups.is_empty() {
-                    return None;
-                }
-                Some(
-                    MultiRaftCommand::HandleNodeJoin {
-                        new_node_id: node_id,
-                        affected_groups,
-                    }
-                    .into(),
-                )
             }
         }
     }
@@ -151,50 +78,53 @@ impl SwimSender {
         self.0.send(cmd.into()).await
     }
 
-    pub(crate) async fn resolve_shard_group(&self, resource_key: Vec<u8>) -> Option<ShardGroup> {
+    pub(crate) async fn resolve_shard_group(
+        &self,
+        resource_key: Vec<u8>,
+    ) -> anyhow::Result<Option<ShardGroup>> {
         let (send, recv) = tokio::sync::oneshot::channel();
         self.send(SwimQueryCommand::ResolveShardGroup {
             key: resource_key,
             reply: send,
         })
-        .await
-        .ok()?;
-        recv.await.ok()?
+        .await?;
+        Ok(recv.await?)
     }
+
     pub(crate) async fn resolve_shard_leader(
         &self,
         shard_group_id: ShardGroupId,
-    ) -> Option<ShardLeaderEntry> {
+    ) -> anyhow::Result<Option<ShardLeaderEntry>> {
         let (send, recv) = tokio::sync::oneshot::channel();
         self.send(SwimQueryCommand::ResolveShardLeader {
             shard_group_id,
             reply: send,
         })
-        .await
-        .ok()?;
-        recv.await.ok()?
+        .await?;
+        Ok(recv.await?)
     }
 
     pub(crate) async fn get_shard_info(
         &self,
         key: Vec<u8>,
-    ) -> Option<(ShardGroup, Option<ShardLeaderEntry>)> {
+    ) -> anyhow::Result<Option<(ShardGroup, Option<ShardLeaderEntry>)>> {
         let (send, recv) = tokio::sync::oneshot::channel();
         self.send(SwimQueryCommand::GetShardInfo { key, reply: send })
-            .await
-            .ok()?;
-        recv.await.ok()?
+            .await?;
+        Ok(recv.await?)
     }
 
-    pub(crate) async fn resolve_address(&self, node_id: NodeId) -> Option<NodeAddress> {
+    pub(crate) async fn resolve_address(
+        &self,
+        node_id: NodeId,
+    ) -> anyhow::Result<Option<NodeAddress>> {
         let (send, recv) = tokio::sync::oneshot::channel();
         self.send(SwimQueryCommand::ResolveAddress {
             node_id,
             reply: send,
         })
-        .await
-        .ok()?;
-        recv.await.ok()?
+        .await?;
+        Ok(recv.await?)
     }
 }
 

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -58,7 +58,7 @@ impl SwimActor {
                     let _ = scheduler_tx.send(cmd.into()).await;
                 }
                 SwimEvent::Membership(m) => {
-                    if let Some(cmd) = state.to_raft_command(m) {
+                    if let Some(cmd) = m.into_raft_command(&state.node_id, &state.topology) {
                         let _ = raft_tx.send(cmd).await;
                     }
                 }

--- a/src/clusters/swims/messages/command.rs
+++ b/src/clusters/swims/messages/command.rs
@@ -1,8 +1,9 @@
 use std::net::SocketAddr;
 
-use crate::clusters::raft::messages::LeaderChange;
-use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::NodeId;
+use crate::clusters::raft::messages::{LeaderChange, MultiRaftActorCommand, MultiRaftCommand};
+use crate::clusters::swims::peer_discovery::JoinAttempt;
+use crate::clusters::swims::topology::Topology;
 use crate::schedulers::ticker_message::TimerCommand;
 
 use super::packet::{OutboundPacket, SwimPacket};
@@ -66,6 +67,41 @@ impl MembershipEvent {
         match self {
             MembershipEvent::NodeAlive { node_id, .. } => node_id,
             MembershipEvent::NodeDead { node_id } => node_id,
+        }
+    }
+
+    pub(crate) fn into_raft_command(
+        self,
+        local_node_id: &NodeId,
+        topology: &Topology,
+    ) -> Option<MultiRaftActorCommand> {
+        if self.node_id() == local_node_id {
+            return None;
+        }
+        match self {
+            MembershipEvent::NodeDead { node_id } => Some(
+                MultiRaftCommand::HandleNodeDeath {
+                    dead_node_id: node_id,
+                }
+                .into(),
+            ),
+            MembershipEvent::NodeAlive { node_id, .. } => {
+                let affected_groups: Vec<_> = topology
+                    .shard_groups_for_node(&node_id)
+                    .into_iter()
+                    .cloned()
+                    .collect();
+                if affected_groups.is_empty() {
+                    return None;
+                }
+                Some(
+                    MultiRaftCommand::HandleNodeJoin {
+                        new_node_id: node_id,
+                        affected_groups,
+                    }
+                    .into(),
+                )
+            }
         }
     }
 }

--- a/src/clusters/swims/messages/packet.rs
+++ b/src/clusters/swims/messages/packet.rs
@@ -45,23 +45,28 @@ impl SwimPacket {
     }
 }
 
-impl Display for SwimPacket {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let (kind, header, target) = match self {
+impl SwimPacket {
+    fn kind_header_target(&self) -> (&str, &SwimHeader, Option<&SocketAddr>) {
+        match self {
             Self::Ping(h) => ("PING", h, None),
             Self::Ack(h) => ("ACK", h, None),
             Self::PingReq { target, header } => ("PINGREQ", header, Some(target)),
-        };
-
-        write!(f, "[{}] seq: {}, ", kind, header.seq)?;
-
-        if let Some(t) = target {
-            write!(f, "target: {}, ", t)?;
         }
+    }
+}
 
+impl Display for SwimPacket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let (kind, header, target) = self.kind_header_target();
+        let target_str = target
+            .map(|t| format!(", target: {}", t))
+            .unwrap_or_default();
         write!(
             f,
-            "source: {} (inc:{}), gossip: {}",
+            "[{}] seq: {}{}, source: {} (inc:{}), gossip: {}",
+            kind,
+            header.seq,
+            target_str,
             header.source_node_id,
             header.source_incarnation,
             header.gossip.len()

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::swims::topology::Topology;
 
@@ -160,31 +161,51 @@ impl Swim {
                 seq,
                 target_node_id,
                 phase,
-            } => match (phase, target_node_id) {
-                (SwimTimerKind::DirectProbe, Some(target)) => {
-                    self.start_indirect_probe(target, seq)
-                }
-                (SwimTimerKind::IndirectProbe, Some(target)) => self.try_mark_suspect(target),
-                (SwimTimerKind::Suspect, Some(target)) => self.try_mark_dead(target, seq),
-                (SwimTimerKind::ProxyPing, None) => {
-                    self.pending_indirect_pings.remove(&seq);
-                }
-                (SwimTimerKind::JoinTry(join_attempt), None) => {
-                    if join_attempt.remaining_attempts == 0 {
-                        tracing::warn!(
-                            "[{}] Join to {} exhausted all attempts — giving up",
-                            self.node_id,
-                            join_attempt.seed_addr
-                        );
-                        return;
-                    }
-                    self.handle_join(join_attempt);
-                }
-                _ => {}
-            },
+            } => {
+                self.handle_timed_out(seq, target_node_id, phase);
+            }
         }
         #[cfg(test)]
         self.assert_invariants();
+    }
+
+    fn handle_timed_out(&mut self, seq: u32, target_node_id: Option<NodeId>, phase: SwimTimerKind) {
+        if let Some(target) = target_node_id {
+            self.handle_probe_timeout(seq, target, phase);
+        } else {
+            self.handle_non_probe_timeout(seq, phase);
+        }
+    }
+
+    fn handle_probe_timeout(&mut self, seq: u32, target: NodeId, phase: SwimTimerKind) {
+        match phase {
+            SwimTimerKind::DirectProbe => self.start_indirect_probe(target, seq),
+            SwimTimerKind::IndirectProbe => self.try_mark_suspect(target),
+            SwimTimerKind::Suspect => self.try_mark_dead(target, seq),
+            SwimTimerKind::ProxyPing | SwimTimerKind::JoinTry(_) => {}
+        }
+    }
+
+    fn handle_non_probe_timeout(&mut self, seq: u32, phase: SwimTimerKind) {
+        match phase {
+            SwimTimerKind::ProxyPing => {
+                self.pending_indirect_pings.remove(&seq);
+            }
+            SwimTimerKind::JoinTry(attempt) => self.handle_join_timeout(attempt),
+            SwimTimerKind::DirectProbe | SwimTimerKind::IndirectProbe | SwimTimerKind::Suspect => {}
+        }
+    }
+
+    fn handle_join_timeout(&mut self, join_attempt: JoinAttempt) {
+        if join_attempt.remaining_attempts == 0 {
+            tracing::warn!(
+                "[{}] Join to {} exhausted all attempts — giving up",
+                self.node_id,
+                join_attempt.seed_addr
+            );
+            return;
+        }
+        self.handle_join(join_attempt);
     }
 
     fn start_probe(&mut self) {
@@ -231,27 +252,7 @@ impl Swim {
             return;
         };
 
-        // * OPT : pre-allocation
-        let mut peer_addrs = Vec::with_capacity(INDIRECT_PING_COUNT);
-
-        for _ in 0..self.live_node_tracker.len() {
-            let Some(peer_node_id) = self.live_node_tracker.next() else {
-                break;
-            };
-
-            if peer_node_id == target_node_id || peer_node_id == self.node_id {
-                continue;
-            }
-
-            if let Some(peer_member) = self.members.get(&peer_node_id) {
-                peer_addrs.push(peer_member.addr.cluster_addr);
-
-                // * OPT : Check length ONLY after a successful insertion
-                if peer_addrs.len() == INDIRECT_PING_COUNT {
-                    break;
-                }
-            }
-        }
+        let peer_addrs = self.select_ping_peers(&target_node_id);
 
         if peer_addrs.is_empty() {
             self.try_mark_suspect(target_node_id);
@@ -275,6 +276,34 @@ impl Swim {
                 seq,
                 timer: SwimTimer::indirect_probe(target_node_id),
             }));
+    }
+
+    fn select_ping_peers(&mut self, target_node_id: &NodeId) -> Vec<SocketAddr> {
+        let mut peer_addrs = Vec::with_capacity(INDIRECT_PING_COUNT);
+        for _ in 0..self.live_node_tracker.len() {
+            let Some(peer_node_id) = self.live_node_tracker.next() else {
+                break;
+            };
+            if self.try_add_ping_peer(&peer_node_id, target_node_id, &mut peer_addrs) {
+                break;
+            }
+        }
+        peer_addrs
+    }
+
+    fn try_add_ping_peer(
+        &self,
+        peer: &NodeId,
+        target: &NodeId,
+        addrs: &mut Vec<SocketAddr>,
+    ) -> bool {
+        if *peer == *target || *peer == self.node_id {
+            return false;
+        }
+        if let Some(member) = self.members.get(peer) {
+            addrs.push(member.addr.cluster_addr);
+        }
+        addrs.len() == INDIRECT_PING_COUNT
     }
 
     fn try_mark_suspect(&mut self, target_node_id: NodeId) {
@@ -343,109 +372,108 @@ impl Swim {
     }
 
     pub fn step(&mut self, src: SocketAddr, packet: SwimPacket) {
-        // 1. Process Gossip (Piggybacked updates)
-        for member in packet.gossip() {
-            self.apply_membership_update(member.clone());
-        }
-
-        // Piggybacked shard leader gossip — typically few entries per packet (often zero).
-        // Count bounded by remaining byte budget after membership gossip and
-        // dissemination counter (3 × ceil(log₂(N)) retransmissions per entry).
-        for leader_info in packet.shard_leaders() {
-            self.apply_shard_leader_update(leader_info);
-        }
-
+        self.process_piggybacked_gossip(&packet);
         match packet {
-            SwimPacket::Ping(header) => {
-                tracing::info!(
-                    "[{}] ← Received Ping from {} ({}) seq={}",
-                    self.node_id,
-                    header.source_node_id,
-                    src,
-                    header.seq
-                );
-                self.handle_incarnation_check(
-                    header.source_node_id,
-                    src,
-                    header.source_incarnation,
-                );
-                let ack = SwimPacket::Ack(self.generate_swim_header(header.seq));
-
-                self.pending_events
-                    .push(SwimEvent::Packet(OutboundPacket::new(src, ack)))
-            }
-
-            SwimPacket::Ack(header) => {
-                tracing::info!(
-                    "[{}] ← Received Ack  from {} ({}) seq={}",
-                    self.node_id,
-                    header.source_node_id,
-                    src,
-                    header.seq
-                );
-                // TODO: should we ONLY handle Ack message with seq that we can identify?
-                self.handle_incarnation_check(
-                    header.source_node_id.clone(),
-                    src,
-                    header.source_incarnation,
-                );
-                self.pending_events
-                    .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
-                        seq: header.seq,
-                    }));
-
-                if let Some(ProxyPing {
-                    requester_addr,
-                    request_seq,
-                }) = self.pending_indirect_pings.remove(&header.seq)
-                {
-                    let gossip = self.gossip_buffer.collect(MAX_GOSSIP_BYTES);
-                    let used: usize = gossip.iter().map(|m| m.size()).sum();
-                    let remaining = MAX_GOSSIP_BYTES.saturating_sub(used);
-                    let shard_leaders = self.shard_leader_buffer.collect(remaining);
-                    let forwarded_ack = SwimPacket::Ack(SwimHeader {
-                        seq: request_seq,
-                        source_node_id: header.source_node_id,
-                        source_incarnation: header.source_incarnation,
-                        gossip,
-                        shard_leaders,
-                    });
-
-                    self.pending_events
-                        .push(SwimEvent::Packet(OutboundPacket::new(
-                            requester_addr,
-                            forwarded_ack,
-                        )));
-                }
-            }
-
-            SwimPacket::PingReq { header, target, .. } => {
-                self.handle_incarnation_check(
-                    header.source_node_id.clone(),
-                    src,
-                    header.source_incarnation,
-                );
-                let seq = self.next_seq();
-
-                self.pending_indirect_pings.insert(
-                    seq,
-                    ProxyPing {
-                        request_seq: header.seq,
-                        requester_addr: src,
-                    },
-                );
-                let ping = SwimPacket::Ping(self.generate_swim_header(seq));
-                self.pending_events
-                    .push(SwimEvent::Packet(OutboundPacket::new(target, ping)));
-                self.pending_events
-                    .push(SwimEvent::Timer(TimerCommand::SetSchedule {
-                        seq,
-                        timer: SwimTimer::proxy_ping(),
-                    }));
-            }
+            SwimPacket::Ping(header) => self.handle_ping(src, header),
+            SwimPacket::Ack(header) => self.handle_ack(src, header),
+            SwimPacket::PingReq { header, target, .. } => self.handle_ping_req(src, header, target),
         }
         #[cfg(test)]
         self.assert_invariants();
+    }
+
+    fn process_piggybacked_gossip(&mut self, packet: &SwimPacket) {
+        for member in packet.gossip() {
+            self.apply_membership_update(member.clone());
+        }
+        for leader_info in packet.shard_leaders() {
+            self.apply_shard_leader_update(leader_info);
+        }
+    }
+
+    fn handle_ping(&mut self, src: SocketAddr, header: SwimHeader) {
+        tracing::info!(
+            "[{}] ← Received Ping from {} ({}) seq={}",
+            self.node_id,
+            header.source_node_id,
+            src,
+            header.seq
+        );
+        self.handle_incarnation_check(header.source_node_id, src, header.source_incarnation);
+        let ack = SwimPacket::Ack(self.generate_swim_header(header.seq));
+        self.pending_events
+            .push(SwimEvent::Packet(OutboundPacket::new(src, ack)));
+    }
+
+    fn handle_ack(&mut self, src: SocketAddr, header: SwimHeader) {
+        tracing::info!(
+            "[{}] ← Received Ack  from {} ({}) seq={}",
+            self.node_id,
+            header.source_node_id,
+            src,
+            header.seq
+        );
+        self.handle_incarnation_check(
+            header.source_node_id.clone(),
+            src,
+            header.source_incarnation,
+        );
+        self.pending_events
+            .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
+                seq: header.seq,
+            }));
+        self.maybe_forward_ack(&header);
+    }
+
+    fn maybe_forward_ack(&mut self, header: &SwimHeader) {
+        let Some(ProxyPing {
+            requester_addr,
+            request_seq,
+        }) = self.pending_indirect_pings.remove(&header.seq)
+        else {
+            return;
+        };
+        let gossip = self.gossip_buffer.collect(MAX_GOSSIP_BYTES);
+        let used: usize = gossip.iter().map(|m| m.size()).sum();
+        let shard_leaders = self
+            .shard_leader_buffer
+            .collect(MAX_GOSSIP_BYTES.saturating_sub(used));
+        let forwarded_ack = SwimPacket::Ack(SwimHeader {
+            seq: request_seq,
+            source_node_id: header.source_node_id.clone(),
+            source_incarnation: header.source_incarnation,
+            gossip,
+            shard_leaders,
+        });
+        self.pending_events
+            .push(SwimEvent::Packet(OutboundPacket::new(
+                requester_addr,
+                forwarded_ack,
+            )));
+    }
+
+    fn handle_ping_req(&mut self, src: SocketAddr, header: SwimHeader, target: SocketAddr) {
+        self.handle_incarnation_check(
+            header.source_node_id.clone(),
+            src,
+            header.source_incarnation,
+        );
+        let seq = self.next_seq();
+        self.pending_indirect_pings.insert(
+            seq,
+            ProxyPing {
+                request_seq: header.seq,
+                requester_addr: src,
+            },
+        );
+        let ping = SwimPacket::Ping(self.generate_swim_header(seq));
+        self.pending_events
+            .push(SwimEvent::Packet(OutboundPacket::new(target, ping)));
+        self.pending_events
+            .push(SwimEvent::Timer(TimerCommand::SetSchedule {
+                seq,
+                timer: SwimTimer::proxy_ping(),
+            }));
     }
 
     fn apply_membership_update(&mut self, member: SwimNode) {
@@ -488,28 +516,16 @@ impl Swim {
         addr: SocketAddr,
         remote_inc: u64,
     ) {
-        // If we receive a direct message from someone, they are obviously Alive.
-        // If their incarnation is higher than we thought, update it.
         if let Some(member) = self.members.get(&source_node_id) {
             if remote_inc > member.incarnation {
                 let mut node_addr = member.addr;
                 node_addr.cluster_addr = addr;
-                if let Some(suspect_seq) = self.last_suspected_seqs.remove(&source_node_id) {
-                    self.pending_events
-                        .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
-                            seq: suspect_seq,
-                        }));
-                }
-                self.update_member(
-                    source_node_id.clone(),
-                    node_addr,
-                    SwimNodeState::Alive,
-                    remote_inc,
-                );
+                self.cancel_suspect_timer(&source_node_id);
+                self.update_member(source_node_id, node_addr, SwimNodeState::Alive, remote_inc);
             }
         } else {
             self.update_member(
-                source_node_id.clone(),
+                source_node_id,
                 NodeAddress {
                     cluster_addr: addr,
                     client_addr: addr,
@@ -527,55 +543,10 @@ impl Swim {
         state: SwimNodeState,
         incarnation: u64,
     ) {
-        let (changed, member) = match self.members.entry(node_id.clone()) {
-            Entry::Vacant(e) => {
-                let node = SwimNode {
-                    node_id: node_id.clone(),
-                    addr,
-                    state,
-                    incarnation,
-                };
-                e.insert(node.clone());
-
-                (true, node)
-            }
-
-            Entry::Occupied(mut e) => {
-                let node = e.get_mut();
-
-                // Dead is a terminal state.
-                // If it's dead, ignore the update and exit the function entirely.
-                // After this "tombstone" period, the node is deleted from the HashMap entirely
-                // To join the cluster again, a node should join it with new node ID.
-                if node.state == SwimNodeState::Dead {
-                    return;
-                }
-
-                let old_state = node.state;
-                let old_inc = node.incarnation;
-
-                // RULE: Higher incarnation always wins.
-                if incarnation > node.incarnation {
-                    node.incarnation = incarnation;
-                    node.state = state;
-                }
-                // RULE: Equal incarnation, stricter state wins (Dead > Suspect > Alive)
-                else if incarnation == node.incarnation {
-                    // Requires `SwimNodeState` to derive `PartialOrd, Ord`
-                    node.state = node.state.max(state);
-                }
-
-                let changed = node.state != old_state || node.incarnation != old_inc;
-                (changed, node.clone())
-            }
+        let Some((changed, member)) = self.upsert_member(&node_id, addr, state, incarnation) else {
+            return;
         };
-
-        if node_id != self.node_id {
-            self.live_node_tracker
-                .update(node_id.clone(), &member.state);
-        }
-        self.topology.update(node_id.clone(), &member.state);
-
+        self.sync_trackers(&node_id, &member);
         if changed {
             tracing::info!(
                 "[{}] Member update: {} @ {:?} → {:?} (inc {})",
@@ -585,39 +556,82 @@ impl Swim {
                 member.state,
                 incarnation
             );
-
-            match member.state {
-                SwimNodeState::Alive => {
-                    if let Some(suspect_seq) = self.last_suspected_seqs.remove(&node_id) {
-                        self.pending_events
-                            .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
-                                seq: suspect_seq,
-                            }));
-                    }
-                    self.pending_events
-                        .push(SwimEvent::Membership(MembershipEvent::NodeAlive {
-                            node_id: node_id.clone(),
-                            addr: addr.cluster_addr,
-                        }));
-                }
-                SwimNodeState::Dead => {
-                    self.pending_events
-                        .push(SwimEvent::Membership(MembershipEvent::NodeDead {
-                            node_id: node_id.clone(),
-                        }));
-                }
-                SwimNodeState::Suspect => {
-                    let seq = self.next_seq();
-                    self.last_suspected_seqs.insert(node_id.clone(), seq);
-                    self.pending_events
-                        .push(SwimEvent::Timer(TimerCommand::SetSchedule {
-                            seq,
-                            timer: SwimTimer::suspect_timer(node_id),
-                        }));
-                }
-            }
-
+            self.emit_state_change(&node_id, &member);
             self.gossip_buffer.enqueue(member, self.members.len());
+        }
+    }
+
+    fn upsert_member(
+        &mut self,
+        node_id: &NodeId,
+        addr: NodeAddress,
+        state: SwimNodeState,
+        incarnation: u64,
+    ) -> Option<(bool, SwimNode)> {
+        match self.members.entry(node_id.clone()) {
+            Entry::Vacant(e) => {
+                let node = SwimNode {
+                    node_id: node_id.clone(),
+                    addr,
+                    state,
+                    incarnation,
+                };
+                e.insert(node.clone());
+                Some((true, node))
+            }
+            Entry::Occupied(mut e) => {
+                let node = e.get_mut();
+                if node.state == SwimNodeState::Dead {
+                    return None;
+                }
+                let changed = node.resolve_state(state, incarnation);
+                Some((changed, node.clone()))
+            }
+        }
+    }
+
+    fn sync_trackers(&mut self, node_id: &NodeId, member: &SwimNode) {
+        if *node_id != self.node_id {
+            self.live_node_tracker
+                .update(node_id.clone(), &member.state);
+        }
+        self.topology.update(node_id.clone(), &member.state);
+    }
+
+    fn emit_state_change(&mut self, node_id: &NodeId, member: &SwimNode) {
+        match member.state {
+            SwimNodeState::Alive => {
+                self.cancel_suspect_timer(node_id);
+                self.pending_events
+                    .push(SwimEvent::Membership(MembershipEvent::NodeAlive {
+                        node_id: node_id.clone(),
+                        addr: member.addr.cluster_addr,
+                    }));
+            }
+            SwimNodeState::Dead => {
+                self.pending_events
+                    .push(SwimEvent::Membership(MembershipEvent::NodeDead {
+                        node_id: node_id.clone(),
+                    }));
+            }
+            SwimNodeState::Suspect => {
+                let seq = self.next_seq();
+                self.last_suspected_seqs.insert(node_id.clone(), seq);
+                self.pending_events
+                    .push(SwimEvent::Timer(TimerCommand::SetSchedule {
+                        seq,
+                        timer: SwimTimer::suspect_timer(node_id.clone()),
+                    }));
+            }
+        }
+    }
+
+    fn cancel_suspect_timer(&mut self, node_id: &NodeId) {
+        if let Some(suspect_seq) = self.last_suspected_seqs.remove(node_id) {
+            self.pending_events
+                .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
+                    seq: suspect_seq,
+                }));
         }
     }
 
@@ -673,16 +687,98 @@ impl Swim {
         membership
     }
 
+    pub(crate) fn dispatch(&mut self, event: SwimActorCommand) {
+        match event {
+            SwimActorCommand::Protocol(cmd) => self.dispatch_protocol(cmd),
+            SwimActorCommand::Query(q) => self.handle_query(q),
+        }
+    }
+
+    fn dispatch_protocol(&mut self, cmd: SwimCommand) {
+        match cmd {
+            SwimCommand::PacketReceived { src, packet } => self.step(src, packet),
+            SwimCommand::Timeout(event) => self.handle_timeout(event),
+            SwimCommand::AnnounceShardLeader(event) => {
+                self.announce_shard_leader(event.shard_group_id, event.leader_node_id, event.term)
+            }
+        }
+    }
+
+    fn handle_query(&self, command: SwimQueryCommand) {
+        match command {
+            SwimQueryCommand::GetMembers { reply } => {
+                let _ = reply.send(self.get_members());
+            }
+            SwimQueryCommand::ResolveAddress { node_id, reply } => {
+                let _ = reply.send(self.resolve_address(&node_id));
+            }
+            SwimQueryCommand::ResolveShardGroup { key, reply } => {
+                let _ = reply.send(self.topology.shard_group_for(&key).cloned());
+            }
+            SwimQueryCommand::ResolveShardLeader {
+                shard_group_id,
+                reply,
+            } => {
+                let _ = reply.send(self.topology.shard_leader(shard_group_id).cloned());
+            }
+            SwimQueryCommand::GetShardInfo { key, reply } => {
+                let _ = reply.send(self.get_shard_info(&key));
+            }
+        }
+    }
+
+    fn get_shard_info(&self, key: &[u8]) -> Option<(ShardGroup, Option<ShardLeaderEntry>)> {
+        self.topology.shard_group_for(key).cloned().map(|group| {
+            let leader = self.topology.shard_leader(group.id).cloned();
+            (group, leader)
+        })
+    }
+
+    pub(crate) fn to_raft_command(&self, event: MembershipEvent) -> Option<MultiRaftActorCommand> {
+        if *event.node_id() == self.node_id {
+            return None;
+        }
+        match event {
+            MembershipEvent::NodeDead { node_id } => Some(
+                MultiRaftCommand::HandleNodeDeath {
+                    dead_node_id: node_id,
+                }
+                .into(),
+            ),
+            MembershipEvent::NodeAlive { node_id, .. } => {
+                let affected_groups: Vec<_> = self
+                    .topology
+                    .shard_groups_for_node(&node_id)
+                    .into_iter()
+                    .cloned()
+                    .collect();
+                if affected_groups.is_empty() {
+                    return None;
+                }
+                Some(
+                    MultiRaftCommand::HandleNodeJoin {
+                        new_node_id: node_id,
+                        affected_groups,
+                    }
+                    .into(),
+                )
+            }
+        }
+    }
+
     #[cfg(test)]
     fn assert_invariants(&self) {
-        // Self never in live_node_tracker (excluded from probe targets)
         assert!(
             !self.live_node_tracker.contains(&self.node_id),
             "self ({}) found in live_node_tracker",
-            self.node_id,
+            self.node_id
         );
+        self.assert_tracker_only_alive();
+        self.assert_suspected_seqs_consistent();
+    }
 
-        // live_node_tracker only contains Alive nodes from members
+    #[cfg(test)]
+    fn assert_tracker_only_alive(&self) {
         for node_id in self.live_node_tracker.iter() {
             let member = self
                 .members
@@ -693,22 +789,22 @@ impl Swim {
                 SwimNodeState::Alive,
                 "live_node_tracker contains non-Alive node {:?} (state={:?})",
                 node_id,
-                member.state,
+                member.state
             );
         }
-
-        // No Dead or Suspect nodes in live_node_tracker
         for (node_id, member) in &self.members {
             if member.state != SwimNodeState::Alive {
                 assert!(
                     !self.live_node_tracker.contains(node_id),
                     "Dead/Suspect node {:?} found in live_node_tracker",
-                    node_id,
+                    node_id
                 );
             }
         }
+    }
 
-        // last_suspected_seqs only contains Suspect nodes
+    #[cfg(test)]
+    fn assert_suspected_seqs_consistent(&self) {
         for node_id in self.last_suspected_seqs.keys() {
             if let Some(member) = self.members.get(node_id) {
                 assert_eq!(
@@ -716,7 +812,7 @@ impl Swim {
                     SwimNodeState::Suspect,
                     "last_suspected_seqs contains non-Suspect node {:?} (state={:?})",
                     node_id,
-                    member.state,
+                    member.state
                 );
             }
         }

--- a/src/clusters/swims/swim.rs
+++ b/src/clusters/swims/swim.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use crate::clusters::raft::messages::{MultiRaftActorCommand, MultiRaftCommand};
 use crate::clusters::swims::peer_discovery::JoinAttempt;
 use crate::clusters::swims::topology::Topology;
 
@@ -732,38 +731,6 @@ impl Swim {
             let leader = self.topology.shard_leader(group.id).cloned();
             (group, leader)
         })
-    }
-
-    pub(crate) fn to_raft_command(&self, event: MembershipEvent) -> Option<MultiRaftActorCommand> {
-        if *event.node_id() == self.node_id {
-            return None;
-        }
-        match event {
-            MembershipEvent::NodeDead { node_id } => Some(
-                MultiRaftCommand::HandleNodeDeath {
-                    dead_node_id: node_id,
-                }
-                .into(),
-            ),
-            MembershipEvent::NodeAlive { node_id, .. } => {
-                let affected_groups: Vec<_> = self
-                    .topology
-                    .shard_groups_for_node(&node_id)
-                    .into_iter()
-                    .cloned()
-                    .collect();
-                if affected_groups.is_empty() {
-                    return None;
-                }
-                Some(
-                    MultiRaftCommand::HandleNodeJoin {
-                        new_node_id: node_id,
-                        affected_groups,
-                    }
-                    .into(),
-                )
-            }
-        }
     }
 
     #[cfg(test)]

--- a/src/clusters/swims/topology.rs
+++ b/src/clusters/swims/topology.rs
@@ -142,14 +142,17 @@ impl Topology {
         if self.vnodes.is_empty() || n == 0 {
             return Vec::new();
         }
+        self.collect_distinct_owners(hash, n)
+    }
+
+    fn collect_distinct_owners(&self, hash: u32, n: usize) -> Vec<&NodeId> {
         let mut result: Vec<&NodeId> = Vec::with_capacity(n);
         for token in self.walk_clockwise_from(hash) {
-            if result.iter().any(|o| **o == token.pnode_id) {
-                continue;
-            }
-            result.push(&token.pnode_id);
-            if result.len() == n {
-                break;
+            if !result.iter().any(|o| **o == token.pnode_id) {
+                result.push(&token.pnode_id);
+                if result.len() == n {
+                    break;
+                }
             }
         }
         result
@@ -256,10 +259,13 @@ impl Topology {
 
     #[cfg(test)]
     fn assert_invariants(&self) {
-        use std::collections::HashSet;
+        self.assert_reverse_index_consistent();
+        self.assert_groups_consistent();
+        self.assert_vnode_counts();
+    }
 
-        // Reverse index matches groups: every node in node_group_ids
-        // must appear as a member of the referenced group.
+    #[cfg(test)]
+    fn assert_reverse_index_consistent(&self) {
         for (node_id, group_ids) in &self.node_group_ids {
             for gid in group_ids {
                 let group = self
@@ -270,12 +276,15 @@ impl Topology {
                     group.members.contains(node_id),
                     "node {:?} in reverse index for group {:?} but not in group members",
                     node_id,
-                    gid,
+                    gid
                 );
             }
         }
+    }
 
-        // Every group member appears in node_group_ids
+    #[cfg(test)]
+    fn assert_groups_consistent(&self) {
+        use std::collections::HashSet;
         for (gid, group) in &self.groups {
             for member in &group.members {
                 let ids = self
@@ -286,21 +295,21 @@ impl Topology {
                     ids.contains(gid),
                     "group {:?} member {:?} missing group in reverse index",
                     gid,
-                    member,
+                    member
                 );
             }
-
-            // All group members are distinct
             let unique: HashSet<&NodeId> = group.members.iter().collect();
             assert_eq!(
                 unique.len(),
                 group.members.len(),
                 "group {:?} has duplicate members",
-                gid,
+                gid
             );
         }
+    }
 
-        // Vnode count matches: each node should have exactly vnodes_per_pnode vnodes
+    #[cfg(test)]
+    fn assert_vnode_counts(&self) {
         for node_id in self.node_group_ids.keys() {
             let count = self
                 .vnodes
@@ -310,7 +319,7 @@ impl Topology {
             assert_eq!(
                 count, self.config.vnodes_per_pnode as usize,
                 "node {:?} has {count} vnodes, expected {}",
-                node_id, self.config.vnodes_per_pnode,
+                node_id, self.config.vnodes_per_pnode
             );
         }
     }

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -329,67 +329,28 @@ async fn test_gossip_propagation() {
     );
 }
 
-#[tokio::test]
-async fn test_indirect_ping_trigger() {
-    // This tests the timer logic: Tick -> Ping -> Timeout -> Indirect Ping
-    // Drives the TickerActor directly via TickerCommand::ForceTick.
-
-    let mut harness = setup_single().await;
-    let mut rx_out = harness.rx_out.take().unwrap();
-    let peer_1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
-    let peer_2: SocketAddr = "127.0.0.1:9002".parse().unwrap();
-
-    // 1. Manually add two Alive peers to the actor
-    // We do this by sending them as gossip from a "bootstrap" packet
-    let p1 = SwimNode {
-        node_id: "node-peer-1".into(),
-        addr: NodeAddress {
-            cluster_addr: peer_1,
-            client_addr: peer_1,
-        },
+fn make_peer(name: &str, addr: SocketAddr) -> SwimNode {
+    SwimNode {
+        node_id: name.into(),
+        addr: NodeAddress { cluster_addr: addr, client_addr: addr },
         state: SwimNodeState::Alive,
         incarnation: 1,
-    };
-    let p2 = SwimNode {
-        node_id: "node-peer-2".into(),
-        addr: NodeAddress {
-            cluster_addr: peer_2,
-            client_addr: peer_2,
-        },
-        state: SwimNodeState::Alive,
-        incarnation: 1,
-    };
+    }
+}
 
-    harness
-        .tx_in
-        .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
-            src: peer_1,
-            packet: SwimPacket::Ping(SwimHeader {
-                seq: 1,
-                source_node_id: "node-peer-1".into(),
-                source_incarnation: 1,
-                gossip: vec![p1, p2],
-                shard_leaders: vec![],
-            }),
-        }))
-        .await
-        .unwrap();
+async fn force_ticks(ticker_tx: &mpsc::Sender<TickerCommand<SwimTimer>>, count: usize) {
+    for _ in 0..count {
+        ticker_tx.send(TickerCommand::ForceTick).await.unwrap();
+    }
+}
 
-    let _ack = rx_out.recv().await.unwrap(); // Clear the Ack
-
-    // 2. Force-tick PROBE_INTERVAL_TICKS times so the ticker fires a
-    //    ProtocolPeriodElapsed, which makes SwimProtocol start a probe.
-    //    LiveNodeTracker inserts at a random position, so start_probe() may land
-    //    on self and skip. Retry up to 3 periods to guarantee hitting a peer.
+async fn wait_for_ping(
+    harness: &TestHarness,
+    rx_out: &mut mpsc::Receiver<OutboundPacket>,
+) -> SocketAddr {
     let mut target_addr = None;
     for _ in 0..3 {
-        for _ in 0..PROBE_INTERVAL_TICKS {
-            harness
-                .ticker_tx
-                .send(TickerCommand::ForceTick)
-                .await
-                .unwrap();
-        }
+        force_ticks(&harness.ticker_tx, PROBE_INTERVAL_TICKS as usize).await;
         match time::timeout(Duration::from_millis(100), rx_out.recv()).await {
             Ok(Some(pkt)) if matches!(pkt.packet(), SwimPacket::Ping(_)) => {
                 target_addr = Some(pkt.target);
@@ -398,32 +359,34 @@ async fn test_indirect_ping_trigger() {
             _ => {}
         }
     }
-    let target_addr = target_addr.expect("Actor should send a Ping within 3 protocol periods");
+    target_addr.expect("Actor should send a Ping within 3 protocol periods")
+}
 
-    // 3. DON'T send an Ack. Force-tick DIRECT_ACK_TIMEOUT_TICKS times so the
-    //    direct probe timeout and the state machine transitions to indirect probing.
-    for _ in 0..DIRECT_ACK_TIMEOUT_TICKS {
-        harness
-            .ticker_tx
-            .send(TickerCommand::ForceTick)
-            .await
-            .unwrap();
-    }
+#[tokio::test]
+async fn test_indirect_ping_trigger() {
+    let mut harness = setup_single().await;
+    let mut rx_out = harness.rx_out.take().unwrap();
+    let peer_1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
+    let peer_2: SocketAddr = "127.0.0.1:9002".parse().unwrap();
 
-    // 4. Expect Indirect Pings (PingReq) sent to the *other* peer
+    harness.tx_in.send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
+        src: peer_1,
+        packet: SwimPacket::Ping(SwimHeader {
+            seq: 1, source_node_id: "node-peer-1".into(), source_incarnation: 1,
+            gossip: vec![make_peer("node-peer-1", peer_1), make_peer("node-peer-2", peer_2)],
+            shard_leaders: vec![],
+        }),
+    })).await.unwrap();
+    let _ack = rx_out.recv().await.unwrap();
+
+    let target_addr = wait_for_ping(&harness, &mut rx_out).await;
+    force_ticks(&harness.ticker_tx, DIRECT_ACK_TIMEOUT_TICKS as usize).await;
+
     let indirect_ping = time::timeout(Duration::from_millis(100), rx_out.recv())
-        .await
-        .expect("Should send indirect ping")
-        .unwrap();
-
+        .await.expect("Should send indirect ping").unwrap();
     match indirect_ping.packet() {
-        SwimPacket::PingReq {
-            target: req_target, ..
-        } => {
-            assert_eq!(
-                *req_target, target_addr,
-                "PingReq should target the failed node"
-            );
+        SwimPacket::PingReq { target: req_target, .. } => {
+            assert_eq!(*req_target, target_addr, "PingReq should target the failed node");
         }
         _ => panic!("Expected PingReq, got {:?}", indirect_ping.packet()),
     }

--- a/src/clusters/types/node.rs
+++ b/src/clusters/types/node.rs
@@ -42,6 +42,18 @@ impl SwimNode {
             .map(|v| v.len())
             .unwrap_or(0)
     }
+
+    pub(crate) fn resolve_state(&mut self, state: SwimNodeState, incarnation: u64) -> bool {
+        let old_state = self.state;
+        let old_inc = self.incarnation;
+        if incarnation > self.incarnation {
+            self.incarnation = incarnation;
+            self.state = state;
+        } else if incarnation == self.incarnation {
+            self.state = self.state.max(state);
+        }
+        self.state != old_state || self.incarnation != old_inc
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Encode, Decode)]

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -39,6 +39,21 @@ impl ClientStreamWriter {
         Ok(())
     }
 
+    pub(crate) async fn dispatch(
+        &mut self,
+        swim_sender: SwimSender,
+        raft_sender: RaftSender,
+        request: ConnectionRequests,
+    ) -> anyhow::Result<()> {
+        match request {
+            ConnectionRequests::Connection(_) => Ok(()),
+            ConnectionRequests::Query(q) => self.handle_query(swim_sender, q).await,
+            ConnectionRequests::Propose(req) => {
+                self.handle_propose(swim_sender, raft_sender, req).await
+            }
+        }
+    }
+
     pub(crate) async fn handle_query(
         &mut self,
         swim_sender: SwimSender,
@@ -57,7 +72,7 @@ impl ClientStreamWriter {
             QueryCommand::GetShardInfo { key } => {
                 let response = swim_sender
                     .get_shard_info(key)
-                    .await
+                    .await?
                     .map(|(group, leader)| ShardInfoResponse {
                         shard_group_id: group.id.0,
                         leader_node_id: leader.as_ref().map(|e| e.leader_node_id.to_string()),
@@ -74,33 +89,34 @@ impl ClientStreamWriter {
         raft_sender: RaftSender,
         req: ProposeRequest,
     ) -> anyhow::Result<()> {
+        let response = Self::execute_propose(&swim_sender, &raft_sender, req).await?;
+        self.write(&response).await?;
+        Ok(())
+    }
+
+    async fn execute_propose(
+        swim_sender: &SwimSender,
+        raft_sender: &RaftSender,
+        req: ProposeRequest,
+    ) -> anyhow::Result<ProposeResponse> {
         let Some(shard_group) = swim_sender
             .resolve_shard_group(req.resource_key.clone())
-            .await
+            .await?
         else {
-            self.write(&ProposeResponse::Error(ProposeError::ShardNotFound))
-                .await?;
-            return Ok(());
+            return Ok(ProposeResponse::Error(ProposeError::ShardNotFound));
         };
-
         let raft_cmd = req.command.clone().into_raft_command(shard_group.members);
-
         let Some(result) = raft_sender.propose(shard_group.id, raft_cmd).await else {
-            self.write(&ProposeResponse::Error(ProposeError::ShardNotFound))
-                .await?;
-            return Ok(());
+            return Ok(ProposeResponse::Error(ProposeError::ShardNotFound));
         };
-
         let response = match result {
             Ok(()) => ProposeResponse::Success,
             Err(ProposeError::NotLeader(ref hint)) if !req.forwarded => {
-                Self::try_forward(&swim_sender, hint.clone(), shard_group.id, req).await
+                Self::try_forward(swim_sender, hint.clone(), shard_group.id, req).await
             }
             Err(err) => ProposeResponse::Error(err),
         };
-
-        self.write(&response).await?;
-        Ok(())
+        Ok(response)
     }
 
     async fn try_forward(
@@ -109,22 +125,61 @@ impl ClientStreamWriter {
         shard_group_id: ShardGroupId,
         req: ProposeRequest,
     ) -> ProposeResponse {
-        // Try 1: use leader hint from Raft → resolve client_addr via SWIM member table
-        if let Some(leader_id) = &leader_hint
-            && let Some(node_addr) = swim_sender.resolve_address(leader_id.clone()).await
-            && let Ok(response) = Self::forward_to_leader(node_addr.client_addr, &req).await
-        {
-            return response;
+        if let Some(resp) = Self::try_forward_via_hint(swim_sender, &leader_hint, &req).await {
+            return resp;
         }
-
-        // Try 2: fall back to shard leader gossip (may have different/newer leader info)
-        if let Some(entry) = swim_sender.resolve_shard_leader(shard_group_id).await
-            && let Ok(response) = Self::forward_to_leader(entry.leader_addr.client_addr, &req).await
-        {
-            return response;
+        if let Some(resp) = Self::try_forward_via_gossip(swim_sender, shard_group_id, &req).await {
+            return resp;
         }
-
         ProposeResponse::Error(ProposeError::NotLeader(leader_hint))
+    }
+
+    async fn try_forward_via_hint(
+        swim_sender: &SwimSender,
+        leader_hint: &Option<NodeId>,
+        req: &ProposeRequest,
+    ) -> Option<ProposeResponse> {
+        let leader_id = leader_hint.as_ref()?;
+        let node_addr = match swim_sender.resolve_address(leader_id.clone()).await {
+            Ok(Some(addr)) => addr,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::debug!("Resolve address for {} failed: {e}", leader_id);
+                return None;
+            }
+        };
+        match Self::forward_to_leader(node_addr.client_addr, req).await {
+            Ok(resp) => Some(resp),
+            Err(e) => {
+                tracing::debug!("Forward via hint to {} failed: {e}", node_addr.client_addr);
+                None
+            }
+        }
+    }
+
+    async fn try_forward_via_gossip(
+        swim_sender: &SwimSender,
+        shard_group_id: ShardGroupId,
+        req: &ProposeRequest,
+    ) -> Option<ProposeResponse> {
+        let entry = match swim_sender.resolve_shard_leader(shard_group_id).await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::debug!("Resolve shard leader for {:?} failed: {e}", shard_group_id);
+                return None;
+            }
+        };
+        match Self::forward_to_leader(entry.leader_addr.client_addr, req).await {
+            Ok(resp) => Some(resp),
+            Err(e) => {
+                tracing::debug!(
+                    "Forward via gossip to {} failed: {e}",
+                    entry.leader_addr.client_addr
+                );
+                None
+            }
+        }
     }
 
     async fn forward_to_leader(
@@ -161,31 +216,24 @@ impl ClientStreamReader {
     }
     pub async fn read_bytes(&mut self) -> Result<BytesMut, std::io::Error> {
         loop {
-            // 1. Attempt to parse what we already have buffered
-            //    If we received multiple messages in one packet, this ensures we process them all
-            //    before reading from the socket again.
             if let Some(msg) = self.parse_frame()? {
                 return Ok(msg);
             }
-
-            // 2. If no full frame is available, read more data from the socket.
-            //    'read_buf' automatically appends to the BytesMut
-            let n = self.stream.read_buf(&mut self.buffer).await?;
-            if 0 == n {
-                // If we hit EOF but still have partial data, that's an error
-                return if self.buffer.is_empty() {
-                    Err(std::io::Error::new(
-                        ErrorKind::ConnectionAborted,
-                        "Connection closed",
-                    ))
-                } else {
-                    Err(std::io::Error::new(
-                        ErrorKind::UnexpectedEof,
-                        "Partial frame received",
-                    ))
-                };
-            }
+            self.read_more().await?;
         }
+    }
+
+    async fn read_more(&mut self) -> Result<(), std::io::Error> {
+        let n = self.stream.read_buf(&mut self.buffer).await?;
+        if n == 0 {
+            let kind = if self.buffer.is_empty() {
+                ErrorKind::ConnectionAborted
+            } else {
+                ErrorKind::UnexpectedEof
+            };
+            return Err(std::io::Error::new(kind, "Connection closed"));
+        }
+        Ok(())
     }
 
     /// Tries to split off a full message from the internal buffer.

--- a/src/impls/metadata_storage.rs
+++ b/src/impls/metadata_storage.rs
@@ -14,28 +14,42 @@ use crate::clusters::{
 #[allow(dead_code)]
 enum GroupKey {
     LogEntry(u64),
-    HardState,
-    SnapMeta,
-    SnapData,
-    AppliedIndex,
-    Epoch,
+    Fixed(u8),
 }
 
 impl GroupKey {
+    fn hard_state() -> Self {
+        Self::Fixed(0x02)
+    }
+    #[allow(dead_code)]
+    fn snap_meta() -> Self {
+        Self::Fixed(0x03)
+    }
+    #[allow(dead_code)]
+    fn snap_data() -> Self {
+        Self::Fixed(0x04)
+    }
+    #[allow(dead_code)]
+    fn applied_index() -> Self {
+        Self::Fixed(0x05)
+    }
+    #[allow(dead_code)]
+    fn epoch() -> Self {
+        Self::Fixed(0x06)
+    }
+
     fn encode(&self) -> Vec<u8> {
         match self {
-            GroupKey::LogEntry(index) => {
-                let mut key = Vec::with_capacity(9);
-                key.push(0x01);
-                key.extend_from_slice(&index.to_be_bytes());
-                key
-            }
-            GroupKey::HardState => vec![0x02],
-            GroupKey::SnapMeta => vec![0x03],
-            GroupKey::SnapData => vec![0x04],
-            GroupKey::AppliedIndex => vec![0x05],
-            GroupKey::Epoch => vec![0x06],
+            GroupKey::LogEntry(index) => Self::encode_log_entry(*index),
+            GroupKey::Fixed(tag) => vec![*tag],
         }
+    }
+
+    fn encode_log_entry(index: u64) -> Vec<u8> {
+        let mut key = Vec::with_capacity(9);
+        key.push(0x01);
+        key.extend_from_slice(&index.to_be_bytes());
+        key
     }
 
     fn encode_for(&self, group_id: u64) -> Vec<u8> {
@@ -61,7 +75,7 @@ impl DbOp {
         }
 
         fn put_hard_state(group_id: u64, term: u64, voted_for: Option<NodeId>) -> DbOp {
-            let key = GroupKey::HardState.encode_for(group_id);
+            let key = GroupKey::hard_state().encode_for(group_id);
             let value = bincode::encode_to_vec(&(term, voted_for), BINCODE_CONFIG)
                 .expect("encode HardState failed");
             DbOp::Put { key, value }
@@ -69,7 +83,7 @@ impl DbOp {
 
         fn delete_from(group_id: u64, from_index: u64) -> DbOp {
             let start = GroupKey::LogEntry(from_index).encode_for(group_id);
-            let end = GroupKey::HardState.encode_for(group_id);
+            let end = GroupKey::hard_state().encode_for(group_id);
             DbOp::DeleteRange { start, end }
         }
 
@@ -134,7 +148,7 @@ impl MetadataStorage {
     fn take_persistent_state_for(&self, group_id: u64) -> RaftPersistentState {
         let Some(bytes) = self
             .db
-            .get(GroupKey::HardState.encode_for(group_id))
+            .get(GroupKey::hard_state().encode_for(group_id))
             .unwrap_or_default()
         else {
             return RaftPersistentState::default();
@@ -153,7 +167,7 @@ impl MetadataStorage {
 
     fn list_log_entires(&self, group_id: u64) -> Vec<LogEntry> {
         let start = GroupKey::LogEntry(0).encode_for(group_id);
-        let end = GroupKey::HardState.encode_for(group_id);
+        let end = GroupKey::hard_state().encode_for(group_id);
         self.scan_range(&start, &end)
             .into_iter()
             .map(|bytes| {
@@ -269,7 +283,7 @@ mod tests {
     fn key_encoding_preserves_sort_order() {
         let g1_log1 = GroupKey::LogEntry(1).encode_for(1);
         let g1_log2 = GroupKey::LogEntry(2).encode_for(1);
-        let g1_hard = GroupKey::HardState.encode_for(1);
+        let g1_hard = GroupKey::hard_state().encode_for(1);
         let g2_log1 = GroupKey::LogEntry(1).encode_for(2);
 
         assert!(g1_log1 < g1_log2, "log entries must sort by index");

--- a/src/it/raft_election.rs
+++ b/src/it/raft_election.rs
@@ -41,19 +41,14 @@ async fn mock_swim_handler(
 ///
 /// After enough ticks for election + heartbeat propagation, queries the elected
 /// leader and serves it to the checker via a TCP endpoint.
-async fn run_raft_node(
+fn build_address_map(
     node_name: &str,
     cluster_port: u16,
-    query_port: u16,
-    group: ShardGroup,
     peer_names: &[&str],
-) -> Result<(), Box<dyn std::error::Error>> {
-    let node_id = NodeId::new(node_name);
-
-    // Build address map from turmoil hostnames
+) -> HashMap<NodeId, SocketAddr> {
     let mut address_map = HashMap::new();
     address_map.insert(
-        node_id.clone(),
+        NodeId::new(node_name),
         SocketAddr::new(turmoil::lookup(node_name), cluster_port),
     );
     for &peer in peer_names {
@@ -63,22 +58,56 @@ async fn run_raft_node(
             SocketAddr::new(turmoil::lookup(peer), CLUSTER_PORT + peer_idx),
         );
     }
+    address_map
+}
 
-    // Create channels
+async fn drive_ticks(
+    ticker: &mpsc::Sender<TickerCommand<crate::clusters::raft::messages::RaftTimer>>,
+    count: usize,
+) {
+    for _ in 0..count {
+        let _ = ticker.send(TickerCommand::ForceTick).await;
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn serve_leader(
+    query_port: u16,
+    leader: Option<NodeId>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", query_port)).await?;
+    let (stream, _) = listener.accept().await?;
+    let (_read, mut write) = stream.into_split();
+    let bytes = bincode::encode_to_vec(&leader, BINCODE_CONFIG).unwrap();
+    let len = bytes.len() as u32;
+    write.write_all(&len.to_be_bytes()).await?;
+    write.write_all(&bytes).await?;
+    Ok(())
+}
+
+async fn run_raft_node(
+    node_name: &str,
+    cluster_port: u16,
+    query_port: u16,
+    group: ShardGroup,
+    peer_names: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let node_id = NodeId::new(node_name);
+    let address_map = build_address_map(node_name, cluster_port, peer_names);
+
     let (raft_tx, raft_mailbox) = mpsc::channel(100);
     let (transport_tx, transport_rx) = mpsc::channel(100);
     let (ticker_tx, ticker_rx) = mpsc::channel(64);
     let (swim_tx, swim_rx) = SwimActor::channel(64);
-
     let ticker_force = ticker_tx.clone();
 
-    // Create and spawn actors
     let bind_addr: SocketAddr = format!("0.0.0.0:{}", cluster_port).parse().unwrap();
     let listener = crate::net::TcpListener::bind(bind_addr).await?;
 
     tokio::spawn(mock_swim_handler(swim_rx, address_map));
     tokio::spawn(run_scheduling_actor(raft_tx.clone(), ticker_rx));
-
     tokio::spawn(RaftTransportActor::run(
         node_id.clone(),
         listener,
@@ -86,7 +115,6 @@ async fn run_raft_node(
         transport_rx,
         swim_tx.clone(),
     ));
-
     let db = MetadataStorage::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
     tokio::spawn(MultiRaftActor::run(
         node_id,
@@ -97,7 +125,6 @@ async fn run_raft_node(
         swim_tx,
     ));
 
-    // Ensure the shard group
     raft_tx
         .send(
             MultiRaftCommand::EnsureGroup {
@@ -107,26 +134,11 @@ async fn run_raft_node(
         )
         .await
         .unwrap();
-
-    // Let the actor process EnsureGroup and send timer commands to the ticker
     for _ in 0..10 {
         tokio::task::yield_now().await;
     }
+    drive_ticks(&ticker_force, 200).await;
 
-    // Drive the ticker with ForceTick. Between each tick, yield + sleep to give
-    // transport and actor tasks time to process RPCs across the network.
-    //
-    // Election timeout = 50 base + ~6-8 jitter ticks. After election, the leader
-    // sends heartbeats (AppendEntries) which tell followers the leader_id.
-    // 200 ticks with interleaved yields is more than enough for the full cycle.
-    for _ in 0..200 {
-        let _ = ticker_force.send(TickerCommand::ForceTick).await;
-        tokio::task::yield_now().await;
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        tokio::task::yield_now().await;
-    }
-
-    // Query the elected leader
     let (reply_tx, reply_rx) = oneshot::channel();
     raft_tx
         .send(MultiRaftActorCommand::GetLeader {
@@ -136,18 +148,8 @@ async fn run_raft_node(
         .await
         .unwrap();
     let leader = reply_rx.await.unwrap();
+    serve_leader(query_port, leader).await?;
 
-    // Serve the result to the checker via TCP
-    let listener = TcpListener::bind(format!("0.0.0.0:{}", query_port)).await?;
-    let (stream, _) = listener.accept().await?;
-    let (_read, mut write) = stream.into_split();
-
-    let bytes = bincode::encode_to_vec(&leader, BINCODE_CONFIG).unwrap();
-    let len = bytes.len() as u32;
-    write.write_all(&len.to_be_bytes()).await?;
-    write.write_all(&bytes).await?;
-
-    // Keep actors alive for the rest of the simulation
     tokio::time::sleep(Duration::from_secs(600)).await;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,7 @@ use crate::schedulers::actor::run_scheduling_actor;
 use crate::{
     clusters::{swims::actor::SwimActor, transport::SwimTransportActor},
     config::ENV,
-    connections::{
-        clients::{ClientStreamReader, ClientStreamWriter},
-        request::ConnectionRequests,
-    },
+    connections::clients::{ClientStreamReader, ClientStreamWriter},
 };
 use anyhow::Result;
 use tokio::sync::mpsc;
@@ -143,17 +140,5 @@ async fn handle_client_stream(
     let mut stream_reader = ClientStreamReader::new(read_half);
     let mut stream_writer = ClientStreamWriter::new(write_half);
     let request = stream_reader.read_request().await?;
-
-    match request {
-        ConnectionRequests::Connection(_request) => {}
-        ConnectionRequests::Query(query_type) => {
-            stream_writer.handle_query(swim_sender, query_type).await?
-        }
-        ConnectionRequests::Propose(req) => {
-            stream_writer
-                .handle_propose(swim_sender, raft_sender, req)
-                .await?
-        }
-    }
-    Ok(())
+    stream_writer.dispatch(swim_sender, raft_sender, request).await
 }


### PR DESCRIPTION
## What changed

### CRAP score reduction

### Code convention enforcement (`.claude/rules/code-convention.md`)

Applied systematically across the codebase:

- **Encapsulation**: Free functions taking `&Struct` as first arg moved to `impl Struct` methods. Assert invariants moved from `MetadataStateMachine` to `TopicMeta`/`RangeMeta`. `resolve_state` moved to `SwimNode`. Protocol dispatch moved from `SwimActor` to `Swim`.
- **Result over Option**: `SwimSender` query methods (`resolve_shard_group`, `resolve_address`, etc.) converted from `Option<T>` to `anyhow::Result<Option<T>>` — channel failures now propagate instead of silently returning `None`. `RaftReader::read_node_id`/`read_message` converted from `Option` to `Result`. `build_split_proposal` returns `Result`.
- **No boolean flags**: `send_append_entries_response(target, success: bool)` replaced with `accept_append_entries`/`reject_append_entries`.
- **Compile-time exhaustiveness**: All wildcard `_ => {}` match arms replaced with explicit variant listings.
- **Temporal coupling**: validation happens before mutation. If it's expected failure,  log them instead of propagating it (as mutation already committed).
- **Error observability**: `StaleSegment` error variant added. Forward failures in `ClientStreamWriter` logged at `debug!` level before discarding.

### Structural improvements
- `DeferredReply` enum replaces boxed closures for deferred reply handling in `MultiRaft` — no type erasure, no allocation
- `MultiRaft` owns `deferred` buffer internally; actor loop simplified to `process` → flush → `fire_deferred`
- `SwimActor` reduced to thin async shell; all protocol logic, query handling, and raft command translation are `Swim` methods
- Flush-before-recv pattern eliminates duplicate flush call in `SwimActor::run`