### PR TITLE
feat: Segment Cache Lock-Free RIngBuffer implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,7 @@ name = "east-guard"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "bincode",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0.18"
 rocksdb = "0.24.0"
 crossbeam-channel = "0.5"
 crc32fast = "1.4"
+arc-swap = "1"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/diagrams/data-plane/d1_storage_engine.md
+++ b/diagrams/data-plane/d1_storage_engine.md
@@ -239,7 +239,7 @@ Lock-free ring buffer of immutable `Arc<SegmentRecordBatch>` batches. Single wri
 ```rust
 struct SegmentCache {
     // All fields private — access only through methods below.
-    batches: [AtomicPtr<SegmentRecordBatch>; CAPACITY],
+    batches: [ArcSwapOption<SegmentRecordBatch>; CAPACITY],
     tail: AtomicU64,
     commit_offset: AtomicU64,
     eviction_frontier: AtomicU64,
@@ -248,7 +248,7 @@ struct SegmentCache {
 
 impl SegmentCache {
     // Write path — called by DataPlane
-    fn publish(&self, batch: Arc<SegmentRecordBatch>);       // store ptr, advance tail
+    fn publish(&self, batch: Arc<SegmentRecordBatch>);       // store into slot, advance tail
     fn commit(&self, new_offset: u64);                       // advance commit_offset, notify_waiters()
 
     // Read path — called by consumer tasks
@@ -258,7 +258,7 @@ impl SegmentCache {
     fn load_eviction_frontier(&self) -> u64;                 // Acquire load
 
     // Checkpoint path — called by checkpoint worker
-    fn read_batches_for_checkpoint(&self, from: u64, to: u64) -> Vec<Arc<SegmentRecordBatch>>;
+    fn drain_for_checkpoint(&self) -> CheckpointBatch;       // reads frontier..tail, returns batches + new_frontier
     fn advance_eviction_frontier(&self, new_frontier: u64);  // Release store
 }
 
@@ -270,7 +270,7 @@ struct SegmentRecordBatch {
 }
 ```
 
-Internally, `publish` stores via `Arc::into_raw()` (cache slot holds the initial strong ref), readers clone via `Arc::increment_strong_count()` + `Arc::from_raw()`. On eviction, cache drops its ref — batch freed when last consumer releases theirs.
+Slots use `arc_swap::ArcSwapOption` — load + refcount increment is atomic, eliminating the dangling-pointer risk that raw `AtomicPtr` + manual `Arc::increment_strong_count` has when a consumer is preempted at the hot/cold boundary. `publish` calls `ArcSwapOption::store()`, readers call `load_full()` which returns `Option<Arc<…>>` with the refcount already incremented. On eviction, the old Arc is dropped when the slot is overwritten — batch freed when last consumer releases theirs.
 
 **Consumer seek:** Each `SegmentRecordBatch` carries `(start_offset, end_offset)`. Binary search over published batches by offset range to find the batch containing the target offset, then linear scan within the batch.
 

--- a/src/data_plane/checkpoint.rs
+++ b/src/data_plane/checkpoint.rs
@@ -15,7 +15,7 @@ pub struct CheckpointWorker;
 
 impl CheckpointWorker {
     pub(crate) fn spawn(
-        sparse_index: Box<dyn SparseIndex>,
+        sparse_index: Arc<dyn SparseIndex>,
         mailbox: Receiver<CheckpointJob>,
         data_plane_tx: Sender<DataPlaneCommand>,
     ) {

--- a/src/data_plane/cold_read.rs
+++ b/src/data_plane/cold_read.rs
@@ -1,0 +1,131 @@
+use std::fs::File;
+use std::io::{BufReader, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use crossbeam_channel::{Receiver, Sender};
+use tokio::sync::oneshot;
+
+use super::record::{Record, RecordType, SegmentKey};
+use super::sparse_index::SparseIndex;
+
+const DEFAULT_POOL_SIZE: usize = 4;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ColdReadError {
+    #[error("failed to open segment file: {0}")]
+    FileOpen(std::io::Error),
+    #[error("failed to read segment file: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub(crate) struct ColdReadRequest {
+    pub(crate) segment_key: SegmentKey,
+    pub(crate) segment_file_path: PathBuf,
+    pub(crate) start_offset: u64,
+    pub(crate) max_bytes: u64,
+    pub(crate) respond_tx: oneshot::Sender<Result<ColdReadRecords, ColdReadError>>,
+}
+
+pub(crate) struct ColdReadRecords {
+    pub(crate) records: Vec<Record>,
+    pub(crate) next_offset: u64,
+}
+
+pub(crate) struct ColdReadPool;
+
+impl ColdReadPool {
+    pub(crate) fn spawn(
+        pool_size: usize,
+        sparse_index: Arc<dyn SparseIndex>,
+    ) -> Sender<ColdReadRequest> {
+        let (tx, rx) = crossbeam_channel::bounded::<ColdReadRequest>(256);
+
+        for i in 0..pool_size {
+            let rx = rx.clone();
+            let index = Arc::clone(&sparse_index);
+            thread::Builder::new()
+                .name(format!("cold-read-{i}"))
+                .spawn(move || {
+                    Self::worker_loop(rx, &*index);
+                })
+                .expect("failed to spawn cold-read thread");
+        }
+
+        tx
+    }
+
+    pub(crate) fn spawn_default(sparse_index: Arc<dyn SparseIndex>) -> Sender<ColdReadRequest> {
+        Self::spawn(DEFAULT_POOL_SIZE, sparse_index)
+    }
+
+    fn worker_loop(mailbox: Receiver<ColdReadRequest>, sparse_index: &dyn SparseIndex) {
+        while let Ok(req) = mailbox.recv() {
+            let result = Self::process_request(&req, sparse_index);
+            let _ = req.respond_tx.send(result);
+        }
+    }
+
+    fn process_request(
+        req: &ColdReadRequest,
+        sparse_index: &dyn SparseIndex,
+    ) -> Result<ColdReadRecords, ColdReadError> {
+        let byte_position = sparse_index.seek_index(req.segment_key, req.start_offset);
+
+        let file = File::open(&req.segment_file_path).map_err(ColdReadError::FileOpen)?;
+        let file_len = file.metadata()?.len();
+
+        let mut reader = BufReader::new(file);
+        reader.seek(SeekFrom::Start(byte_position))?;
+
+        let mut records = Vec::new();
+        let mut current_offset = req.start_offset;
+        let mut bytes_read = 0u64;
+
+        loop {
+            if bytes_read >= req.max_bytes {
+                break;
+            }
+
+            let pos_before = reader.stream_position()?;
+            if pos_before >= file_len {
+                break;
+            }
+
+            let Ok(record) = Record::decode_from(&mut reader) else {
+                break;
+            };
+
+            let pos_after = reader.stream_position()?;
+            bytes_read += pos_after - pos_before;
+
+            match record.record_type {
+                RecordType::BatchEnd => break,
+                RecordType::Data => {
+                    current_offset += 1;
+                    records.push(record);
+                }
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::io::AsRawFd;
+            let fd = reader.get_ref().as_raw_fd();
+            unsafe {
+                libc::posix_fadvise(
+                    fd,
+                    byte_position as i64,
+                    bytes_read as i64,
+                    libc::POSIX_FADV_DONTNEED,
+                );
+            }
+        }
+
+        Ok(ColdReadRecords {
+            records,
+            next_offset: current_offset,
+        })
+    }
+}

--- a/src/data_plane/sparse_index.rs
+++ b/src/data_plane/sparse_index.rs
@@ -24,7 +24,7 @@ impl SparseEntry {
 
 pub trait SparseIndex: Send + Sync + 'static {
     fn put_batch(&self, entries: Vec<SparseEntry>) -> io::Result<()>;
-    fn seek_for_prev(&self, key: &[u8]) -> Option<(Vec<u8>, Vec<u8>)>;
+    fn seek_index(&self, segment_key: SegmentKey, target_offset: u64) -> u64;
 }
 
 impl SparseIndex for rocksdb::DB {
@@ -36,16 +36,34 @@ impl SparseIndex for rocksdb::DB {
         self.write(batch).map_err(io::Error::other)
     }
 
-    fn seek_for_prev(&self, key: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn seek_index(&self, segment_key: SegmentKey, target_offset: u64) -> u64 {
+        let seek_key = encode_key(segment_key, target_offset);
+
         let mut iter = self.raw_iterator();
-        iter.seek_for_prev(key);
-        if !iter.valid() {
-            return None;
+        iter.seek_for_prev(&seek_key);
+
+        if iter.valid()
+            && let Some(key) = iter.key()
+            && key.len() >= 24
+            && key[..24] == seek_key[..24]
+            && let Some(value) = iter.value()
+            && value.len() == 8
+        {
+            return u64::from_be_bytes(value.try_into().unwrap());
         }
-        let k = iter.key()?.to_vec();
-        let v = iter.value()?.to_vec();
-        Some((k, v))
+        0
     }
+}
+
+#[inline]
+fn encode_key(segment_key: SegmentKey, offset: u64) -> Vec<u8> {
+    let (shard_group_id, range_id, segment_id) = segment_key;
+    let mut key = Vec::with_capacity(32);
+    key.extend_from_slice(&shard_group_id.0.to_be_bytes());
+    key.extend_from_slice(&range_id.0.to_be_bytes());
+    key.extend_from_slice(&segment_id.0.to_be_bytes());
+    key.extend_from_slice(&offset.to_be_bytes());
+    key
 }
 
 #[cfg(test)]
@@ -72,11 +90,18 @@ impl SparseIndex for MockSparseIndex {
         Ok(())
     }
 
-    fn seek_for_prev(&self, key: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn seek_index(&self, segment_key: SegmentKey, target_offset: u64) -> u64 {
+        let seek_key = encode_key(segment_key, target_offset);
         let entries = self.entries.lock().unwrap();
-        entries
-            .range(..=key.to_vec())
-            .next_back()
-            .map(|(k, v)| (k.clone(), v.clone()))
+
+        if let Some((key, value)) = entries.range(..=seek_key.clone()).next_back()
+            && key.len() >= 24
+            && key[..24] == seek_key[..24]
+            && value.len() == 8
+        {
+            return u64::from_be_bytes(value.as_slice().try_into().unwrap());
+        }
+
+        0
     }
 }

--- a/src/data_plane/states/segment/cache.rs
+++ b/src/data_plane/states/segment/cache.rs
@@ -1,0 +1,311 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use arc_swap::ArcSwapOption;
+use tokio::sync::Notify;
+
+use crate::data_plane::record::SegmentRecordBatch;
+#[cfg(test)]
+use crate::test_traits::TAssertInvariant;
+
+const DEFAULT_CAPACITY: usize = 1024;
+
+// Slots use `ArcSwapOption` instead of raw `AtomicPtr` to make load + refcount
+// increment atomic. With `AtomicPtr`, a consumer at the hot/cold boundary
+// (position == eviction_frontier) could load a raw pointer, then get preempted
+// before calling `Arc::increment_strong_count`. If the publisher wraps the
+// entire ring (~1024 publishes) during that window, the slot is overwritten
+// and the old Arc freed — the consumer wakes up holding a dangling pointer.
+// `ArcSwapOption::load_full()` returns `Option<Arc<…>>` with the refcount
+// already incremented, closing this gap with ~2-5ns overhead per read —
+// negligible since batch processing cost dominates.
+//
+// Refcount lifecycle:
+//   - `store(Some(batch))`: slot takes ownership. If overwriting, old Arc is
+//     dropped (refcount -1). Old batch freed only if no readers hold it.
+//   - `load_full()`: returns a new Arc clone (refcount +1). Slot keeps its
+//     own ref independently. Caller dropping the Arc decrements refcount.
+//   - Eviction: `advance_eviction_frontier` moves the cursor but does NOT
+//     clear the slot. The old Arc stays alive until `publish` overwrites it
+//     on the next ring wrap. This is delayed cleanup, not a leak — the slot
+//     is logically evicted (readers rejected by frontier check) but the
+//     memory is reclaimed when the publisher physically reaches that slot.
+pub(crate) struct SegmentCache {
+    batches: Box<[ArcSwapOption<SegmentRecordBatch>]>,
+    capacity: usize,
+    tail: AtomicU64,
+    commit_offset: AtomicU64,
+    eviction_frontier: AtomicU64,
+    notify: Notify,
+}
+
+impl SegmentCache {
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        // when capacity is a power of two, we can replace the expensive modulo
+        // division with bitwise AND — a single-cycle CPU instruction
+        assert!(capacity > 0 && capacity.is_power_of_two());
+
+        let batches = std::iter::repeat_with(|| ArcSwapOption::new(None))
+            .take(capacity)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        SegmentCache {
+            batches,
+            capacity,
+            tail: AtomicU64::new(0),
+            commit_offset: AtomicU64::new(0),
+            eviction_frontier: AtomicU64::new(0),
+            notify: Notify::new(),
+        }
+    }
+
+    fn slot_index(&self, position: u64) -> usize {
+        (position as usize) & (self.capacity - 1)
+    }
+
+    // Write path (called by DataPlane)
+
+    pub(super) fn publish(&self, batch: Arc<SegmentRecordBatch>) {
+        let tail = self.tail.load(Ordering::Acquire);
+        let idx = self.slot_index(tail);
+        self.batches[idx].store(Some(batch));
+
+        // ! SAFETY: why not self.tail.fetch_add(1)?
+        // because there is only one writer thread
+        self.tail.store(tail + 1, Ordering::Release);
+    }
+
+    pub(super) fn commit(&self, new_offset: u64) {
+        self.commit_offset.store(new_offset, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    // Read path (called by consumer tasks)
+
+    pub(crate) fn load_commit_offset(&self) -> u64 {
+        self.commit_offset.load(Ordering::Acquire)
+    }
+
+    pub(super) fn load_tail(&self) -> u64 {
+        self.tail.load(Ordering::Acquire)
+    }
+
+    pub async fn notified(&self) {
+        self.notify.notified().await;
+    }
+
+    pub(super) fn read_batch(&self, position: u64) -> Option<Arc<SegmentRecordBatch>> {
+        let commit = self.commit_offset.load(Ordering::Acquire);
+        let frontier = self.eviction_frontier.load(Ordering::Acquire);
+
+        if position >= commit || position < frontier {
+            return None;
+        }
+
+        let idx = self.slot_index(position);
+        self.batches[idx].load_full()
+    }
+
+    pub(super) fn load_eviction_frontier(&self) -> u64 {
+        self.eviction_frontier.load(Ordering::Acquire)
+    }
+
+    // Checkpoint path (called by checkpoint worker)
+    pub(crate) fn drain_for_checkpoint(&self) -> CheckpointBatch {
+        let frontier = self.eviction_frontier.load(Ordering::Acquire);
+        let tail = self.tail.load(Ordering::Acquire);
+
+        if frontier >= tail {
+            return CheckpointBatch {
+                batches: Vec::new(),
+                new_frontier: frontier,
+            };
+        }
+
+        let mut batches = Vec::with_capacity((tail - frontier) as usize);
+        for pos in frontier..tail {
+            let idx = self.slot_index(pos);
+            if let Some(batch) = self.batches[idx].load_full() {
+                batches.push(batch);
+            }
+        }
+
+        CheckpointBatch {
+            batches,
+            new_frontier: tail,
+        }
+    }
+
+    pub(crate) fn advance_eviction_frontier(&self, new_frontier: u64) {
+        self.eviction_frontier
+            .store(new_frontier, Ordering::Release);
+    }
+}
+
+pub(crate) struct CheckpointBatch {
+    pub batches: Vec<Arc<SegmentRecordBatch>>,
+    pub new_frontier: u64,
+}
+
+impl CheckpointBatch {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.batches.is_empty()
+    }
+
+    pub(crate) fn last_lsn(&self) -> u64 {
+        self.batches.last().map(|b| b.lsn).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+impl TAssertInvariant for SegmentCache {
+    fn assert_invariants(&self) {
+        let frontier = self.eviction_frontier.load(Ordering::Acquire);
+        let commit = self.commit_offset.load(Ordering::Acquire);
+        let tail = self.tail.load(Ordering::Acquire);
+
+        assert!(
+            frontier <= commit,
+            "eviction_frontier ({frontier}) > commit_offset ({commit})"
+        );
+        assert!(commit <= tail, "commit_offset ({commit}) > tail ({tail})");
+
+        for pos in frontier..tail {
+            let idx = self.slot_index(pos);
+            assert!(
+                self.batches[idx].load().is_some(),
+                "empty slot at position {pos} (between frontier and tail)"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::data_plane::record::Record;
+
+    fn make_batch(start: u64, end: u64, lsn: u64) -> Arc<SegmentRecordBatch> {
+        Arc::new(SegmentRecordBatch {
+            records: vec![Record::data(Bytes::from("test"))],
+            start_offset: start,
+            end_offset: end,
+            lsn,
+        })
+    }
+
+    #[test]
+    fn publish_and_read() {
+        let cache = SegmentCache::with_capacity(4);
+
+        let batch = make_batch(0, 10, 1);
+        cache.publish(batch.clone());
+        cache.commit(1);
+
+        let read = cache.read_batch(0).unwrap();
+        assert_eq!(read.start_offset, 0);
+        assert_eq!(read.end_offset, 10);
+    }
+
+    #[test]
+    fn read_beyond_commit_returns_none() {
+        let cache = SegmentCache::with_capacity(4);
+
+        cache.publish(make_batch(0, 10, 1));
+        assert!(cache.read_batch(0).is_none());
+    }
+
+    #[test]
+    fn read_behind_eviction_returns_none() {
+        let cache = SegmentCache::with_capacity(4);
+
+        cache.publish(make_batch(0, 10, 1));
+        cache.commit(1);
+        cache.advance_eviction_frontier(1);
+
+        assert!(cache.read_batch(0).is_none());
+    }
+
+    #[test]
+    fn multiple_publishes() {
+        let cache = SegmentCache::with_capacity(4);
+
+        for i in 0..3u64 {
+            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+        }
+        cache.commit(3);
+
+        for i in 0..3u64 {
+            let batch = cache.read_batch(i).unwrap();
+            assert_eq!(batch.start_offset, i * 10);
+        }
+    }
+
+    #[test]
+    fn eviction_frontier_advances() {
+        let cache = SegmentCache::with_capacity(4);
+
+        cache.publish(make_batch(0, 10, 1));
+        cache.publish(make_batch(10, 20, 2));
+        cache.commit(2);
+
+        cache.advance_eviction_frontier(1);
+
+        assert!(cache.read_batch(0).is_none());
+        assert!(cache.read_batch(1).is_some());
+    }
+
+    #[test]
+    fn drain_for_checkpoint() {
+        let cache = SegmentCache::with_capacity(4);
+
+        for i in 0..3u64 {
+            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+        }
+
+        let checkpoint = cache.drain_for_checkpoint();
+        assert_eq!(checkpoint.batches.len(), 3);
+        assert_eq!(checkpoint.new_frontier, 3);
+    }
+
+    #[test]
+    fn ring_buffer_wraps() {
+        let cache = SegmentCache::with_capacity(4);
+
+        for i in 0..6u64 {
+            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+            if i >= 1 {
+                cache.advance_eviction_frontier(i - 1);
+            }
+        }
+        cache.commit(6);
+
+        let batch = cache.read_batch(5).unwrap();
+        assert_eq!(batch.start_offset, 50);
+    }
+
+    #[test]
+    fn cursors_maintain_ordering() {
+        let cache = SegmentCache::with_capacity(8);
+
+        for i in 0..5u64 {
+            cache.publish(make_batch(i, i + 1, i + 1));
+        }
+        cache.commit(5);
+        cache.advance_eviction_frontier(2);
+
+        let frontier = cache.load_eviction_frontier();
+        let commit = cache.load_commit_offset();
+        let tail = cache.load_tail();
+
+        assert!(frontier <= commit);
+        assert!(commit <= tail);
+    }
+}

--- a/src/data_plane/states/segment/mod.rs
+++ b/src/data_plane/states/segment/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod cache;
+pub(crate) mod tracker;
+use cache::*;

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -1,0 +1,83 @@
+use std::{path::PathBuf, sync::Arc};
+
+use crate::data_plane::{
+    checkpoint::CheckpointJob,
+    record::{SegmentKey, SegmentRecordBatch},
+};
+
+use super::*;
+pub(crate) struct SegmentTracker {
+    cache: Arc<SegmentCache>,
+    pub(crate) size_bytes: u64,
+    checkpoint_lsn: u64,
+    segment_file_path: PathBuf,
+}
+
+impl SegmentTracker {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            cache: Arc::new(SegmentCache::new()),
+            size_bytes: 0,
+            checkpoint_lsn: 0,
+            segment_file_path: path,
+        }
+    }
+
+    pub(crate) fn uncheckpointed(&self) -> u64 {
+        self.cache.load_tail() - self.cache.load_eviction_frontier()
+    }
+
+    pub(crate) fn publish(&self, batch: SegmentRecordBatch) {
+        self.cache.publish(Arc::new(batch));
+        let tail = self.cache.load_tail();
+        self.cache.commit(tail);
+    }
+
+    pub(crate) fn checkpoint(&self, key: SegmentKey) -> CheckpointJob {
+        CheckpointJob {
+            segment_key: key,
+            cache: self.cache.clone(),
+            segment_file_path: self.segment_file_path.clone(),
+        }
+    }
+
+    pub(crate) fn advance_checkpoint(&mut self, checkpointed_lsn: u64) {
+        self.checkpoint_lsn = self.checkpoint_lsn.max(checkpointed_lsn);
+    }
+
+    pub(crate) fn checkpoint_lsn(&self) -> u64 {
+        self.checkpoint_lsn
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::{
+        data_plane::states::segment::tracker::SegmentTracker, test_traits::TAssertInvariant,
+    };
+
+    impl TAssertInvariant for SegmentTracker {
+        fn assert_invariants(&self) {
+            self.cache.assert_invariants();
+
+            let frontier = self.cache.load_eviction_frontier();
+            let tail = self.cache.load_tail();
+            if frontier == tail && tail > 0 {
+                assert!(
+                    self.checkpoint_lsn > 0,
+                    "all batches evicted but checkpoint_lsn is 0 — \
+                     eviction happened without reporting checkpoint"
+                );
+            }
+        }
+    }
+
+    impl SegmentTracker {
+        pub fn cache(&self) -> Arc<SegmentCache> {
+            self.cache.clone()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `AtomicPtr` + manual `Arc::increment_strong_count` with `arc-swap::ArcSwapOption` in SegmentCache ring buffer
- Eliminates all `unsafe` code and the dangling-pointer risk at the hot/cold boundary where a preempted consumer could observe freed memory
- Abstract sparse index behind `SparseIndex` trait (`put_batch`, `seek_index`) with RocksDB impl and test mock
- `CheckpointWorker` and `ColdReadPool` share sparse index via `Arc<dyn SparseIndex>`
- `ColdReadPool` errors propagate via `ColdReadError` enum instead of silently returning empty results
- `SegmentTracker` encapsulates cache + checkpoint job creation, moved to `states/segment/` module
- D1 design doc updated to reflect `ArcSwapOption` slots and `drain_for_checkpoint` API

## Test plan

- [x] All 244 existing tests pass with no regressions
- [x] SegmentCache tests cover publish/read, eviction frontier, ring wrap, checkpoint drain, cursor ordering
- [x] SegmentTracker invariant checks (cache delegation + checkpoint_lsn consistency)
- [x] Clippy clean (`--all-targets --all-features -- -D warnings`)

