### PR TITLE
feat: entry-id offset model

### DIFF
--- a/diagrams/data-plane/d1_storage_engine.md
+++ b/diagrams/data-plane/d1_storage_engine.md
@@ -6,6 +6,21 @@
 
 ---
 
+## Offset Model
+
+Follows Northguard/Pulsar: offsets are **per-entry (batch), not per-record**. Producers are offset-agnostic — the broker assigns `entry_id` during WAL flush.
+
+| Concept | EastGuard | Pulsar equivalent |
+|---|---|---|
+| Segment | `SegmentKey` | `ledgerId` |
+| Entry offset | `entry_id: u64` (per-segment, broker-assigned) | `entryId` |
+| Record within entry | `record_index: u32` (consumer-side) | `batchIndex` |
+| Record ID | `(SegmentKey, entry_id, record_index)` | `(ledgerId, entryId, batchIndex)` |
+
+Each `Produce` command carries an opaque `EntryPayload` — one pre-serialized blob from the producer client. The broker never parses or re-serializes record contents. Multiple `Produce` commands accumulate as separate `StagedEntry`s in the tracker; on flush, each gets its own `entry_id`. Batching win comes from amortizing WAL fsync across multiple entries, not from merging their contents.
+
+---
+
 ## Data Formats
 
 ### Filesystem Layout
@@ -21,7 +36,7 @@
       {segment_id}.seg                   # append-only, ≤1GB
 ```
 
-WAL is per-node (single sequential write point), split into fixed-size log files (e.g., 64MB each). When the active file reaches the size limit, it is sealed and a new file is opened. Old WAL files are deleted once all their records have been durably written to their respective segment files (see WAL Lifecycle below). Segment files organized by ownership hierarchy. Removing a shard group = `rm -rf {data_dir}/{shard_group_id}/`.
+WAL is per-node (single sequential write point), split into fixed-size log files (e.g., 64MB each). When the active file reaches the size limit, it is sealed and a new file is opened. Old WAL files are deleted once all their entries have been durably written to their respective segment files (see WAL Lifecycle below). Segment files organized by ownership hierarchy. Removing a shard group = `rm -rf {data_dir}/{shard_group_id}/`.
 
 ### Record Format
 
@@ -33,22 +48,55 @@ Base record (both WAL and segment files):
 
 Trailing length enables O(1) backward scan from EOF — read last 4 bytes, jump back `length + 9` (header size), verify CRC. Used in both WAL and segment files.
 
-Record types: `Data` (user payload), `BatchEnd` (marks flush boundary).
+Record types: `Data` (entry payload), `BatchEnd` (marks flush boundary).
 
-**WAL `Data` records** prepend a 32-byte routing header inside the payload — not in the base record header, not in user data. CRC covers the routing header.
+### Entry Format: Header + Opaque Payload
+
+An entry lives inside the base record wrapper — CRC, trailing length, and backward scan are inherited unchanged. Within the payload, an entry has two layers — a decompressed header the broker reads, and an opaque blob the broker never touches:
 
 ```
 WAL Data record payload layout:
-[shard_group_id: 8B][range_id: 8B][segment_id: 8B][logical_offset: 8B][user_data: M bytes]
- └──────────────────── routing header (32B) ──────────────────────────┘
 
-Segment file Data record payload layout:
-[user_data: N bytes]
+[shard_group_id: 8B][range_id: 8B][segment_id: 8B][entry_id: 8B][record_count: 4B]
+ └──────────────────── routing header (36B, WAL-only) ──────────────────────────────┘
+[opaque payload: remaining bytes]   ← compressed record data (broker-opaque)
 ```
 
-Routing header is WAL-only. During checkpoint, records are written to segment files with the routing header stripped — segment file path (`{shard_group_id}/{range_id}/{segment_id}.seg`) already encodes routing, and `logical_offset` is tracked by the sparse index. `logical_offset` enables idempotent WAL replay: records already in the segment file are skipped by comparing the record's `logical_offset` against the segment's current `end_offset` (see D5).
+The broker reads the routing header (segment routing + `entry_id` + `record_count`). The opaque payload is stored, replicated, and served as-is — zero serde at the broker.
 
-**Batch boundaries:** A `BatchEnd` record is written at the end of each batch. Batches are closed by whichever trigger fires first: 10ms elapsed, 20k records accumulated, or 10MB buffered. In the WAL, `BatchEnd` marks the fsync boundary (one fsync per batch). In segment files, `BatchEnd` marks batch boundaries for readers (consumer scan stops at `BatchEnd`). The sparse index writes one entry per batch at the `BatchEnd` boundary.
+**Segment file Data record payload layout** (checkpoint strips routing header, keeps entry payload):
+
+```
+[opaque payload: N bytes]   ← entry data blob (no routing header)
+```
+
+Same as WAL minus the routing header — segment file path already encodes routing, and `entry_id` is tracked by the sparse index.
+
+**Opaque payload internal format** (producer/consumer contract, invisible to broker):
+
+```
+decompress →
+  [key_len: u32][key][value_len: u32][value]   ← record 0
+  [key_len: u32][key][value_len: u32][value]   ← record 1
+  ...
+  (repeat record_count times)
+```
+
+Each record is a `(key, value)` pair — matching Northguard's record definition ("composed of a key, a value, as well as user-defined headers, all of which are just a sequence of bytes"). Compression (LZ4/ZSTD) applies to the entire payload block — one compress/decompress per entry, amortized across all records.
+
+**Data flow — broker never touches payload internals:**
+
+```
+Producer client: encode records → compress → EntryPayload
+        ↓
+Produce { segment_key, data: EntryPayload, record_count }
+        ↓
+Broker: stamp entry_id → WAL (routing header + blob) → cache (blob as-is) → replicate (blob as-is)
+        ↓
+Consumer: receive blob → decompress → parse records by record_index
+```
+
+**Batch boundaries:** A `BatchEnd` record is written at the end of each WAL flush. Flushes are closed by whichever trigger fires first: 10ms elapsed or 10MB buffered. In the WAL, `BatchEnd` marks the fsync boundary (one fsync per flush). In segment files, `BatchEnd` marks entry boundaries for readers. The sparse index writes one index entry per `entry_id` at the `BatchEnd` boundary.
 
 **Segment file I/O:** Both reads and writes use standard buffered I/O + `posix_fadvise(POSIX_FADV_DONTNEED)`. `FADV_DONTNEED` after each write and read evicts pages so segment file I/O doesn't pollute the OS page cache. No alignment constraints, no padding, same I/O model for reads and writes. WAL also uses standard buffered I/O + fsync (write-once-read-never in normal path).
 
@@ -60,30 +108,36 @@ enum RecordType {
     BatchEnd,
 }
 
-struct DataRoutingHeader {
+struct RoutingHeader {
     shard_group_id: ShardGroupId,
     range_id: RangeId,
     segment_id: SegmentId,
-    logical_offset: u64,
+    entry_id: u64,
+    record_count: u32,
 }
+
+// Opaque blob from producer — broker never parses.
+// Implements bincode Encode/Decode for wire transport (D2 ReplicaAppend).
+// Deref<Target = Bytes> for zero-copy access.
+struct EntryPayload(Bytes);
 
 struct Record {
     crc32: u32,
     record_type: RecordType,
-    payload: Bytes,         // WAL: routing header + user data. Segment file: user data only.
+    payload: Bytes,         // WAL: routing header + entry payload. Segment file: entry payload only.
 }
 ```
 
 ### Sparse Offset Index
 
-Separate RocksDB instance (not the metadata RocksDB). Sparse — not every offset indexed:
+Separate RocksDB instance (not the metadata RocksDB). Sparse — one entry per `entry_id`:
 
 ```
-Key:   [shard_group_id: 8B][range_id: 8B][segment_id: 8B][offset: 8B]
+Key:   [shard_group_id: 8B][range_id: 8B][segment_id: 8B][entry_id: 8B]
 Value: [byte_position: 8B]
 ```
 
-One entry per batch (e.g., every ~1000 records or every batch boundary). Consumer seek: RocksDB `seek_for_prev(target_offset)` → nearest indexed offset ≤ target → `pread()` segment file at that position → scan forward to exact offset. Batch fetching is native: `pread()` from the indexed position reads all records up to the next `BatchEnd` marker (or the next index entry's byte position if bounded). No per-record index lookup needed — one seek locates the batch, one sequential read returns it.
+One index entry per entry in the segment file. Consumer seek: RocksDB `seek_for_prev(target_entry_id)` → nearest indexed entry ≤ target → `pread()` segment file at that position → scan forward to exact entry. No per-record index lookup needed — one seek locates the entry, consumer uses `record_index` within it.
 
 Sparse index trades one short sequential scan on read for dramatically fewer index writes. Rebuilt from segment files on crash — not a source of truth.
 
@@ -92,35 +146,35 @@ Sparse index trades one short sequential scan on read for dramatically fewer ind
 ## Write Path
 
 ```
-records arrive
+Produce arrives (one per producer, pre-serialized EntryPayload)
     │
     ▼
-tracker.staged_records.push(record)
+tracker.staged_entries.push(StagedEntry)
     │
-    │ batch trigger fires (10ms / 20k records / 10MB)
+    │ flush trigger fires (10ms / 10MB)
     ▼
-╔════════════════════════════════════════════════════╗
-║ WAL: serialize all buffers with routing headers    ║
-║      → flat interleaved write → fsync              ║
-║      assign LSN to each record                     ║
-╚════════════════════════════╤═══════════════════════╝
+╔═══════════════════════════════════════════════════════════╗
+║ WAL: for each staged entry, write routing header + blob   ║
+║      → flat interleaved write → BatchEnd → fsync          ║
+║      assign entry_id to each entry                        ║
+╚════════════════════════════╤══════════════════════════════╝
                          │ ◄── durability point
                          ▼
-   ┌─────────── for each dirty segment ───────────┐
-   │ tracker.publish_staged(lsn)                 │
-   │   → drain staged_records → CachedBatch      │
-   │   → Arc::new() → store at batches[write_cursor%CAP]│
-   │   → write_cursor.store(write_cursor + 1, Release)           │
-   └─────────────────────┬──────────────────────-┘
+   ┌─────────── for each dirty segment ────────────────┐
+   │ tracker.publish_staged(lsn)                       │
+   │   for each staged entry:                          │
+   │     → entry_id = next_entry_id++                  │
+   │     → Arc::new(CachedEntry) → ring buffer publish │
+   └─────────────────────┬────────────────────────────-┘
                          │ ◄── in cache, not yet visible
                          ▼
    ┌─────────── D2+: replicate ─────────────────┐
-   │ send per-segment batches to all followers  │
+   │ send per-entry ReplicaAppend to followers  │
    │ wait ALL replica fsync ACK                 │
    └─────────────────────┬─────────────────────-┘
                          │
                          ▼
-   read_cursor.store(write_cursor, Release)
+   read_cursor advance (per entry, after all replicas ACK)
    notify.notify_waiters()  ◄── consumers can read
                          │
                          ▼
@@ -137,20 +191,20 @@ WAL fsync is the sole disk write on the critical path. Cache publish is two atom
 ## Read Path
 
 ```
-Consume(topic, range, offset)
+Consume(topic, range, entry_id, record_index)
     │
     ▼
 position < eviction_frontier?
     ├── yes → COLD: dispatch to cold read pool (see below)
     │
     ├── no, position < read_cursor?
-    │       └── yes → HOT: cache.read_batch(position) — Arc clone, no lock
+    │       └── yes → HOT: cache.read_committed(position) — Arc clone, no lock
     │
     └── position == read_cursor?
             └── yes → TAILING: cache.notified().await — wake on read_cursor advance
 ```
 
-Consumer offset tracking: consumers track their read position client-side. Each `Consume(topic, range, offset)` request carries the offset explicitly — the server is stateless with respect to consumer position. Consumer group offset commit and resume semantics are deferred (see roadmap backlog "Consumer Groups").
+Consumer offset tracking: consumers track their read position client-side via `(entry_id, record_index)`. The server is stateless with respect to consumer position. Consumer group offset commit and resume semantics are deferred (see roadmap backlog "Consumer Groups").
 
 **Hot/cold transition:** Consumer checks `eviction_frontier` on each iteration. When reading behind the frontier, it dispatches to cold read pool. Once its position catches up to `eviction_frontier`, the next read switches to the hot cache path (direct `Arc` clone from the ring buffer). The transition is seamless — same consumer task, same stream, just a different data source.
 
@@ -160,7 +214,7 @@ Consumer offset tracking: consumers track their read position client-side. Each 
 
 ### WAL (WalStorage + WalWriter + Lifecycle)
 
-WAL is the durability foundation — all other components depend on it. `SegmentRingBuffer` batches carry WAL LSNs, `DataPlane` writes through the WAL before publishing to cache.
+WAL is the durability foundation — all other components depend on it. `SegmentRingBuffer` entries carry WAL LSNs, `DataPlane` writes through the WAL before publishing to cache.
 
 ```rust
 // WAL I/O trait — injected into DataPlane. Mock in tests, WalWriter in production.
@@ -169,6 +223,8 @@ trait WalStorage {
     fn fsync(&mut self) -> io::Result<()>;
     fn rotate(&mut self) -> io::Result<()>;                        // seal active, open next
     fn delete_below(&mut self, watermark_lsn: u64);                // unlink eligible files
+    fn buf(&mut self) -> &mut Vec<u8>;                             // shared serialization buffer
+    fn next_lsn(&self) -> u64;                                    // for timer seq dedup
 }
 
 // Production implementation of WalStorage trait.
@@ -195,15 +251,15 @@ The WAL is a sequence of fixed-size log files, not a single ever-growing file. T
 
 **Rotation:** When the active WAL file reaches the size limit (~64MB), it is sealed (no more writes) and a new file is opened with the next sequence number. Writes always go to exactly one file — the active one.
 
-**LSN (Log Sequence Number):** Each WAL record carries an explicit node-local LSN — a monotonically increasing `u64` assigned by DataPlane during WAL write. LSN is carried by each `CachedBatch` in the ring buffer, enabling the checkpoint worker to report last-checkpointed LSN back to DataPlaneActor without recomputing from file positions.
+**LSN (Log Sequence Number):** Each WAL flush gets a node-local LSN — a monotonically increasing `u64` assigned by DataPlane. LSN is carried by each `CachedEntry` in the ring buffer, enabling the checkpoint worker to report last-checkpointed LSN back to DataPlaneActor without recomputing from file positions.
 
-**Deletion:** A sealed WAL file is eligible for deletion once ALL records in it have been checkpointed — flushed to their respective segment files and fsynced. Deletion gated by a **checkpoint LSN watermark**: each `WalFileEntry` covers a contiguous LSN range (`min_lsn` to `max_lsn`). The checkpoint worker reports LSN via `CheckpointComplete` to DataPlaneActor; the global checkpoint watermark is the minimum `checkpoint_lsn` across all active `SegmentTracker`s. A WAL file is unlinked when the global checkpoint watermark exceeds its `max_lsn`.
+**Deletion:** A sealed WAL file is eligible for deletion once ALL entries in it have been checkpointed — flushed to their respective segment files and fsynced. Deletion gated by a **checkpoint LSN watermark**: each `WalFileEntry` covers a contiguous LSN range (`min_lsn` to `max_lsn`). The checkpoint worker reports LSN via `CheckpointComplete` to DataPlaneActor; the global checkpoint watermark is the minimum `checkpoint_lsn` across all active `SegmentTracker`s. A WAL file is unlinked when the global checkpoint watermark exceeds its `max_lsn`.
 
 **Checkpoint LSN relationships:**
 
 ```
 checkpointed_lsn (per-segment)                    — reported by checkpoint worker in CheckpointComplete
-        │                                            "I flushed batches up to this WAL LSN for this segment"
+        │                                            "I flushed entries up to this WAL LSN for this segment"
         ▼
 segments[key].checkpoint_lsn (DataPlane)           — SegmentTracker field, accumulates latest
         │                                            checkpointed_lsn from each segment
@@ -213,7 +269,7 @@ global_checkpoint_watermark                        — min(segments.values().map
         ▼
 WAL deletion: unlink files where max_lsn ≤ watermark
 
-eviction_frontier (per-segment, in SegmentRingBuffer)   — ring buffer batch position (not an LSN)
+eviction_frontier (per-segment, in SegmentRingBuffer)   — ring buffer slot position (not an LSN)
                                                      tracks which cache slots can be reused
                                                      NOT comparable across segments or to WAL LSNs
 ```
@@ -221,26 +277,26 @@ eviction_frontier (per-segment, in SegmentRingBuffer)   — ring buffer batch po
 ```
 WAL file lifecycle:
 
-  wal-000001.log  [active]       → batch writes + fsync
+  wal-000001.log  [active]       → entry writes + fsync
                   [sealed]       → size limit reached, new file opened
-                  [checkpointing] → cache flushing records to segment files
-                  [deleted]      → all records checkpointed, unlink
+                  [checkpointing] → cache flushing entries to segment files
+                  [deleted]      → all entries checkpointed, unlink
 
 Deletion condition for wal-NNNNNN.log:
   checkpoint_watermark = min(each segment's last-checkpointed LSN)
   wal_file.max_lsn ≤ checkpoint_watermark
 ```
 
-**Bounded WAL size:** Under normal operation, the lag between WAL write and checkpoint is bounded by checkpoint frequency and cache size. WAL accumulation is bounded by the slowest checkpoint across all active segments on the node. Checkpoint frequency balances WAL retention (unflushed records keep WAL files alive) against disk I/O scheduling (larger, less frequent flushes are more efficient).
+**Bounded WAL size:** Under normal operation, the lag between WAL write and checkpoint is bounded by checkpoint frequency and cache size. WAL accumulation is bounded by the slowest checkpoint across all active segments on the node. Checkpoint frequency balances WAL retention (unflushed entries keep WAL files alive) against disk I/O scheduling (larger, less frequent flushes are more efficient).
 
 ### SegmentRingBuffer
 
-Lock-free ring buffer of immutable `Arc<CachedBatch>` batches. Single writer (`DataPlane` calls `publish` + `commit`), multiple readers (consumer tasks). No locks. Two cursors: `write_cursor` is the write cursor — where the next batch will be stored; `read_cursor` is the read cursor — consumers only see batches behind `read_cursor`. In D1 they advance together; in D2+ `read_cursor` lags by one replication RTT.
+Lock-free ring buffer of immutable `Arc<CachedEntry>` entries. Single writer (`DataPlane` calls `publish` + `advance_read_cursor`), multiple readers (consumer tasks). No locks. Two cursors: `write_cursor` is the write cursor — where the next entry will be stored; `read_cursor` is the read cursor — consumers only see entries behind `read_cursor`. In D1 they advance together; in D2+ `read_cursor` lags by one replication RTT.
 
 ```rust
 struct SegmentRingBuffer {
     // All fields private — access only through methods below.
-    batches: [ArcSwapOption<CachedBatch>; CAPACITY],
+    batches: [ArcSwapOption<CachedEntry>; CAPACITY],
     write_cursor: AtomicU64,
     read_cursor: AtomicU64,
     eviction_frontier: AtomicU64,
@@ -249,34 +305,32 @@ struct SegmentRingBuffer {
 
 impl SegmentRingBuffer {
     // Write path — called by DataPlane via SegmentTracker
-    fn publish(&self, batch: Arc<CachedBatch>);              // store into slot, advance write_cursor
-    fn commit(&self, new_offset: u64);                       // advance read_cursor, notify_waiters()
+    fn publish(&self, entry: Arc<CachedEntry>);              // store into slot, advance write_cursor
+    fn advance_read_cursor(&self, new_offset: u64);          // advance read_cursor, notify_waiters()
 
     // Read path — called by consumer tasks
-    fn load_read_cursor(&self) -> u64;                     // Acquire load
+    fn load_read_cursor(&self) -> u64;                       // Acquire load
     async fn notified(&self);                                // notify.notified().await
-    fn read_committed(&self, position: u64) -> Option<Arc<CachedBatch>>;  // committed only
-    fn load_published(&self, position: u64) -> Option<Arc<CachedBatch>>;  // committed + uncommitted
+    fn read_committed(&self, position: u64) -> Option<Arc<CachedEntry>>;  // committed only
+    fn load_published(&self, position: u64) -> Option<Arc<CachedEntry>>;  // committed + uncommitted
     fn load_eviction_frontier(&self) -> u64;                 // Acquire load
 
     // Checkpoint path — called by checkpoint worker
-    fn drain_for_checkpoint(&self) -> CheckpointBatch;       // reads frontier..read_cursor, returns batches + new_frontier
+    fn drain_for_checkpoint(&self) -> CheckpointBatch;       // reads frontier..read_cursor, returns entries + new_frontier
     fn advance_eviction_frontier(&self, new_frontier: u64);  // Release store
 }
 
-struct CachedBatch {
-    records: Vec<Bytes>,           // user data only, no WAL overhead
-    start_offset: u64,             // first record's logical offset
-    end_offset: u64,               // last record's logical offset
-    lsn: u64,                      // WAL LSN for checkpoint tracking
+struct CachedEntry {
+    data: EntryPayload,        // opaque blob from producer — broker never parses
+    record_count: u32,         // number of records in this entry
+    entry_id: u64,             // broker-assigned, per-segment monotonic
+    lsn: u64,                  // WAL LSN for checkpoint tracking
 }
 ```
 
-Slots use `arc_swap::ArcSwapOption` — load + refcount increment is atomic, eliminating the dangling-pointer risk that raw `AtomicPtr` + manual `Arc::increment_strong_count` has when a consumer is preempted at the hot/cold boundary. `publish` calls `ArcSwapOption::store()`, readers call `load_full()` which returns `Option<Arc<…>>` with the refcount already incremented. On eviction, the old Arc is dropped when the slot is overwritten — batch freed when last consumer releases theirs.
+Slots use `arc_swap::ArcSwapOption` — load + refcount increment is atomic, eliminating the dangling-pointer risk that raw `AtomicPtr` + manual `Arc::increment_strong_count` has when a consumer is preempted at the hot/cold boundary. `publish` calls `ArcSwapOption::store()`, readers call `load_full()` which returns `Option<Arc<…>>` with the refcount already incremented. On eviction, the old Arc is dropped when the slot is overwritten — entry freed when last consumer releases theirs.
 
-**Consumer seek:** Each `CachedBatch` carries `(start_offset, end_offset)`. Binary search over published batches by offset range to find the batch containing the target offset, then linear scan within the batch.
-
-**Ordering:** Within a segment, record ordering is preserved. Per-segment `staged_records` are appended in arrival order during the batch window. Cross-segment ordering is not guaranteed (and not needed — event streaming guarantees ordering per-range, not globally).
+**Ordering:** Within a segment, entries are ordered by `entry_id`. Multiple `Produce` commands from different producers are staged as separate `StagedEntry`s and published in FIFO order — each with its own `entry_id`. Cross-segment ordering is not guaranteed (and not needed — event streaming guarantees ordering per-range, not globally).
 
 ### DataPlane + DataPlaneActor
 
@@ -287,6 +341,12 @@ Follows the sync-first pattern (see `build-actor` skill): pure sync state machin
 WAL does blocking file I/O (write, fsync, rotate, unlink) — injected via `WalStorage` trait so `DataPlane` can be tested with a mock WAL that records calls without touching disk. Same pattern as `Raft` + `RaftStorage` (see `src/clusters/raft/storage.rs`).
 
 ```rust
+struct StagedEntry {
+    data: EntryPayload,             // opaque blob from producer
+    record_count: u32,
+    segment_key: SegmentKey,
+}
+
 struct SegmentTracker {
     cache: Arc<SegmentRingBuffer>,
     size_bytes: u64,                     // accumulated data bytes, triggers RollSegment at ~1GB
@@ -294,9 +354,9 @@ struct SegmentTracker {
     segment_file_path: PathBuf,
     role: SegmentRole,                   // Leader | Follower (D2)
     replica_set: Vec<NodeId>,            // [leader, follower, ...] (D2)
-    committed_end_offset: u64,           // last committed logical offset (D2)
-    next_offset: u64,                    // next logical offset to assign (D2)
-    staged_records: Vec<StagingRecord>,  // per-segment write buffer (D2, replaces accumulation_buffers)
+    committed_entry_id: u64,             // last committed entry_id (D2)
+    next_entry_id: u64,                  // next entry_id to assign on publish
+    staged_entries: Vec<StagedEntry>,    // accumulated entries awaiting flush
 }
 
 // State machine — pure sync, no channels. I/O only through injected WalStorage.
@@ -307,7 +367,6 @@ struct DataPlane<W: WalStorage> {
     segments: HashMap<SegmentKey, SegmentTracker>,
     dirty_segments: Vec<SegmentKey>,
     pending_events: Vec<DataPlaneEvent>,
-    buffer_record_count: usize,
     buffer_byte_count: usize,
     needs_flush: bool,
     data_dir: PathBuf,
@@ -351,6 +410,13 @@ enum DataPlaneCommand {
     Timeout(DataPlaneTimeoutCallback),
     InterNode(DataPlaneInterNodeCommand),  // all inter-node commands via transport
 }
+
+struct Produce {
+    segment_key: SegmentKey,    // resolved by broker's routing layer, not from producer
+    data: EntryPayload,         // opaque blob from producer client
+    record_count: u32,          // producer declares record count
+    reply: oneshot::Sender<ProduceAck>,
+}
 ```
 
 **Event flow for produce:**
@@ -364,9 +430,9 @@ handle_command(Produce { reply, .. })
             │
             ▼
         replication.enqueue_reply(key, reply)  ◄── reply tracked in ReplicationState
-        tracker.buffer_record(key, data)       ◄── buffer into staged_records
+        tracker.stage_entry(key, data, record_count) ◄── push to staged_entries
             │
-            │ batch trigger fires (10ms / 20k / 10MB / needs_flush)
+            │ flush trigger fires (10ms / 10MB / needs_flush)
             ▼
         flush_batch()
             │
@@ -375,10 +441,11 @@ handle_command(Produce { reply, .. })
             │
             └── WAL fsync succeeds
                     publish_staged(lsn) for each dirty segment
+                    │ (each staged entry gets its own entry_id)
                     │
-                    ├── Leader, no followers → commit_batch, drain pending_replies with Ok
+                    ├── Leader, no followers → commit_entry, drain pending_replies with Ok
                     ├── Leader, followers → emit BatchPublished (replication fan-out)
-                    │       dispatch: begin_replication → send ReplicaAppend
+                    │       dispatch: begin_replication → send ReplicaAppend per entry
                     │       on all acks → commit_segment → drain replies with Ok
                     └── Follower → send ReplicaAck to leader via InterNodeCommandQueued
 ```
@@ -395,11 +462,11 @@ Built from WAL replay + segment directory scan at startup (D5).
 
 **Backpressure:** Natural. If WAL fsync is slow, the dedicated thread stalls, the inbound `crossbeam` channel fills, producers block on `send()`. No async flow control needed.
 
-**Timer:** Two timer types: `BatchFlushTimer` (10ms batch deadline) and `ReplicationTimer` (1s replication timeout, D2), both implementing `TTimer`. Each has its own `SchedulerSender`. Callbacks arrive as `DataPlaneTimeoutCallback` variants via `DataPlaneCommand::Timeout`.
+**Timer:** Two timer types: `BatchFlushTimer` (10ms deadline) and `ReplicationTimer` (1s replication timeout, D2), both implementing `TTimer`. Each has its own `SchedulerSender`. Callbacks arrive as `DataPlaneTimeoutCallback` variants via `DataPlaneCommand::Timeout`.
 
 ### Checkpoint Worker
 
-Single dedicated OS thread. Sequential pipeline: read batches → write segment file → fsync → update sparse index → advance eviction frontier → report. No protocol logic, no state transitions — just a worker loop. Parallelism wouldn't help — checkpoint is write-bound (sequential writes to one stream, fsync dominates), and multiple concurrent fsyncs to the same disk add contention, not throughput. Cold read pool uses multiple threads because reads are latency-bound with independent `pread()` calls across different files. No caller waits on the checkpoint result (fire-and-forget from DataPlaneActor).
+Single dedicated OS thread. Sequential pipeline: read entries → write segment file → fsync → update sparse index → advance eviction frontier → report. No protocol logic, no state transitions — just a worker loop. Parallelism wouldn't help — checkpoint is write-bound (sequential writes to one stream, fsync dominates), and multiple concurrent fsyncs to the same disk add contention, not throughput. Cold read pool uses multiple threads because reads are latency-bound with independent `pread()` calls across different files. No caller waits on the checkpoint result (fire-and-forget from DataPlaneActor).
 
 ```rust
 fn run_checkpoint_worker(
@@ -407,7 +474,7 @@ fn run_checkpoint_worker(
     mailbox: crossbeam::channel::Receiver<CheckpointJob>,
     data_plane_tx: crossbeam::channel::Sender<DataPlaneCommand>,
 ) {
-    // loop { recv job → read batches → write .seg → fsync → FADV_DONTNEED
+    // loop { recv job → read entries → write .seg → fsync → FADV_DONTNEED
     //        → update sparse_index → advance eviction_frontier → send CheckpointComplete }
 }
 
@@ -432,11 +499,11 @@ submit CheckpointJob {
 } ─── crossbeam channel ─────────► recv CheckpointJob
                                        │
                                        ▼
-                                   read batches from cache
+                                   read entries from cache
                                    (read-only, behind write_cursor)
                                        │
                                        ▼
-                                   coalesce → write to .seg file
+                                   write entry payload to .seg file
                                        │
                                        ▼
                                    fsync segment file
@@ -458,19 +525,18 @@ mailbox.recv() ◄─────────────────    Checkpo
   unlink WAL files ≤ watermark         }
 ```
 
-Batches behind `eviction_frontier` with `Arc::strong_count() == 1` (only the cache slot holds a ref — no active consumer reading them) are freed. Batches still held by consumers stay alive via `Arc` refcount until those consumers advance past them.
+Entries behind `eviction_frontier` with `Arc::strong_count() == 1` (only the cache slot holds a ref — no active consumer reading them) are freed. Entries still held by consumers stay alive via `Arc` refcount until those consumers advance past them.
 
 ### Checkpoint Triggers and Cache Policy
 
 Segment files are derived from WAL — they exist for cold read performance, not durability. Checkpoint is driven by data volume, not time. No checkpoint timer needed.
 
-**Ring buffer capacity:** configurable slot count per segment (e.g., 1024 batches ≈ 32MB). Node-level hard cap on total ring buffer memory across all segment caches (e.g., 4GB). Data stays in cache as long as possible — longer residency means more hot reads served from memory.
+**Ring buffer capacity:** configurable slot count per segment (e.g., 1024 entries ≈ 32MB). Node-level hard cap on total ring buffer memory across all segment caches (e.g., 4GB). Data stays in cache as long as possible — longer residency means more hot reads served from memory.
 
-**Three checkpoint triggers** — checkpoint happens when there's a reason, not on a clock:
+**Two checkpoint triggers** — checkpoint happens when there's a reason, not on a clock:
 
-1. **Segment size approaching limit.** `DataPlane` tracks `segments[key].size_bytes` — accumulated data bytes per segment, incremented as records are accumulated. When approaching 1GB, submits a checkpoint job — one large, efficient bulk write. After checkpoint, the segment rolls (`RollSegment`).
-2. **Node cache budget pressure.** When total cache memory approaches the node-level budget, DataPlaneActor force-checkpoints the segments with the most uncheckpointed batches to free cache slots.
-3. **WAL retention pressure.** When total WAL size exceeds a threshold (e.g., 2GB), DataPlaneActor checkpoints the segments keeping the oldest WAL files alive. Bounds crash recovery time and WAL disk usage.
+1. **Segment size approaching limit.** `DataPlane` tracks `segments[key].size_bytes` — accumulated data bytes per segment, incremented on each `stage_entry`. When approaching 1GB, submits a checkpoint job — one large, efficient bulk write. After checkpoint, the segment rolls (`RollSegment`).
+2. **Node cache budget pressure.** When total cache memory approaches the node-level budget, DataPlaneActor force-checkpoints the segments with the most uncheckpointed entries to free cache slots.
 
 All triggers submit work to checkpoint worker. The `eviction_frontier` is the single source of truth — triggers check it against `write_cursor` to determine what needs flushing. When the ring wraps, the writer overwrites the oldest slot — but only if it's behind the eviction frontier (already checkpointed) and has `Arc::strong_count() == 1` (no active reader). If the oldest slot is still held, checkpoint is forced before advancing.
 
@@ -481,14 +547,14 @@ Fixed-size thread pool (e.g., 4 threads). Cold reads are initiated by many indep
 ```rust
 struct ColdReadRequest {
     segment_key: SegmentKey,
-    start_offset: u64,
+    start_entry_id: u64,
     max_bytes: u64,
     respond_tx: oneshot::Sender<ColdReadResult>,
 }
 
 struct ColdReadResult {
-    records: Vec<Record>,
-    next_offset: u64,
+    entries: Vec<EntryPayload>,
+    next_entry_id: u64,
 }
 ```
 
@@ -499,17 +565,17 @@ position < eviction_frontier
 or segment sealed (no cache)
 
 send ColdReadRequest {
-  segment_key, start_offset,
+  segment_key, start_entry_id,
   max_bytes, respond_tx
 } ─── crossbeam channel ────────► recv ColdReadRequest
                                       │
                                       ▼
-                                  seek_for_prev(start_offset)
+                                  seek_for_prev(start_entry_id)
                                   → byte_position
                                       │
                                       ▼
                                   pread(seg_file, byte_position)
-                                  scan forward to exact offset
+                                  scan forward to exact entry
                                       │
                                       ▼
                                   POSIX_FADV_DONTNEED on range
@@ -518,7 +584,7 @@ send ColdReadRequest {
 .await oneshot ◄───────────────── respond_tx.send(ColdReadResult)
 (non-blocking)
 
-yield records to consumer stream
+yield entry to consumer stream
 check eviction_frontier:
   if position >= eviction_frontier
     → switch to hot cache path
@@ -536,13 +602,13 @@ Crash recovery scans from the oldest un-deleted WAL file forward (see Phase D5).
 
 ### Uncommitted Tail on Replication Failure
 
-When replication (D2+) partially fails, records may be in the leader's cache (`write_cursor` advanced) but not yet committed (`read_cursor` not advanced). Two sub-cases:
+When replication (D2+) partially fails, entries may be in the leader's cache (`write_cursor` advanced) but not yet committed (`read_cursor` not advanced). Two sub-cases:
 
-**Follower fails, leader healthy:** The leader seals the segment with `end_offset = read_cursor` — the last offset ACKed by all replicas. Batches at positions `read_cursor` through `write_cursor - 1` are uncommitted: cached on the leader and fsynced in the leader's WAL, but never ACKed to the producer. The leader drains these uncommitted batches from cache and replays them into the new segment (opened after `RollSegment`), where they will be re-committed with the new replica set. Producers whose records were in the uncommitted window also retry (no ACK received).
+**Follower fails, leader healthy:** The leader seals the segment with `end_entry_id = committed_entry_id` — the last entry_id ACKed by all replicas. Entries at positions `read_cursor` through `write_cursor - 1` are uncommitted: cached on the leader and fsynced in the leader's WAL, but never ACKed to the producer. The leader drains these uncommitted entries from cache via `uncommitted_entries()` and replays them into the new segment (opened after `RollSegment`), where they will be re-committed with the new replica set. Producers whose entries were in the uncommitted window also retry (no ACK received).
 
-**Leader crashes after WAL write:** WAL records beyond the sealed segment's `end_offset` are orphaned. On recovery (D5), WAL replay compares each record's `logical_offset` against the segment's `end_offset` — records past it belong to the old, sealed segment and are skipped. The producer never received an ACK for these records and retries against the new segment leader.
+**Leader crashes after WAL write:** WAL entries beyond the sealed segment's `end_entry_id` are orphaned. On recovery (D5), WAL replay compares each entry's `entry_id` against the segment's `end_entry_id` — entries past it belong to the old, sealed segment and are skipped. The producer never received an ACK for these entries and retries against the new segment leader.
 
-In D1 (no replication, `read_cursor == write_cursor`), this subsection does not apply — there is no replication failure mode. See invariant 15.
+In D1 (no replication, `read_cursor == write_cursor`), this subsection does not apply — there is no replication failure mode. See invariant 14.
 
 ---
 
@@ -552,15 +618,15 @@ In D1 (no replication, `read_cursor == write_cursor`), this subsection does not 
 
 2. **Active file is last in `files`.** `WalWriter.files.back()` is always the active file (`file: Some(...)`); all preceding entries are sealed (`file: None`). Rotation takes the active entry's `File` handle (`Option::take`) and pushes a new active entry to the back.
 
-3. **LSN monotonicity.** WAL LSNs are monotonically increasing. Each record's LSN is strictly greater than the previous record's LSN, across all WAL files.
+3. **LSN monotonicity.** WAL LSNs are monotonically increasing. Each flush's LSN is strictly greater than the previous flush's LSN, across all WAL files.
 
-4. **Segment file records ordered by logical offset.** Records within a segment file are strictly ordered by `logical_offset`. No gaps, no reordering.
+4. **Segment file entries ordered by entry_id.** Entries within a segment file are strictly ordered by `entry_id`. No gaps, no reordering.
 
 5. **WAL deletion gated by checkpoint watermark.** A WAL file is deleted only when `global_checkpoint_watermark ≥ wal_file.max_lsn`. The watermark is the minimum last-checkpointed LSN across all active segments.
 
-6. **Cache spans eviction frontier to tail; readers bounded by read_cursor.** Batches between `eviction_frontier` and `write_cursor` are always in the ring buffer. Consumer-visible range is positions `eviction_frontier` through `read_cursor - 1`. Batches at positions `read_cursor` through `write_cursor - 1` exist in cache but are not yet visible to consumers. Batches behind `eviction_frontier` may still exist (held by consumer `Arc` refs) but are eligible for slot reuse. Batches at or beyond `write_cursor` do not exist.
+6. **Cache spans eviction frontier to tail; readers bounded by read_cursor.** Entries between `eviction_frontier` and `write_cursor` are always in the ring buffer. Consumer-visible range is positions `eviction_frontier` through `read_cursor - 1`. Entries at positions `read_cursor` through `write_cursor - 1` exist in cache but are not yet visible to consumers. Entries behind `eviction_frontier` may still exist (held by consumer `Arc` refs) but are eligible for slot reuse. Entries at or beyond `write_cursor` do not exist.
 
-7. **Checkpoint is idempotent.** All three triggers (segment size, cache budget, WAL retention) check `eviction_frontier` against `write_cursor`. No new batches since last checkpoint → no-op.
+7. **Checkpoint is idempotent.** Both triggers (segment size, cache budget) check `eviction_frontier` against `write_cursor`. No new entries since last checkpoint → no-op.
 
 8. **Segment file I/O uses buffered I/O + `POSIX_FADV_DONTNEED`.** Both checkpoint writes and cold reads use standard buffered I/O. `FADV_DONTNEED` after each operation evicts pages from OS page cache.
 
@@ -568,16 +634,18 @@ In D1 (no replication, `read_cursor == write_cursor`), this subsection does not 
 
 10. **Segment file ≤ 1GB.** DataPlaneActor signals `RollSegment` when approaching the limit. Enforced at the write path — never retroactively truncated.
 
-11. **WAL fsync is the durability boundary.** Records are durable only after the WAL batch containing them is fsynced. Producer ACK sent after WAL fsync + cache publish + replication. Segment files and sparse index are derived — their absence never means data loss.
+11. **WAL fsync is the durability boundary.** Entries are durable only after the WAL flush containing them is fsynced. Producer ACK sent after WAL fsync + cache publish + replication. Segment files and sparse index are derived — their absence never means data loss.
 
-12. **Node-level cache budget is a hard cap.** Sum of all ring buffer allocations never exceeds the configured budget. Under pressure, force checkpoint to advance eviction frontiers; if all batches are uncheckpointed, backpressure propagates to WAL dispatch.
+12. **Node-level cache budget is a hard cap.** Sum of all ring buffer allocations never exceeds the configured budget. Under pressure, force checkpoint to advance eviction frontiers; if all entries are uncheckpointed, backpressure propagates to WAL dispatch.
 
-13. **Published batches are immutable.** No mutation after `write_cursor` advancement. Writer never modifies data behind `write_cursor`. Readers only access data behind `write_cursor`. This is the SWMR (single-writer, multiple-reader) invariant that eliminates locking.
+13. **Published entries are immutable.** No mutation after `write_cursor` advancement. Writer never modifies data behind `write_cursor`. Readers only access data behind `write_cursor`. This is the SWMR (single-writer, multiple-reader) invariant that eliminates locking.
 
-14. **Within-segment record ordering preserved.** Per-segment accumulation buffers maintain arrival order. Records in a `CachedBatch` are ordered by `logical_offset`. Cross-segment ordering is not guaranteed.
+14. **`eviction_frontier` ≤ `read_cursor` ≤ `write_cursor` always.** Three monotonically advancing markers partition the ring buffer into zones. In D1 (no replication), `read_cursor == write_cursor` — both advance together on cache publish. In D2+, `read_cursor` lags `write_cursor` by one replication RTT: `write_cursor` advances on cache publish, `read_cursor` advances after all replicas ACK.
 
-15. **`eviction_frontier` ≤ `read_cursor` ≤ `write_cursor` always.** Three monotonically advancing markers partition the ring buffer into zones. In D1 (no replication), `read_cursor == write_cursor` — both advance together on cache publish. In D2+, `read_cursor` lags `write_cursor` by one replication RTT: `write_cursor` advances on cache publish, `read_cursor` advances after all replicas ACK.
+15. **Sealed segment `end_entry_id` = last committed entry_id.** On seal, `end_entry_id` is set to `committed_entry_id` at seal time, not `write_cursor`. Entries at positions `read_cursor` through `write_cursor - 1` are uncommitted — replayed into the next segment by the leader (see "Uncommitted Tail on Replication Failure").
 
-16. **Sealed segment `end_offset` = last committed offset.** On seal, `end_offset` is set to `read_cursor` at seal time, not `write_cursor`. Batches at positions `read_cursor` through `write_cursor - 1` are uncommitted — replayed into the next segment by the leader (see "Uncommitted Tail on Replication Failure").
+16. **Consumer read position determines data source.** A consumer at `position` follows exactly one path: `position < eviction_frontier` → cold read path (cold read pool); `eviction_frontier ≤ position < read_cursor` → hot cache read (clone `Arc` from ring buffer); `position == read_cursor` → tailing (await `notify`). Consumers never read at or beyond `read_cursor` — entries at positions `read_cursor` through `write_cursor - 1` are uncommitted and invisible. This prevents consumers from observing entries that may be rolled back on replication failure.
 
-17. **Consumer read position determines data source.** A consumer at `position` follows exactly one path: `position < eviction_frontier` → cold read path (cold read pool); `eviction_frontier ≤ position < read_cursor` → hot cache read (clone `Arc` from ring buffer); `position == read_cursor` → tailing (await `notify`). Consumers never read at or beyond `read_cursor` — batches at positions `read_cursor` through `write_cursor - 1` are uncommitted and invisible. This prevents consumers from observing records that may be rolled back on replication failure.
+17. **Broker is opaque to entry payloads.** The broker never parses, re-serializes, or merges `EntryPayload` contents. Producer client encodes records, consumer client decodes them. The broker stamps `entry_id`, writes the blob to WAL, caches it, and replicates it as-is. Compression is end-to-end between producer and consumer.
+
+18. **One Produce = one entry = one entry_id.** Each `Produce` command stages one `StagedEntry`. Multiple produces accumulate as separate entries in `staged_entries`. On flush, each gets its own monotonically increasing `entry_id`. Entries from different producers are never merged.

--- a/diagrams/data-plane/d2_segment_replication.md
+++ b/diagrams/data-plane/d2_segment_replication.md
@@ -11,25 +11,25 @@
 ### Leader Write Path
 
 ```
-records arrive
+Produce arrives (one per producer, pre-serialized EntryPayload)
     │
     ▼
-tracker.staged_records.push(record)
+tracker.staged_entries.push(StagedEntry)
     │
-    │ batch trigger fires (10ms / 20k records / 10MB)
+    │ flush trigger fires (10ms / 10MB)
     ▼
-╔═══════════════════════════════════════════════════════╗
-║ WAL: serialize all buffers with routing headers       ║
-║      → flat interleaved write → fsync                 ║
-║      assign LSN to each record                        ║
-╚════════════════════════╤══════════════════════════════╝
+╔════════════════════════════════════════════════════════════════╗
+║ WAL: for each staged entry, write routing header + blob       ║
+║      → flat interleaved write → BatchEnd → fsync              ║
+║      assign entry_id to each entry                            ║
+╚════════════════════════╤═══════════════════════════════════════╝
                          │ ◄── durability point (local)
                          ▼
    ┌─────────── for each dirty segment ──────────────┐
    │ tracker.publish_staged(lsn)                     │
-   │   → drain staged_records → CachedBatch          │ 
-   │   → Arc::new() → store at batches[w_cursor%CAP] │
-   │   → w_cursor.store(w_cursor+1, Release)         │
+   │   for each staged entry:                        │
+   │     → entry_id = next_entry_id++                │
+   │     → Arc::new(CachedEntry) → ring buffer       │
    └─────────────────────┬───────────────────────────┘
                          │ ◄── in cache, not yet visible to consumers
                          ▼
@@ -61,45 +61,45 @@ tracker.staged_records.push(record)
 
 WAL fsync is the sole disk write on the leader's critical path, same as D1. The replication fan-out is network I/O (async, non-blocking). Produce latency = `local_fsync + max(follower_fsyncs)` — one local fsync plus one replication RTT in the common case.
 
-**No-follower fast path:** When `tracker.followers()` is empty (replication_factor=1), `flush_batch()` checks `tracker.followers().is_empty()` after publish. If true: immediately call `commit_batch`, drain all pending replies with `Ok`, no `ReplicaAppend`, no timer, no `PendingBatch`. Degrades to D1 behavior.
+**No-follower fast path:** When `tracker.followers()` is empty (replication_factor=1), `flush_batch()` checks `tracker.followers().is_empty()` after publish. If true: immediately call `commit_entry` for each published entry, drain all pending replies with `Ok`, no `ReplicaAppend`, no timer, no `PendingBatch`. Degrades to D1 behavior.
 
 ### Follower Write Path
 
 ```
-ReplicaAppend arrives
+ReplicaAppend arrives (one entry: EntryPayload + entry_id)
     │
     ├── segment unknown? validate & create SegmentTracker (see self-authorization)
     │
     ▼
-tracker.staged_records.push(records)
+tracker.stage_entry_from_replica(data, record_count, entry_id)
     │
-    │ flush_batch() fires (unified — see below)
+    │ needs_flush = true → flush_batch() fires immediately
     ▼
-╔═══════════════════════════════════════════════════════╗
-║ WAL: drain each tracker.staged_records (all segments) ║
-║    → single write → fsync → BatchEnd                  ║
-╚════════════════════════════╤══════════════════════════╝
-                             │ ◄── durability point (all records in this flush)
+╔═══════════════════════════════════════════════════════════╗
+║ WAL: for each staged entry, write routing header + blob   ║
+║    → single write → BatchEnd → fsync                      ║
+╚════════════════════════════╤══════════════════════════════╝
+                             │ ◄── durability point (all entries in this flush)
                              ▼
        per follower segment:
-         publish_staged(lsn) → ReplicaAck to leader
+         publish_staged(lsn) → ReplicaAck { entry_id } to leader
        per leader segment:
          publish_staged(lsn) → BatchPublished (replication fan-out)
 
-CommitAdvance { committed_end_offset } arrives later from leader
+CommitAdvance { committed_entry_id } arrives later from leader
     │
     ▼
-read_cursor += 1, notify.notify_waiters()    ◄── follower consumers can read
-tracker.committed_end_offset = committed_end_offset
+tracker.commit_entry(committed_entry_id)
+  → read_cursor += 1, notify.notify_waiters()    ◄── follower consumers can read
 ```
 
-Records arrive pre-batched in `ReplicaAppend` — no accumulation on the follower side. Both leader and follower segments buffer into `tracker.staged_records`. The unified flush drains all trackers in a single WAL write + fsync + `BatchEnd`, enabling uniform crash recovery (D5).
+Records arrive pre-batched in `ReplicaAppend` — no accumulation on the follower side. Both leader and follower segments buffer into `tracker.staged_entries`. The unified flush drains all trackers in a single WAL write + fsync + `BatchEnd`, enabling uniform crash recovery (D5).
 
-**Unified WAL Flush.** A node writes to one WAL. All segments buffer into `tracker.staged_records` — the buffer is embedded in `SegmentTracker`, co-located with `role`, `cache`, and `committed_end_offset`. `flush_batch()` iterates dirty segments, drains each tracker's `staged_records`, and writes everything in a single WAL write + fsync + `BatchEnd`. Post-flush, `tracker.role` determines events: leader → `BatchPublished` (replication fan-out), follower → `ReplicaAck` via `InterNodeCommandQueued`. Single lookup per segment, no separate buffer map.
+**Unified WAL Flush.** A node writes to one WAL. All segments buffer into `tracker.staged_entries` — the buffer is embedded in `SegmentTracker`, co-located with `role`, `cache`, and `committed_entry_id`. `flush_batch()` iterates dirty segments, drains each tracker's `staged_entries`, and writes everything in a single WAL write + fsync + `BatchEnd`. Post-flush, `tracker.role` determines events: leader → `BatchPublished` (replication fan-out), follower → `ReplicaAck` via `InterNodeCommandQueued`. Single lookup per segment, no separate buffer map.
 
-Flush fires when either a leader batch trigger trips (10ms / 20k / 10MB) OR the actor finishes draining the mailbox with `needs_flush == true`. Multiple `ReplicaAppend`s from different leaders that arrive in the same mailbox batch share one fsync. Leader records ride along for free if a follower triggers the flush, and vice versa.
+Flush fires when either a leader flush trigger trips (10ms / 10MB) OR the actor finishes draining the mailbox with `needs_flush == true`. Multiple `ReplicaAppend`s from different leaders that arrive in the same mailbox drain share one fsync. Leader entries ride along for free if a follower triggers the flush, and vice versa.
 
-Follower-to-leader promotion (F2) requires no buffer migration: the new segment's `SegmentTracker` is created with `role = Leader` and an empty `staged_records`. `flush_batch()` handles it like any other leader segment.
+Follower-to-leader promotion (F2) requires no buffer migration: the new segment's `SegmentTracker` is created with `role = Leader` and an empty `staged_entries`. `flush_batch()` handles it like any other leader segment.
 
 ### Replica Self-Authorization
 
@@ -112,11 +112,11 @@ Only the segment leader requires explicit `SegmentAssignment` from the coordinat
 
 ### Commit Notification
 
-After the leader advances `read_cursor` (all replicas ACKed), it sends `CommitAdvance { segment_key, committed_end_offset }` to all followers. Followers advance their own `read_cursor` on receipt — follower consumers can then read the committed batch.
+After the leader advances `read_cursor` (all replicas ACKed), it sends `CommitAdvance { segment_key, committed_entry_id }` to all followers. Followers advance their own `read_cursor` on receipt — follower consumers can then read the committed entry.
 
-`CommitAdvance` carries the **logical record offset** (`committed_end_offset`), not the ring buffer batch position. Follower on receipt: `tracker.commit_batch(committed_end_offset)` — internally advances `read_cursor` by 1, sets `committed_end_offset`, and notifies consumers. Decouples the wire protocol from ring buffer internals. Lightweight message (`segment_key` + `u64`), sent once per commit per follower. TCP ordering guarantees it arrives before the next `ReplicaAppend`. Follower visibility lags the leader by ~0.5 RTT (one network hop), not by one batch interval.
+`CommitAdvance` carries the `entry_id`, not the ring buffer slot position. Follower on receipt: `tracker.commit_entry(committed_entry_id)` — internally advances `read_cursor` by 1, sets `committed_entry_id`, and notifies consumers. Decouples the wire protocol from ring buffer internals. Lightweight message (`segment_key` + `u64`), sent once per commit per follower. TCP ordering guarantees it arrives before the next `ReplicaAppend`. Follower visibility lags the leader by ~0.5 RTT (one network hop), not by one flush interval.
 
-**Validation:** `debug_assert!(next_batch.end_offset == received_offset)`. Mismatch indicates a bug (TCP guarantees ordering, so message reordering is impossible). In release: log error, disconnect from leader — follower can't trust subsequent messages. Leader's `ReplicationTimeout` fires and seals.
+**Validation:** `debug_assert!(cached_entry.entry_id == committed_entry_id)`. Mismatch indicates a bug (TCP guarantees ordering, so message reordering is impossible). In release: log error, disconnect from leader — follower can't trust subsequent messages. Leader's `ReplicationTimeout` fires and seals.
 
 ---
 
@@ -129,42 +129,41 @@ SegmentTracker (D1 fields unchanged)
 ├── cache: SegmentRingBuffer, size_bytes, checkpoint_lsn, segment_file_path
 ├── role: Leader | Follower                     ← NEW
 ├── replica_set: [leader, follower, follower]   ← NEW
-├── committed_end_offset: u64                   ← NEW (init 0)
-├── next_offset: u64                            ← NEW (decoupled from size_bytes)
-└── staged_records: Vec<StagingRecord>           ← NEW (moved from DataPlane)
+├── committed_entry_id: u64                     ← NEW (init 0)
+├── next_entry_id: u64                          ← NEW (broker-assigned per entry)
+└── staged_entries: Vec<StagedEntry>            ← NEW (accumulated produce entries)
 ```
 
-**`next_offset` vs `size_bytes`:** D1 uses `size_bytes` as both byte counter and logical offset source — these are now decoupled. `next_offset` tracks the logical offset for the next record (initialized from `SegmentAssignment` for normal segments, `old.committed_end_offset + 1` for post-seal). `size_bytes` tracks cumulative bytes for 1GB limit, always starts at 0. `SegmentAssignment` carries `start_offset` (D3 — for initial segments: 0, rolled segments: `prev.end_offset + 1`).
+**`next_entry_id` vs `size_bytes`:** `next_entry_id` tracks the next entry ID to assign on publish (incremented per entry, not per record). `size_bytes` tracks cumulative payload bytes for the 1GB segment limit. `SegmentAssignment` carries `start_entry_id` (D3 — for initial segments: 0, rolled segments: `prev.end_entry_id + 1`).
 
-**D1 migration:** D1's `DataPlane.accumulation_buffers: HashMap<SegmentKey, Vec<BufferedRecord>>` is removed. Per-segment buffer moves into `tracker.staged_records`. Aggregate counters `buffer_record_count` / `buffer_byte_count` stay on `DataPlane` — they track totals across all leader segments for batch trigger thresholds (20k / 10MB are global). Follower records do not count toward these — followers trigger flush via `needs_flush`. `DataPlane.dirty_segments: Vec<SegmentKey>` tracks which segments have buffered data — `flush_batch()` only visits dirty segments, avoiding O(all_segments) iteration.
+**Two-phase publish:** `stage_to_wal(wal_buf)` encodes each staged entry into WAL buffer (one WAL record per entry, with routing header). `publish_staged(lsn)` drains `staged_entries`, assigns `entry_id` to each, publishes to ring buffer. Commit is separate: `commit_entry(entry_id)` (`read_cursor` += 1, updates `committed_entry_id`, notifies consumers). Also adds `followers() → &[NodeId]` returning `replica_set[1..]`.
 
-**Two-phase publish:** D1's `publish()` auto-commits. D2 splits into a two-phase lifecycle: `stage_to_wal(wal_buf)` (encodes `staged_records` into WAL buffer without draining) then `publish_staged(lsn)` (drains `staged_records` → `CachedBatch` → cache publish, advances `write_cursor`). Commit is separate: `commit_batch(end_offset)` (`read_cursor` += 1, updates `committed_end_offset`, notifies consumers). Also adds `followers() → &[NodeId]` returning `replica_set[1..]`.
+**Entry types:** `StagedEntry` (`EntryPayload` + `record_count` + `SegmentKey`) lives in `states/segment/record.rs` — the opaque blob from the producer. `WalRecord` (CRC + type + payload) lives in `wal.rs` — the WAL serialization format. `CachedEntry` (in `cache.rs`) stores `EntryPayload` (opaque blob, broker never parses). WAL owns the serialization buffer (`WalStorage::buf()`); trackers encode into it via `stage_to_wal`.
 
-**Record types:** `StagingRecord` (user_data + `RoutingHeader`) lives in `states/segment/record.rs` — the pre-WAL record that knows its routing. `WalRecord` (CRC + type + payload) lives in `wal.rs` — the WAL serialization format. `CachedBatch` (in `cache.rs`) stores `Vec<Bytes>` (just user data, no WAL overhead). WAL owns the serialization buffer (`WalStorage::buf()`); trackers encode into it via `stage_to_wal`.
+**Two position domains — do not conflate:**
+- `SegmentRingBuffer.read_cursor` — ring buffer slot position. Always advances by 1 per committed entry.
+- `SegmentTracker.committed_entry_id` — the `entry_id` of the last committed entry. Carried in `SealRequest.end_entry_id`, `CommitAdvance`.
 
-**Two offset domains — do not conflate:**
-- `SegmentRingBuffer.read_cursor` — ring buffer batch position. Always advances by 1.
-- `SegmentTracker.committed_end_offset` — logical record offset (e.g., 42000). Carried in `SealRequest.end_offset`, `CommitAdvance`, feeds MetadataStateMachine invariant 8.
-
-**Checkpoint change:** D1's `drain_for_checkpoint()` drains `eviction_frontier..write_cursor`. D2 bounds to `eviction_frontier..read_cursor` — uncommitted batches may be replayed into a different segment on seal.
+**Checkpoint change:** `drain_for_checkpoint()` bounds to `eviction_frontier..read_cursor` — uncommitted entries may be replayed into a different segment on seal.
 
 ### DataPlane State Machine
 
 **New fields:**
 - `node_id: NodeId` — role determination and self-authorization
 - `needs_flush: bool` — set by `process_replica_append()` and `handle_seal_response()`, checked by actor after mailbox drain, reset by `flush_batch()`
-- `dirty_segments: Vec<SegmentKey>` — tracks segments with non-empty `staged_records`; `flush_batch()` only visits these
+- `buffer_byte_count: usize` — payload bytes across all leader staged entries, drives 10MB flush threshold
+- `dirty_segments: Vec<SegmentKey>` — tracks segments with non-empty `staged_entries`; `flush_batch()` only visits these
 - `replication: ReplicationState` — reply tracking and in-flight batch management (see ReplicationState below)
 
 **New methods:**
 
 | Method | Role | Effect |
 |---|---|---|
-| `process_replica_append()` | Follower | Validate sender (self-authorization), buffer in `tracker.staged_records`, set `needs_flush` |
-| `commit_segment(key, end_offset)` | Both | `tracker.commit_batch(end_offset)`, send `CommitAdvance` to followers via `InterNodeCommandQueued` |
-| `handle_seal_response(...)` | Leader | Create new tracker (`next_offset = old.committed_end_offset + 1`, `size_bytes = 0`), replay uncommitted tail via `uncommitted_records()`, call `replication.segment_handoff()`, send `SegmentSealed` to old followers via `InterNodeCommandQueued` |
+| `process_replica_append()` | Follower | Validate sender (self-authorization), stage entry via `stage_entry_from_replica()`, set `needs_flush` |
+| `commit_segment(key, entry_id)` | Both | `tracker.commit_entry(entry_id)`, send `CommitAdvance` to followers via `InterNodeCommandQueued` |
+| `handle_seal_response(...)` | Leader | Create new tracker (`start_entry_id = old.committed_entry_id + 1`), replay uncommitted tail via `uncommitted_entries()`, call `replication.segment_handoff()`, send `SegmentSealed` to old followers via `InterNodeCommandQueued` |
 
-**`flush_batch()` changes (D1 → D2):** Three phases: (1) `stage_to_wal(wal.buf())` for each dirty segment — encodes `staged_records` into WAL's internal buffer, (2) `wal.flush_batch()` — single write+fsync, returns LSN, (3) `publish_staged(lsn)` for each dirty segment — drains `staged_records` into `CachedBatch`, publishes to ring buffer. Per segment, `tracker.role` determines event: Leader with followers → `BatchPublished`, Leader without followers → immediate `commit_batch` (no-follower fast path), Follower → `ReplicaAck` via `InterNodeCommandQueued`. Triggers: `BatchFlushDeadline` timer (10ms, set on first buffered record) OR batch size threshold (20k/10MB global counters) OR `needs_flush` after mailbox drain.
+**`flush_batch()` changes (D1 → D2):** Three phases: (1) `stage_to_wal(wal.buf())` for each dirty segment — encodes each staged entry into WAL with routing header, (2) `wal.flush_batch()` — single write+fsync, returns LSN, (3) `publish_staged(lsn)` for each dirty segment — drains `staged_entries`, assigns `entry_id` to each, publishes to ring buffer. Per entry per segment, `tracker.role` determines event: Leader with followers → `BatchPublished`, Leader without followers → immediate `commit_entry` (no-follower fast path), Follower → `ReplicaAck` via `InterNodeCommandQueued`. Triggers: `BatchFlushDeadline` timer (10ms) OR byte threshold (10MB) OR `needs_flush` after mailbox drain.
 
 **Other changes:** `handle_segment_assignment()` stores `replica_set`, sets role (leader-only in D2 — followers self-authorize). Followers reject `Produce` with error.
 
@@ -192,11 +191,11 @@ struct ReplicationState {
 struct PendingBatch {
     replies: Vec<oneshot::Sender<ProduceAck>>,
     pending_acks: HashSet<NodeId>,
-    batch_end_offset: u64,
+    entry_id: u64,
 }
 ```
 
-Per-segment `VecDeque` — each segment's batches commit in order independently. `end_offset` in `ReplicaAck` correlates to `batch_end_offset` — logical offsets are monotonic per segment, no synthetic counter needed. Late acks for sealed segments are silently dropped.
+Per-segment `VecDeque` — each segment's entries commit in order independently. `entry_id` in `ReplicaAck` correlates to `PendingBatch.entry_id` — entry IDs are monotonic per segment. Late acks for sealed segments are silently dropped.
 
 Key methods: `enqueue_reply()` (Pending phase), `begin_replication()` (moves replies to `PendingBatch`, returns timer seq if first in-flight), `process_ack()` (removes node from `pending_acks`, returns `AckCommitted` with replies when all acked), `segment_handoff()` (migrates replies from old to new segment on seal), `fail_all()` (drains all replies with `Err` on WAL failure). Timer seq gating via `is_active_timer()` prevents stale timeout callbacks from firing after a timer has been reset by `process_ack()`.
 
@@ -206,18 +205,18 @@ Top-level `DataPlaneCommand` has four variants. Inter-node commands arrive via `
 
 | Command | Variant | Source | Key fields |
 |---|---|---|---|
-| `Produce` | top-level | Client | `segment_key`, `records`, `reply` |
+| `Produce` | top-level | Client | `segment_key`, `data: EntryPayload`, `record_count`, `reply` |
 | `CheckpointComplete` | top-level | Checkpoint worker | `segment_key`, `checkpointed_lsn` |
 | `Timeout` | top-level | Ticker | `DataPlaneTimeoutCallback` |
-| `SegmentAssignment` | inter-node | Coordinator (D3) | `segment_key`, `replica_set`, `start_offset` |
-| `ReplicaAppend` | inter-node | Leader via transport | `segment_key`, `replica_set`, `records`, `start_offset` |
-| `ReplicaAck` | inter-node | Follower via transport | `segment_key`, `end_offset`, `from` |
-| `CommitAdvance` | inter-node | Leader via transport | `segment_key`, `committed_end_offset` |
-| `SealRequest` | inter-node | Leader via transport | `segment_key`, `failed_nodes`, `end_offset` |
+| `SegmentAssignment` | inter-node | Coordinator (D3) | `segment_key`, `replica_set`, `start_entry_id` |
+| `ReplicaAppend` | inter-node | Leader via transport | `segment_key`, `replica_set`, `data: EntryPayload`, `record_count`, `entry_id` |
+| `ReplicaAck` | inter-node | Follower via transport | `segment_key`, `entry_id`, `from` |
+| `CommitAdvance` | inter-node | Leader via transport | `segment_key`, `committed_entry_id` |
+| `SealRequest` | inter-node | Leader via transport | `segment_key`, `failed_nodes`, `end_entry_id` |
 | `SealResponse` | inter-node | Coordinator via transport | `old_segment_key`, `new_segment_id`, `new_replica_set` |
 | `SegmentSealed` | inter-node | Leader via transport | `segment_key` |
 
-`ReplicaAppend` carries `start_offset` only — `end_offset` is derived from `start_offset + records.len() - 1` at the receiver. `ReplicaAck` includes `from: NodeId` so the leader can identify which follower acked. `SealRequest` routing to coordinator is deferred to D3 (currently placeholder).
+`ReplicaAppend` carries `entry_id` (broker-assigned) + `data: EntryPayload` (opaque blob, zero-copy via `Bytes` refcount). `ReplicaAck` includes `from: NodeId` so the leader can identify which follower acked. `SealRequest` routing to coordinator is deferred to D3 (currently placeholder).
 
 **SegmentSealed follower handling:** Submit final checkpoint, then drop `SegmentTracker`. No further `ReplicaAppend` accepted for that segment.
 
@@ -228,11 +227,11 @@ Top-level `DataPlaneCommand` has four variants. Inter-node commands arrive via `
 | `CheckpointRequired` | Both | `CheckpointJob` |
 | `BatchFlushTimerScheduled` | Leader | `TimerCommand<BatchFlushTimer>` |
 | `BatchPublished` | Leader | `lsn`, `segment_batches: Vec<PendingReplicationBatch>` |
-| `ReplicaAckReceived` | Leader | `segment_key`, `end_offset`, `from` |
+| `ReplicaAckReceived` | Leader | `segment_key`, `entry_id`, `from` |
 | `InterNodeCommandQueued` | Both | `targets: Vec<NodeId>`, `message: DataPlaneInterNodeCommand` |
-| `ReplicationTimedOut` | Leader | `segment_key`, `committed_end_offset` |
+| `ReplicationTimedOut` | Leader | `segment_key`, `committed_entry_id` |
 
-`PendingReplicationBatch` is a struct: `{ segment_key, batch: Arc<CachedBatch>, replica_set: Vec<NodeId>, followers: Vec<NodeId> }`. Provides `into_replica_append()` to convert into `(targets, ReplicaAppend)` for transport dispatch.
+`PendingReplicationBatch` is a struct: `{ segment_key, entry: Arc<CachedEntry>, replica_set: Vec<NodeId>, followers: Vec<NodeId> }`. Provides `into_replica_append()` to convert into `(targets, ReplicaAppend)` — `EntryPayload` is cloned via `Bytes` refcount (zero-copy).
 
 `InterNodeCommandQueued` is a generic wrapper for all outbound inter-node messages (replaces individual `Send*` events from the original design). Used for `CommitAdvance`, `ReplicaAck`, `SealRequest`, and `SegmentSealed` — all dispatched uniformly through `DataTransportCommand::send()`.
 
@@ -277,13 +276,13 @@ All `data_port` wire messages, consolidated across phases:
 
 | Message | Direction | Key fields | Phase |
 |---|---|---|---|
-| `ReplicaAppend` | Leader → followers | `segment_key`, `replica_set`, `records`, `start_offset` | D2 |
-| `ReplicaAck` | Follower → leader | `segment_key`, `end_offset`, `from` | D2 |
-| `CommitAdvance` | Leader → followers | `segment_key`, `committed_end_offset` | D2 |
-| `SealRequest` | Leader → coordinator | `segment_key`, `failed_nodes: Vec<NodeId>`, `end_offset` | D2 |
+| `ReplicaAppend` | Leader → followers | `segment_key`, `replica_set`, `data: EntryPayload`, `record_count`, `entry_id` | D2 |
+| `ReplicaAck` | Follower → leader | `segment_key`, `entry_id`, `from` | D2 |
+| `CommitAdvance` | Leader → followers | `segment_key`, `committed_entry_id` | D2 |
+| `SealRequest` | Leader → coordinator | `segment_key`, `failed_nodes: Vec<NodeId>`, `end_entry_id` | D2 |
 | `SealResponse` | Coordinator → leader | `old_segment_key`, `new_segment_id`, `new_replica_set` | D2/D3 |
 | `SegmentSealed` | Leader → old followers | `segment_key` | D2 |
-| `SegmentAssignment` | Coordinator → leader | `segment_key`, `replica_set`, `start_offset` | D3 |
+| `SegmentAssignment` | Coordinator → leader | `segment_key`, `replica_set`, `start_entry_id` | D3 |
 | `CatchUpAssignment` | Coordinator → replacement | `segment_key`, `replica_set` | D2 |
 | `CatchUpRequest` | Replacement → healthy replica | `segment_key`, `local_end_offset` | D2 |
 | `CatchUpResponse` | Healthy replica → replacement | `segment_key`, `records`, `start/end_offset` | D2 |
@@ -296,9 +295,9 @@ All `data_port` wire messages, consolidated across phases:
 
 All failures converge to one response: **seal the segment, open a new one.** No retry, no ISR, no reconciliation.
 
-**Offset handoff:** `SealRequest` carries `end_offset = tracker.committed_end_offset` (logical offset of last record ACKed by all replicas). The coordinator passes it through `RollSegment` → `apply_roll_segment()` seals with this value, new segment starts at `end_offset + 1`. Maintains MetadataStateMachine invariant 8 (offset continuity).
+**Entry ID handoff:** `SealRequest` carries `end_entry_id = tracker.committed_entry_id` (last entry_id ACKed by all replicas). The coordinator passes it through `RollSegment` → `apply_roll_segment()` seals with this value, new segment starts at `end_entry_id + 1`.
 
-**Uncommitted tail replay:** Records between `read_cursor` and `write_cursor` at seal time are not part of the sealed segment — but they are not dropped. On `SealResponse`, the leader reads uncommitted batches from the old segment's cache via `tracker.uncommitted_records()`, injects their records into the new segment's `tracker.staged_records` (re-WAL'd with new routing headers on next `flush_batch()`), and migrates the pending reply channels via `replication.segment_handoff()`. When the replayed records are committed in the new segment with the new replica set, the original producers receive `Ok` — they never see a failure, just higher latency (~50-100ms seal overhead). No producer retry, no duplicates from the seal mechanism itself.
+**Uncommitted tail replay:** Entries between `read_cursor` and `write_cursor` at seal time are not part of the sealed segment — but they are not dropped. On `SealResponse`, the leader reads uncommitted entries from the old segment's cache via `tracker.uncommitted_entries()`, stages them into the new segment's `tracker.staged_entries` (re-WAL'd with new routing headers on next `flush_batch()`), and migrates the pending reply channels via `replication.segment_handoff()`. When the replayed entries are committed in the new segment with the new replica set, the original producers receive `Ok` — they never see a failure, just higher latency (~50-100ms seal overhead). No producer retry, no duplicates from the seal mechanism itself.
 
 Old WAL records (under the sealed segment's routing headers) are cleaned up by normal WAL file deletion once the checkpoint watermark advances past them.
 
@@ -315,7 +314,7 @@ Leader D      Coordinator A     Raft [A,B,C]    Follower E
    │ stop new produces for seg 7     │               │
    │               │                 │               │
    │─SealRequest──►│                 │               │
-   │ {end_offset}  │─RollSegment────►│               │
+   │ {end_entry_id}│─RollSegment────►│               │
    │               │ {new_rs:[D,E,G]}│ commit        │
    │               │◄────────────────│               │
    │◄SealResponse──│                 │               │
@@ -359,7 +358,7 @@ Coordinator A    Raft [A,B,C]    Healthy E     Replacement H
    │─CatchUpAssignment──────────────────────────────►│
    │                  │              │  check local  │
    │                  │              │◄─CatchUpReq───│
-   │                  │              │ {end_offset}  │
+   │                  │              │ {end_entry_id}│
    │                  │              │─CatchUpResp──►│
    │                  │              │ stream delta  │
    │                  │              │        verify + complete
@@ -407,7 +406,7 @@ Broker D              Broker E              Broker G              Broker F (dead
    │                     │                     │                     ✗
    │ open seg 8 (Leader) │                     │
    │ read uncommitted batches from seg 7 cache │
-   │ inject records into seg 8 tracker.staged_records
+   │ replay uncommitted entries into seg 8 tracker.staged_entries
    │ migrate pending reply channels to seg 8   │
    │──SegmentSealed─────►│                     │
    │                  close seg 7              │
@@ -456,11 +455,11 @@ Between Raft commit (step 3) and `data_port` notifications reaching participants
 
 2. **`read_cursor` ≤ `write_cursor` with replication gap.** In D2, `read_cursor` lags `write_cursor` by one replication RTT. `write_cursor` advances on cache publish (after local WAL fsync). `read_cursor` advances after all replicas ACK. Consumers only read up to `read_cursor`. Extends D1 invariant 15 — in D1, `read_cursor == write_cursor`; in D2, `read_cursor ≤ write_cursor` with the gap closed by replication.
 
-3. **Sealed segment `end_offset` = last committed logical offset.** On seal, `end_offset = tracker.committed_end_offset` — the logical offset of the last record ACKed by all replicas. Records past this (published to cache but uncommitted) are replayed into the new segment (see invariant 10). Same as D1 invariant 16.
+3. **Sealed segment `end_entry_id` = last committed entry_id.** On seal, `end_entry_id = tracker.committed_entry_id` — the entry_id of the last entry ACKed by all replicas. Entries past this (published to cache but uncommitted) are replayed into the new segment (see invariant 10). Same as D1 invariant 15.
 
 4. **Single writer per segment.** Only `replica_set[0]` (the segment leader) accepts `Produce` commands and initiates `ReplicaAppend`. Followers reject `Produce` commands for segments where `role == Follower`.
 
-5. **Follower `committed_end_offset` ≤ leader `committed_end_offset`.** Followers advance `read_cursor` and update `committed_end_offset` on `CommitAdvance` from the leader, which arrives ~0.5 RTT after the leader commits. The follower's committed range is always ≤ the leader's.
+5. **Follower `committed_entry_id` ≤ leader `committed_entry_id`.** Followers advance `read_cursor` and update `committed_entry_id` on `CommitAdvance` from the leader, which arrives ~0.5 RTT after the leader commits. The follower's committed range is always ≤ the leader's.
 
 6. **Replication is per-segment.** Each segment has its own `replica_set` and independent `VecDeque<PendingBatch>`. One WAL flush can produce batches for multiple segments; each is replicated independently. Commit and producer ACK happen per-segment. No cross-segment dependency.
 
@@ -470,7 +469,7 @@ Between Raft commit (step 3) and `data_port` notifications reaching participants
 
 9. **Seal is leader-initiated for follower failures, coordinator-initiated for leader failures.** The segment leader detects follower failure (timeout) and sends `SealRequest`. The coordinator detects leader failure via SWIM `HandleNodeDeath` and proposes `RollSegment` directly.
 
-10. **Uncommitted tail replayed, not dropped.** Records between `read_cursor` and `write_cursor` at seal time are read from the old segment's cache via `uncommitted_records()` and injected into the new segment's `tracker.staged_records`. Pending reply channels migrate via `replication.segment_handoff()`. Producers receive `Ok` after the replayed records commit in the new segment — no retry, no duplicates from the seal mechanism.
+10. **Uncommitted tail replayed, not dropped.** Entries between `read_cursor` and `write_cursor` at seal time are read from the old segment's cache via `uncommitted_entries()` and staged into the new segment's `tracker.staged_entries`. Pending reply channels migrate via `replication.segment_handoff()`. Producers receive `Ok` after the replayed entries commit in the new segment — no retry, no duplicates from the seal mechanism.
 
 11. **Segment leader preserved on follower failure.** `RollSegment` keeps the previous leader at `replica_set[0]` when only a follower failed — preserving cache locality and active producer connections. Only when the leader itself failed does a new node take position 0.
 

--- a/src/data_plane/checkpoint.rs
+++ b/src/data_plane/checkpoint.rs
@@ -49,14 +49,12 @@ impl CheckpointWorker {
         let mut writer = job.get_writer()?;
         let mut index_entries = Vec::with_capacity(checkpoint.batches.len());
 
-        for batch in &checkpoint.batches {
-            let batch_start_position = byte_position;
+        for entry in &checkpoint.batches {
+            let entry_start_position = byte_position;
 
-            for user_data in &batch.records {
-                let record = WalRecord::data(user_data.clone());
-                record.encode_to(&mut writer)?;
-                byte_position += record.encoded_size() as u64;
-            }
+            let record = WalRecord::data((*entry.data).clone());
+            record.encode_to(&mut writer)?;
+            byte_position += record.encoded_size() as u64;
 
             let end_record = WalRecord::batch_end();
             end_record.encode_to(&mut writer)?;
@@ -64,8 +62,8 @@ impl CheckpointWorker {
 
             index_entries.push(SparseEntry::new(
                 job.segment_key,
-                batch.start_offset,
-                batch_start_position.to_be_bytes(),
+                entry.entry_id,
+                entry_start_position.to_be_bytes(),
             ));
         }
 

--- a/src/data_plane/messages/command.rs
+++ b/src/data_plane/messages/command.rs
@@ -1,12 +1,11 @@
 use crate::impl_from_variant;
 use bincode::{Decode, Encode};
-use bytes::Bytes;
 use tokio::sync::oneshot;
 
 use crate::{
     clusters::NodeId,
     clusters::metadata::SegmentId,
-    data_plane::{SegmentKey, timer::DataPlaneTimeoutCallback},
+    data_plane::{EntryPayload, SegmentKey, timer::DataPlaneTimeoutCallback},
 };
 
 pub enum DataPlaneCommand {
@@ -18,7 +17,8 @@ pub enum DataPlaneCommand {
 
 pub struct Produce {
     pub segment_key: SegmentKey,
-    pub records: Vec<Bytes>,
+    pub data: EntryPayload,
+    pub record_count: u32,
     pub reply: oneshot::Sender<ProduceAck>,
 }
 
@@ -26,35 +26,36 @@ pub struct Produce {
 pub struct SegmentAssignment {
     pub segment_key: SegmentKey,
     pub replica_set: Vec<NodeId>,
-    pub start_offset: u64,
+    pub start_entry_id: u64,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ReplicaAppend {
     pub segment_key: SegmentKey,
     pub replica_set: Vec<NodeId>,
-    pub records: Vec<Vec<u8>>,
-    pub start_offset: u64,
+    pub data: EntryPayload,
+    pub record_count: u32,
+    pub entry_id: u64,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct ReplicaAck {
     pub segment_key: SegmentKey,
-    pub end_offset: u64,
+    pub entry_id: u64,
     pub from: NodeId,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct CommitAdvance {
     pub segment_key: SegmentKey,
-    pub committed_end_offset: u64,
+    pub committed_entry_id: u64,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct SealRequest {
     pub segment_key: SegmentKey,
     pub failed_nodes: Vec<NodeId>,
-    pub end_offset: u64,
+    pub end_entry_id: u64,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]

--- a/src/data_plane/messages/event.rs
+++ b/src/data_plane/messages/event.rs
@@ -6,7 +6,7 @@ use crate::{
         SegmentKey,
         checkpoint::CheckpointJob,
         messages::command::{DataPlaneInterNodeCommand, ReplicaAppend},
-        states::segment::cache::CachedBatch,
+        states::segment::cache::CachedEntry,
         timer::BatchFlushTimer,
     },
     impl_from_variant,
@@ -15,7 +15,7 @@ use crate::{
 
 pub(crate) struct PendingReplicationBatch {
     pub segment_key: SegmentKey,
-    pub batch: Arc<CachedBatch>,
+    pub entry: Arc<CachedEntry>,
     pub replica_set: Vec<NodeId>,
     pub followers: Vec<NodeId>,
 }
@@ -26,8 +26,9 @@ impl PendingReplicationBatch {
         let message = ReplicaAppend {
             segment_key: self.segment_key,
             replica_set: self.replica_set,
-            records: self.batch.records.iter().map(|r| r.to_vec()).collect(),
-            start_offset: self.batch.start_offset,
+            data: self.entry.data.clone(),
+            record_count: self.entry.record_count,
+            entry_id: self.entry.entry_id,
         };
         (targets, message)
     }
@@ -40,7 +41,7 @@ pub(crate) struct BatchPublished {
 
 pub(crate) struct ReplicaAckReceived {
     pub segment_key: SegmentKey,
-    pub end_offset: u64,
+    pub entry_id: u64,
     pub from: NodeId,
 }
 
@@ -59,7 +60,7 @@ impl InterNodeCommandQueued {
 
 pub(crate) struct ReplicationTimedOut {
     pub segment_key: SegmentKey,
-    pub committed_end_offset: u64,
+    pub committed_entry_id: u64,
 }
 
 pub(crate) enum DataPlaneEvent {

--- a/src/data_plane/mod.rs
+++ b/src/data_plane/mod.rs
@@ -1,7 +1,14 @@
 use std::path::{Path, PathBuf};
 
+use bincode::de::{BorrowDecoder, Decoder, read::Reader};
+use bincode::enc::Encoder;
+use bincode::enc::write::Writer;
+use bincode::error::{DecodeError, EncodeError};
+use bytes::Bytes;
+
 use crate::clusters::metadata::{RangeId, SegmentId};
 use crate::clusters::swims::ShardGroupId;
+use crate::smart_pointer;
 
 pub(crate) mod actor;
 
@@ -20,6 +27,56 @@ pub struct SegmentKey {
     pub shard_group_id: ShardGroupId,
     pub range_id: RangeId,
     pub segment_id: SegmentId,
+}
+
+#[derive(Debug, Clone)]
+pub struct EntryPayload(Bytes);
+
+impl EntryPayload {
+    pub fn new(data: Bytes) -> Self {
+        Self(data)
+    }
+}
+
+smart_pointer!(EntryPayload, Bytes);
+
+impl From<Bytes> for EntryPayload {
+    fn from(b: Bytes) -> Self {
+        Self(b)
+    }
+}
+
+impl From<Vec<u8>> for EntryPayload {
+    fn from(v: Vec<u8>) -> Self {
+        Self(Bytes::from(v))
+    }
+}
+
+impl bincode::Encode for EntryPayload {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        bincode::Encode::encode(&(self.0.len() as u64), encoder)?;
+        encoder.writer().write(&self.0)
+    }
+}
+
+impl<C> bincode::Decode<C> for EntryPayload {
+    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let len: u64 = bincode::Decode::decode(decoder)?;
+        let mut buf = vec![0u8; len as usize];
+        decoder.reader().read(&mut buf)?;
+        Ok(Self(Bytes::from(buf)))
+    }
+}
+
+impl<'de, C> bincode::BorrowDecode<'de, C> for EntryPayload {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = C>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let len: u64 = bincode::Decode::decode(decoder)?;
+        let mut buf = vec![0u8; len as usize];
+        decoder.reader().read(&mut buf)?;
+        Ok(Self(Bytes::from(buf)))
+    }
 }
 
 impl SegmentKey {

--- a/src/data_plane/sparse_index.rs
+++ b/src/data_plane/sparse_index.rs
@@ -7,16 +7,12 @@ pub struct SparseEntry {
     byte_position: [u8; 8],
 }
 impl SparseEntry {
-    pub(crate) fn new(
-        segment_key: SegmentKey,
-        logical_offset: u64,
-        byte_position: [u8; 8],
-    ) -> Self {
+    pub(crate) fn new(segment_key: SegmentKey, entry_id: u64, byte_position: [u8; 8]) -> Self {
         let mut key = Vec::with_capacity(32);
         key.extend_from_slice(&segment_key.shard_group_id.to_be_bytes());
         key.extend_from_slice(&segment_key.range_id.to_be_bytes());
         key.extend_from_slice(&segment_key.segment_id.to_be_bytes());
-        key.extend_from_slice(&logical_offset.to_be_bytes());
+        key.extend_from_slice(&entry_id.to_be_bytes());
         Self { key, byte_position }
     }
 }

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -23,7 +23,6 @@ use tokio::sync::mpsc as tokio_mpsc;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
 
-const BATCH_MAX_RECORDS: usize = 20_000;
 const BATCH_MAX_BYTES: usize = 10 * 1024 * 1024; // 10MB
 
 pub struct DataPlane<W: WalStorage> {
@@ -32,11 +31,8 @@ pub struct DataPlane<W: WalStorage> {
     segments: HashMap<SegmentKey, SegmentTracker>,
     dirty_segments: Vec<SegmentKey>,
     pending_events: Vec<DataPlaneEvent>,
-    buffer_record_count: usize,
     buffer_byte_count: usize,
 
-    //  `needs_flush` means "flush immediately after this mailbox drain, don't wait for the timer." It exists because follower records
-    // (process_replica_append) and seal replays (handle_seal_response) need immediate flush — they can't wait 10ms for BatchFlushDeadline.
     needs_flush: bool,
     data_dir: PathBuf,
     replication: ReplicationState,
@@ -50,7 +46,6 @@ impl<W: WalStorage> DataPlane<W> {
             segments: HashMap::new(),
             dirty_segments: Vec::new(),
             pending_events: Vec::new(),
-            buffer_record_count: 0,
             buffer_byte_count: 0,
             needs_flush: false,
             data_dir,
@@ -90,7 +85,6 @@ impl<W: WalStorage> DataPlane<W> {
         self.dispatch_events(checkpoint_tx, batch_scheduler, repl_scheduler, transport_tx);
     }
 
-    // --- Command handlers (called from handle_command) ---
     fn handle_produce(&mut self, cmd: Produce) {
         let reject = match self.segments.get(&cmd.segment_key) {
             Some(t) if t.role() == SegmentRole::Follower => Some("not leader"),
@@ -108,16 +102,10 @@ impl<W: WalStorage> DataPlane<W> {
             return;
         };
 
-        for user_data in cmd.records {
-            self.buffer_byte_count += user_data.len();
-            self.buffer_record_count += 1;
-            tracker.buffer_record(cmd.segment_key, user_data);
-        }
+        self.buffer_byte_count += cmd.data.len();
+        tracker.stage_entry(cmd.segment_key, cmd.data, cmd.record_count);
         self.dirty_segments.push(cmd.segment_key);
 
-        // Ticker rejects duplicate seqs, so this is a no-op if a flush timer
-        // is already registered for the current LSN. After a flush, next_lsn
-        // advances and the next produce registers a new timer.
         self.raise_event(TimerCommand::SetSchedule {
             seq: self.wal.next_lsn(),
             timer: BatchFlushTimer::deadline(),
@@ -145,15 +133,15 @@ impl<W: WalStorage> DataPlane<W> {
                     return;
                 }
 
-                let committed_end_offset = self
+                let committed_entry_id = self
                     .segments
                     .get(&segment_key)
-                    .map(|t| t.committed_end_offset())
+                    .map(|t| t.committed_entry_id())
                     .unwrap_or(0);
 
                 self.raise_event(event::ReplicationTimedOut {
                     segment_key,
-                    committed_end_offset,
+                    committed_entry_id,
                 });
             }
         }
@@ -167,7 +155,7 @@ impl<W: WalStorage> DataPlane<W> {
             C::ReplicaAck(cmd) => {
                 self.raise_event(event::ReplicaAckReceived {
                     segment_key: cmd.segment_key,
-                    end_offset: cmd.end_offset,
+                    entry_id: cmd.entry_id,
                     from: cmd.from,
                 });
             }
@@ -180,17 +168,16 @@ impl<W: WalStorage> DataPlane<W> {
         }
     }
 
-    // --- Inter-node handlers (called from process_inter_node) ---
     fn handle_segment_assignment(&mut self, cmd: SegmentAssignment) {
         if self.segments.contains_key(&cmd.segment_key) {
             return;
         }
 
-        let tracker = SegmentTracker::new_with_offset(
+        let tracker = SegmentTracker::new_with_start_entry_id(
             cmd.segment_key.file_path(&self.data_dir),
             SegmentRole::Leader,
             cmd.replica_set,
-            cmd.start_offset,
+            cmd.start_entry_id,
         );
 
         self.segments.insert(cmd.segment_key, tracker);
@@ -213,11 +200,11 @@ impl<W: WalStorage> DataPlane<W> {
 
             self.segments.insert(
                 cmd.segment_key,
-                SegmentTracker::new_with_offset(
+                SegmentTracker::new_with_start_entry_id(
                     cmd.segment_key.file_path(&self.data_dir),
                     SegmentRole::Follower,
                     cmd.replica_set,
-                    cmd.start_offset,
+                    cmd.entry_id,
                 ),
             );
         }
@@ -226,19 +213,17 @@ impl<W: WalStorage> DataPlane<W> {
             return;
         };
 
-        tracker.buffer_record_in_bulk(cmd.segment_key, cmd.records, cmd.start_offset);
+        tracker.stage_entry_from_replica(cmd.segment_key, cmd.data, cmd.record_count, cmd.entry_id);
         self.dirty_segments.push(cmd.segment_key);
 
         self.needs_flush = true;
     }
 
-    /// Leader -> follower: advance read_cursor after all replicas ACKed.
     fn handle_commit_advance(&mut self, cmd: CommitAdvance) {
         let Some(tracker) = self.segments.get_mut(&cmd.segment_key) else {
             return;
         };
 
-        // Defensive. In practice, it should never fire.
         if tracker.role() != SegmentRole::Follower {
             tracing::warn!(
                 "CommitAdvance received by non-follower: {:?}",
@@ -246,10 +231,9 @@ impl<W: WalStorage> DataPlane<W> {
             );
             return;
         }
-        tracker.commit_batch(cmd.committed_end_offset);
+        tracker.commit_entry(cmd.committed_entry_id);
     }
 
-    /// Coordinator -> leader: seal approved. Create new segment, replay uncommitted tail.
     fn handle_seal_response(&mut self, cmd: SealResponse) {
         let Some(old_tracker) = self.segments.get(&cmd.old_segment_key) else {
             return;
@@ -257,11 +241,11 @@ impl<W: WalStorage> DataPlane<W> {
 
         let new_segment_key = cmd.old_segment_key.with_segment_id(cmd.new_segment_id);
 
-        let mut new_tracker = SegmentTracker::new_with_offset(
+        let mut new_tracker = SegmentTracker::new_with_start_entry_id(
             new_segment_key.file_path(&self.data_dir),
             SegmentRole::Leader,
             cmd.new_replica_set,
-            old_tracker.committed_end_offset() + 1,
+            old_tracker.committed_entry_id() + 1,
         );
 
         // Replay uncommitted records into the new tracker's staged_records.
@@ -272,8 +256,8 @@ impl<W: WalStorage> DataPlane<W> {
         // D5 crash recovery: duplicate WAL data is safe. Old entries route to the sealed
         // segment (bounded by metadata end_offset), new entries route to the new segment.
         // Metadata-first recovery (Raft log before WAL) provides the seal boundary.
-        for payload in old_tracker.uncommitted_records() {
-            new_tracker.buffer_record(new_segment_key, payload);
+        for (data, record_count) in old_tracker.uncommitted_entries() {
+            new_tracker.stage_entry(new_segment_key, data, record_count);
         }
 
         self.replication
@@ -293,20 +277,18 @@ impl<W: WalStorage> DataPlane<W> {
         self.needs_flush = true;
     }
 
-    /// Leader -> follower: segment is sealed. Submit final checkpoint and drop tracker.
     fn handle_segment_sealed(&mut self, segment_key: SegmentKey) {
         if let Some(tracker) = self.segments.remove(&segment_key) {
             self.raise_event(tracker.checkpoint(segment_key));
         }
     }
 
-    // --- Replication ---
-    fn commit_segment(&mut self, segment_key: SegmentKey, end_offset: u64) {
+    fn commit_segment(&mut self, segment_key: SegmentKey, entry_id: u64) {
         let Some(tracker) = self.segments.get_mut(&segment_key) else {
             return;
         };
 
-        tracker.commit_batch(end_offset);
+        tracker.commit_entry(entry_id);
 
         let followers = tracker.followers().to_vec();
         if !followers.is_empty() {
@@ -314,16 +296,14 @@ impl<W: WalStorage> DataPlane<W> {
                 followers,
                 CommitAdvance {
                     segment_key,
-                    committed_end_offset: end_offset,
+                    committed_entry_id: entry_id,
                 },
             ));
         }
     }
 
     fn should_flush(&self) -> bool {
-        self.needs_flush
-            || self.buffer_record_count >= BATCH_MAX_RECORDS
-            || self.buffer_byte_count >= BATCH_MAX_BYTES
+        self.needs_flush || self.buffer_byte_count >= BATCH_MAX_BYTES
     }
 
     fn flush_batch(&mut self) {
@@ -349,9 +329,6 @@ impl<W: WalStorage> DataPlane<W> {
         let lsn = match self.wal.flush_batch() {
             Ok(lsn) => lsn,
             Err(e) => {
-                // staged_records are NOT cleared — they remain in each tracker
-                // and will be re-encoded on the next flush attempt. Duplicate WAL
-                // entries are safe: D5 replay deduplicates by logical_offset per segment.
                 tracing::error!("WAL flush failed: {e}");
                 self.replication.fail_all(e.to_string());
                 self.needs_flush = false;
@@ -359,7 +336,6 @@ impl<W: WalStorage> DataPlane<W> {
             }
         };
 
-        // -- Post flush
         let mut segment_batches: Vec<event::PendingReplicationBatch> = Vec::new();
 
         for key in dirty {
@@ -370,33 +346,35 @@ impl<W: WalStorage> DataPlane<W> {
                 continue;
             }
 
-            let batch = tracker.publish_staged(lsn);
-            let end_offset = batch.end_offset;
+            let entries = tracker.publish_staged(lsn);
 
-            match tracker.role() {
-                SegmentRole::Leader if tracker.followers().is_empty() => {
-                    tracker.commit_batch(end_offset);
-                }
-                SegmentRole::Leader => {
-                    segment_batches.push(event::PendingReplicationBatch {
-                        segment_key: key,
-                        batch,
-                        replica_set: tracker.replica_set(),
-                        followers: tracker.followers().to_vec(),
-                    });
-                }
-                SegmentRole::Follower => {
-                    self.pending_events.push(
-                        event::InterNodeCommandQueued::new(
-                            vec![tracker.leader_node()],
-                            ReplicaAck {
-                                segment_key: key,
-                                end_offset,
-                                from: self.node_id.clone(),
-                            },
-                        )
-                        .into(),
-                    );
+            for entry in entries {
+                let entry_id = entry.entry_id;
+                match tracker.role() {
+                    SegmentRole::Leader if tracker.followers().is_empty() => {
+                        tracker.commit_entry(entry_id);
+                    }
+                    SegmentRole::Leader => {
+                        segment_batches.push(event::PendingReplicationBatch {
+                            segment_key: key,
+                            entry,
+                            replica_set: tracker.replica_set(),
+                            followers: tracker.followers().to_vec(),
+                        });
+                    }
+                    SegmentRole::Follower => {
+                        self.pending_events.push(
+                            event::InterNodeCommandQueued::new(
+                                vec![tracker.leader_node()],
+                                ReplicaAck {
+                                    segment_key: key,
+                                    entry_id,
+                                    from: self.node_id.clone(),
+                                },
+                            )
+                            .into(),
+                        );
+                    }
                 }
             }
 
@@ -418,12 +396,9 @@ impl<W: WalStorage> DataPlane<W> {
             let _ = reply.send(ProduceAck::Ok);
         }
 
-        self.buffer_record_count = 0;
         self.buffer_byte_count = 0;
         self.needs_flush = false;
     }
-
-    // --- Checkpoint ---
 
     fn compute_checkpoint_watermark(&self) -> u64 {
         self.segments
@@ -433,9 +408,7 @@ impl<W: WalStorage> DataPlane<W> {
             .unwrap_or(0)
     }
 
-    // Sort segments by most uncheckpointed batches, pick the top one, submit a checkpoint for it.
-    // uncheckpointed() is used to sort candidates and segment with the most uncheckpointed batches gets checkpointed first to relieve cache pressure
-    // TODO not wired up yet
+    #[allow(dead_code)]
     fn submit_checkpoint_for_pressure(&mut self) {
         let mut candidates: Vec<(SegmentKey, u64)> = self
             .segments
@@ -451,8 +424,6 @@ impl<W: WalStorage> DataPlane<W> {
             self.raise_event(tracker.checkpoint(*key));
         }
     }
-
-    // --- Event dispatch (called from flush_and_dispatch) ---
 
     fn dispatch_events(
         &mut self,
@@ -496,7 +467,7 @@ impl<W: WalStorage> DataPlane<W> {
                             continue;
                         };
 
-                        self.commit_segment(evt.segment_key, committed.batch_end_offset);
+                        self.commit_segment(evt.segment_key, committed.entry_id);
 
                         for reply in committed.replies {
                             let _ = reply.send(ProduceAck::Ok);
@@ -524,7 +495,7 @@ impl<W: WalStorage> DataPlane<W> {
                             SealRequest {
                                 segment_key: evt.segment_key,
                                 failed_nodes: nodes,
-                                end_offset: evt.committed_end_offset,
+                                end_entry_id: evt.committed_entry_id,
                             },
                         ));
                     }
@@ -536,8 +507,6 @@ impl<W: WalStorage> DataPlane<W> {
         self.assert_invariants();
     }
 
-    // --- Internal utilities ---
-
     fn raise_event(&mut self, event: impl Into<DataPlaneEvent>) {
         self.pending_events.push(event.into());
     }
@@ -548,7 +517,7 @@ impl<W: WalStorage> DataPlane<W> {
 
     #[cfg(test)]
     fn has_buffered_data(&self) -> bool {
-        self.buffer_record_count > 0
+        self.buffer_byte_count > 0
     }
 }
 
@@ -561,28 +530,16 @@ impl<T: WalStorage> TAssertInvariant for DataPlane<T> {
             tracker.assert_invariants();
         }
 
-        let actual_record_count: usize = self
-            .segments
-            .values()
-            .filter(|t| t.role() == SegmentRole::Leader)
-            .map(|t| t.staged_records().len())
-            .sum();
-        assert_eq!(
-            self.buffer_record_count, actual_record_count,
-            "buffer_record_count ({}) != actual leader accumulated records ({actual_record_count})",
-            self.buffer_record_count
-        );
-
         let actual_byte_count: usize = self
             .segments
             .values()
             .filter(|t| t.role() == SegmentRole::Leader)
-            .flat_map(|t| t.staged_records().iter())
-            .map(|r| r.user_data.len())
+            .flat_map(|t| t.staged_entries())
+            .map(|e| e.byte_len())
             .sum();
         assert_eq!(
             self.buffer_byte_count, actual_byte_count,
-            "buffer_byte_count ({}) != actual leader buffered bytes ({actual_byte_count})",
+            "buffer_byte_count ({}) != actual leader staged bytes ({actual_byte_count})",
             self.buffer_byte_count
         );
     }
@@ -621,10 +578,21 @@ mod tests {
             SegmentAssignment {
                 segment_key: key,
                 replica_set,
-                start_offset: 0,
+                start_entry_id: 0,
             }
             .into(),
         )
+    }
+
+    fn produce(key: SegmentKey) -> (DataPlaneCommand, oneshot::Receiver<ProduceAck>) {
+        let (tx, rx) = oneshot::channel();
+        let cmd = Produce {
+            segment_key: key,
+            data: Bytes::from("data").into(),
+            record_count: 1,
+            reply: tx,
+        };
+        (cmd.into(), rx)
     }
 
     #[test]
@@ -646,13 +614,9 @@ mod tests {
     fn produce_to_unknown_segment_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let mut dp = make_data_plane(&dir);
-        let (tx, mut rx) = oneshot::channel();
+        let (cmd, mut rx) = produce(test_key());
 
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("hello")],
-            reply: tx,
-        });
+        dp.handle_command(cmd);
 
         assert!(!dp.has_buffered_data());
         let ack = rx.try_recv().unwrap();
@@ -666,12 +630,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, rx) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         dp.handle_command(DataPlaneCommand::Timeout(
@@ -689,32 +649,24 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        dp.handle_produce(Produce {
+        let (tx, _) = oneshot::channel();
+        dp.handle_command(Produce {
             segment_key: test_key(),
-            records: vec![Bytes::from("hello"), Bytes::from("world!")],
-            reply: oneshot::channel().0,
+            data: Bytes::from("hello world!").into(),
+            record_count: 2,
+            reply: tx,
         });
 
         let tracker = dp.segments.get(&test_key()).unwrap();
-        assert_eq!(
-            tracker.size_bytes(),
-            5 + 6,
-            "size_bytes should track actual data bytes"
-        );
-        assert_eq!(
-            tracker.next_offset(),
-            2,
-            "next_offset should track logical record count"
-        );
+        assert_eq!(tracker.size_bytes(), 12);
+        assert_eq!(tracker.next_entry_id(), 0);
     }
 
     #[test]
     fn segment_assignment_creates_tracker() {
         let dir = tempfile::tempdir().unwrap();
         let mut dp = make_data_plane(&dir);
-
         dp.handle_command(assign_segment(test_key(), vec![]));
-
         assert!(dp.segments.contains_key(&test_key()));
     }
 
@@ -725,12 +677,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, _) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         assert!(dp.has_buffered_data());
@@ -753,12 +701,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, _) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _) = produce(test_key());
+        dp.handle_command(cmd);
 
         let events = dp.take_events();
         let has_set_schedule = events.iter().any(|e| {
@@ -767,10 +711,7 @@ mod tests {
                 DataPlaneEvent::BatchFlushTimerScheduled(TimerCommand::SetSchedule { .. })
             )
         });
-        assert!(
-            has_set_schedule,
-            "first produce should schedule flush timer"
-        );
+        assert!(has_set_schedule);
     }
 
     #[test]
@@ -780,26 +721,17 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, _) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
-        // Flush via size trigger (not the timer)
         dp.flush_batch();
         dp.take_events();
 
-        // Stale timer fires — should be a no-op (no WAL write)
         dp.handle_command(DataPlaneCommand::Timeout(
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
-        assert!(
-            !dp.has_buffered_data(),
-            "stale flush timer should not buffer anything"
-        );
+        assert!(!dp.has_buffered_data());
     }
 
     #[test]
@@ -809,22 +741,15 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, _) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         dp.handle_command(DataPlaneCommand::Timeout(
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
 
-        assert!(
-            !dp.has_buffered_data(),
-            "BatchFlushDeadline should flush immediately"
-        );
+        assert!(!dp.has_buffered_data());
     }
 
     #[test]
@@ -833,24 +758,16 @@ mod tests {
         let mut dp = make_data_plane(&dir);
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let big_records: Vec<Bytes> = (0..BATCH_MAX_RECORDS)
-            .map(|i| Bytes::from(format!("r{i}")))
-            .collect();
-
-        dp.handle_produce(Produce {
+        dp.handle_command(Produce {
             segment_key: test_key(),
-            records: big_records,
+            data: Bytes::from(vec![0u8; BATCH_MAX_BYTES]).into(),
+            record_count: 1,
             reply: oneshot::channel().0,
         });
 
-        assert!(
-            dp.buffer_record_count >= BATCH_MAX_RECORDS,
-            "buffer_record_count ({}) should exceed threshold ({})",
-            dp.buffer_record_count,
-            BATCH_MAX_RECORDS
-        );
+        assert!(dp.buffer_byte_count >= BATCH_MAX_BYTES);
         dp.flush_batch();
-        assert!(!dp.has_buffered_data(), "flush should drain all records");
+        assert!(!dp.has_buffered_data());
     }
 
     #[test]
@@ -859,27 +776,20 @@ mod tests {
         let mut dp = make_data_plane(&dir);
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let big_records: Vec<Bytes> = (0..BATCH_MAX_RECORDS)
-            .map(|i| Bytes::from(format!("r{i}")))
-            .collect();
-
-        dp.handle_produce(Produce {
+        dp.handle_command(Produce {
             segment_key: test_key(),
-            records: big_records,
+            data: Bytes::from(vec![0u8; BATCH_MAX_BYTES]).into(),
+            record_count: 1,
             reply: oneshot::channel().0,
         });
-        assert!(dp.buffer_record_count >= BATCH_MAX_RECORDS);
+        assert!(dp.buffer_byte_count >= BATCH_MAX_BYTES);
         dp.flush_batch();
         dp.take_events();
 
-        // Stale timer fires — no-op because buffer is empty
         dp.handle_command(DataPlaneCommand::Timeout(
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
-        assert!(
-            !dp.has_buffered_data(),
-            "stale flush timer after volume flush should be no-op"
-        );
+        assert!(!dp.has_buffered_data());
     }
 
     #[test]
@@ -900,11 +810,7 @@ mod tests {
             segment_key: key1,
             checkpointed_lsn: 10,
         }));
-        assert_eq!(
-            wal_file_count(),
-            initial_count,
-            "no WAL deletion yet (key2 not checkpointed)"
-        );
+        assert_eq!(wal_file_count(), initial_count);
 
         dp.handle_command(DataPlaneCommand::CheckpointComplete(CheckpointComplete {
             segment_key: key2,
@@ -916,15 +822,48 @@ mod tests {
     fn duplicate_segment_assignment_is_idempotent() {
         let dir = tempfile::tempdir().unwrap();
         let mut dp = make_data_plane(&dir);
-        let key = test_key();
 
-        dp.handle_command(assign_segment(key, vec![]));
-        dp.handle_command(assign_segment(key, vec![]));
+        dp.handle_command(assign_segment(test_key(), vec![]));
+        dp.handle_command(assign_segment(test_key(), vec![]));
 
         assert_eq!(dp.segments.len(), 1);
     }
 
-    // ---- D2 replication tests ----
+    #[test]
+    fn multiple_produces_accumulate_in_tracker() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+
+        dp.handle_command(assign_segment(test_key(), vec![]));
+
+        let (cmd1, _rx1) = produce(test_key());
+        let (cmd2, _rx2) = produce(test_key());
+        let (cmd3, _rx3) = produce(test_key());
+        dp.handle_command(cmd1);
+        dp.take_events();
+        dp.handle_command(cmd2);
+        dp.take_events();
+        dp.handle_command(cmd3);
+        dp.take_events();
+
+        assert!(dp.has_buffered_data());
+        assert!(!dp.should_flush());
+
+        {
+            let t = dp.segments.get(&test_key()).unwrap();
+            assert_eq!(t.staged_entries().len(), 3);
+            assert_eq!(t.cache_write_cursor(), 0);
+            assert_eq!(t.next_entry_id(), 0);
+        }
+
+        dp.flush_batch();
+
+        let t = dp.segments.get(&test_key()).unwrap();
+        assert!(t.staged_entries().is_empty());
+        assert_eq!(t.cache_write_cursor(), 3);
+        assert_eq!(t.next_entry_id(), 3);
+        assert_eq!(t.cache_read_cursor(), 3);
+    }
 
     #[test]
     fn produce_with_followers_creates_replication_gap() {
@@ -934,12 +873,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![test_node_id(), follower]));
 
-        let (tx, _rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         process_and_flush(
@@ -949,16 +884,8 @@ mod tests {
 
         let tracker = dp.segments.get(&test_key()).unwrap();
         let cache = tracker.cache();
-        assert_eq!(
-            cache.load_write_cursor(),
-            1,
-            "tail should advance after publish"
-        );
-        assert_eq!(
-            cache.load_read_cursor(),
-            0,
-            "commit should NOT advance — waiting for replication"
-        );
+        assert_eq!(cache.load_write_cursor(), 1);
+        assert_eq!(cache.load_read_cursor(), 0);
     }
 
     #[test]
@@ -968,12 +895,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![]));
 
-        let (tx, _rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         process_and_flush(
@@ -983,15 +906,11 @@ mod tests {
 
         let cache = dp.segments.get(&test_key()).unwrap().cache();
         assert_eq!(cache.load_write_cursor(), 1);
-        assert_eq!(
-            cache.load_read_cursor(),
-            1,
-            "no followers = immediate commit"
-        );
+        assert_eq!(cache.load_read_cursor(), 1);
     }
 
     #[test]
-    fn flush_emits_replication_ready_for_replicated_segments() {
+    fn flush_emits_batch_published_for_replicated_segments() {
         let dir = tempfile::tempdir().unwrap();
         let mut dp = make_data_plane(&dir);
         let follower = NodeId::new("follower-1");
@@ -1001,12 +920,8 @@ mod tests {
             vec![test_node_id(), follower.clone()],
         ));
 
-        let (tx, _rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
 
         process_and_flush(
@@ -1015,12 +930,10 @@ mod tests {
         );
 
         let events = dp.take_events();
-        let has_replication_ready = events
-            .iter()
-            .any(|e| matches!(e, DataPlaneEvent::BatchPublished(..)));
         assert!(
-            has_replication_ready,
-            "should emit ReplicationReady for replicated segment"
+            events
+                .iter()
+                .any(|e| matches!(e, DataPlaneEvent::BatchPublished(..)))
         );
     }
 
@@ -1032,12 +945,8 @@ mod tests {
 
         dp.handle_command(assign_segment(test_key(), vec![test_node_id(), follower]));
 
-        let (tx, _rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
         dp.take_events();
         process_and_flush(
             &mut dp,
@@ -1048,17 +957,14 @@ mod tests {
         dp.commit_segment(test_key(), 0);
 
         let cache = dp.segments.get(&test_key()).unwrap().cache();
-        assert_eq!(
-            cache.load_read_cursor(),
-            1,
-            "commit should advance after all replicas ACK"
-        );
+        assert_eq!(cache.load_read_cursor(), 1);
 
         let events = dp.take_events();
-        let has_commit_advance = events
-            .iter()
-            .any(|e| matches!(e, DataPlaneEvent::InterNodeCommandQueued(..)));
-        assert!(has_commit_advance, "should emit SendInterNode after commit");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, DataPlaneEvent::InterNodeCommandQueued(..)))
+        );
     }
 
     #[test]
@@ -1071,8 +977,9 @@ mod tests {
             ReplicaAppend {
                 segment_key: test_key(),
                 replica_set: vec![leader, test_node_id()],
-                records: vec![b"setup".to_vec()],
-                start_offset: 0,
+                data: b"setup".to_vec().into(),
+                record_count: 1,
+                entry_id: 0,
             }
             .into(),
         ));
@@ -1080,18 +987,11 @@ mod tests {
         dp.flush_batch();
         dp.take_events();
 
-        let (tx, rx) = oneshot::channel();
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: tx,
-        });
+        let (cmd, rx) = produce(test_key());
+        dp.handle_command(cmd);
 
         let ack = rx.blocking_recv().unwrap();
-        assert!(
-            matches!(ack, ProduceAck::Err(_)),
-            "follower should reject produce"
-        );
+        assert!(matches!(ack, ProduceAck::Err(_)));
     }
 
     #[test]
@@ -1104,18 +1004,18 @@ mod tests {
             ReplicaAppend {
                 segment_key: test_key(),
                 replica_set: vec![leader.clone(), test_node_id()],
-                records: vec![b"data".to_vec()],
-                start_offset: 0,
+                data: b"data".to_vec().into(),
+                record_count: 1,
+                entry_id: 0,
             }
             .into(),
         ));
 
-        assert!(
-            dp.segments.contains_key(&test_key()),
-            "self-authorization should create tracker"
+        assert!(dp.segments.contains_key(&test_key()));
+        assert_eq!(
+            dp.segments.get(&test_key()).unwrap().role(),
+            SegmentRole::Follower
         );
-        let tracker = dp.segments.get(&test_key()).unwrap();
-        assert_eq!(tracker.role(), SegmentRole::Follower);
     }
 
     #[test]
@@ -1127,16 +1027,14 @@ mod tests {
             ReplicaAppend {
                 segment_key: test_key(),
                 replica_set: vec![NodeId::new("other-leader"), NodeId::new("other-follower")],
-                records: vec![b"data".to_vec()],
-                start_offset: 0,
+                data: b"data".to_vec().into(),
+                record_count: 1,
+                entry_id: 0,
             }
             .into(),
         ));
 
-        assert!(
-            !dp.segments.contains_key(&test_key()),
-            "should reject — not in replica_set"
-        );
+        assert!(!dp.segments.contains_key(&test_key()));
     }
 
     #[test]
@@ -1149,8 +1047,9 @@ mod tests {
             ReplicaAppend {
                 segment_key: test_key(),
                 replica_set: vec![leader.clone(), test_node_id()],
-                records: vec![b"data".to_vec()],
-                start_offset: 0,
+                data: b"data".to_vec().into(),
+                record_count: 1,
+                entry_id: 0,
             }
             .into(),
         ));
@@ -1161,13 +1060,13 @@ mod tests {
         dp.handle_command(DataPlaneCommand::InterNode(
             CommitAdvance {
                 segment_key: test_key(),
-                committed_end_offset: 0,
+                committed_entry_id: 0,
             }
             .into(),
         ));
 
         let tracker = dp.segments.get(&test_key()).unwrap();
-        assert_eq!(tracker.committed_end_offset(), 0);
+        assert_eq!(tracker.committed_entry_id(), 0);
         assert_eq!(tracker.cache().load_read_cursor(), 1);
     }
 
@@ -1206,13 +1105,14 @@ mod tests {
             ReplicaAppend {
                 segment_key: test_key(),
                 replica_set: vec![leader, test_node_id()],
-                records: vec![b"data".to_vec()],
-                start_offset: 0,
+                data: b"data".to_vec().into(),
+                record_count: 1,
+                entry_id: 0,
             }
             .into(),
         ));
 
-        assert!(dp.needs_flush, "replica_append should set needs_flush");
+        assert!(dp.needs_flush);
     }
 
     #[test]
@@ -1225,19 +1125,14 @@ mod tests {
         process_and_flush(&mut dp, assign_segment(test_key(), rs.clone()));
         dp.take_events();
 
-        // Produce + flush + commit so read_cursor == write_cursor
-        dp.handle_command(Produce {
-            segment_key: test_key(),
-            records: vec![Bytes::from("data")],
-            reply: oneshot::channel().0,
-        });
+        let (cmd, _) = produce(test_key());
+        dp.handle_command(cmd);
         dp.handle_command(DataPlaneCommand::Timeout(
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
         dp.take_events();
-        dp.segments.get_mut(&test_key()).unwrap().commit_batch(0);
+        dp.segments.get_mut(&test_key()).unwrap().commit_entry(0);
 
-        // SealResponse with no uncommitted records to replay
         dp.handle_command(DataPlaneCommand::InterNode(
             SealResponse {
                 old_segment_key: test_key(),
@@ -1247,17 +1142,13 @@ mod tests {
             .into(),
         ));
 
-        assert!(dp.needs_flush, "seal_response always sets needs_flush");
+        assert!(dp.needs_flush);
 
         let new_key = test_key().with_segment_id(SegmentId(1));
         let new_tracker = dp.segments.get(&new_key).unwrap();
-        assert!(
-            new_tracker.staged_records().is_empty(),
-            "no uncommitted records to replay"
-        );
+        assert!(new_tracker.staged_entries().is_empty());
 
-        // flush_batch should be a no-op (no staged records)
         dp.flush_batch();
-        assert!(!dp.needs_flush, "needs_flush cleared after flush");
+        assert!(!dp.needs_flush);
     }
 }

--- a/src/data_plane/states/replication.rs
+++ b/src/data_plane/states/replication.rs
@@ -18,11 +18,11 @@ pub(crate) struct ReplicationState {
 pub(crate) struct PendingBatch {
     pub(crate) replies: Vec<oneshot::Sender<ProduceAck>>,
     pub(crate) pending_acks: HashSet<NodeId>,
-    pub(crate) batch_end_offset: u64,
+    pub(crate) entry_id: u64,
 }
 
 pub(crate) struct AckCommitted {
-    pub batch_end_offset: u64,
+    pub entry_id: u64,
     pub replies: Vec<oneshot::Sender<ProduceAck>>,
     pub reset_timer_seq: Option<u64>,
 }
@@ -81,7 +81,7 @@ impl ReplicationState {
             PendingBatch {
                 replies,
                 pending_acks,
-                batch_end_offset: pending_repl.batch.end_offset,
+                entry_id: pending_repl.entry.entry_id,
             },
         );
         if is_first {
@@ -123,7 +123,7 @@ impl ReplicationState {
         });
 
         Some(AckCommitted {
-            batch_end_offset: batch.batch_end_offset,
+            entry_id: batch.entry_id,
             replies: batch.replies,
             reset_timer_seq,
         })
@@ -177,7 +177,8 @@ mod tests {
 
     use crate::clusters::metadata::{RangeId, SegmentId};
     use crate::clusters::swims::ShardGroupId;
-    use crate::data_plane::states::segment::cache::CachedBatch;
+    use crate::data_plane::EntryPayload;
+    use crate::data_plane::states::segment::cache::CachedEntry;
 
     fn key(seg: u64) -> SegmentKey {
         SegmentKey::new(ShardGroupId(1), RangeId(0), SegmentId(seg))
@@ -187,11 +188,11 @@ mod tests {
         NodeId::new(id)
     }
 
-    fn batch(start: u64, end: u64) -> Arc<CachedBatch> {
-        Arc::new(CachedBatch {
-            records: vec![Bytes::from("data")],
-            start_offset: start,
-            end_offset: end,
+    fn cached_entry(entry_id: u64) -> Arc<CachedEntry> {
+        Arc::new(CachedEntry {
+            data: EntryPayload::from(Bytes::from("data")),
+            record_count: 1,
+            entry_id,
             lsn: 1,
         })
     }
@@ -199,11 +200,11 @@ mod tests {
     fn pending_repl(
         segment_key: SegmentKey,
         followers: Vec<NodeId>,
-        end_offset: u64,
+        entry_id: u64,
     ) -> PendingReplicationBatch {
         PendingReplicationBatch {
             segment_key,
-            batch: batch(0, end_offset),
+            entry: cached_entry(entry_id),
             replica_set: vec![node("leader")],
             followers,
         }
@@ -216,7 +217,7 @@ mod tests {
         let sk = key(0);
 
         state.enqueue_reply(sk, reply_tx);
-        let repl = pending_repl(sk, vec![node("f1"), node("f2")], 100);
+        let repl = pending_repl(sk, vec![node("f1"), node("f2")], 0);
 
         let seq = state.begin_replication(&repl);
         assert!(seq.is_some());
@@ -228,11 +229,11 @@ mod tests {
         let mut state = ReplicationState::default();
         let sk = key(0);
 
-        let repl1 = pending_repl(sk, vec![node("f1")], 100);
+        let repl1 = pending_repl(sk, vec![node("f1")], 0);
         let seq = state.begin_replication(&repl1);
         assert!(seq.is_some());
 
-        let repl2 = pending_repl(sk, vec![node("f1")], 200);
+        let repl2 = pending_repl(sk, vec![node("f1")], 1);
         let seq2 = state.begin_replication(&repl2);
         assert!(seq2.is_none());
     }
@@ -247,7 +248,7 @@ mod tests {
         state.enqueue_reply(sk, tx1);
         state.enqueue_reply(sk, tx2);
 
-        let repl = pending_repl(sk, vec![node("f1")], 100);
+        let repl = pending_repl(sk, vec![node("f1")], 0);
         state.begin_replication(&repl);
 
         assert!(state.drain_pending_replies(&sk).is_empty());
@@ -260,7 +261,7 @@ mod tests {
         let f1 = node("f1");
         let f2 = node("f2");
 
-        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 100);
+        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 0);
         state.begin_replication(&repl);
 
         let result = state.process_ack(&sk, &f1);
@@ -276,13 +277,13 @@ mod tests {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         state.enqueue_reply(sk, tx);
-        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 100);
+        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 42);
         state.begin_replication(&repl);
 
         assert!(state.process_ack(&sk, &f1).is_none());
 
         let committed = state.process_ack(&sk, &f2).unwrap();
-        assert_eq!(committed.batch_end_offset, 100);
+        assert_eq!(committed.entry_id, 42);
         assert_eq!(committed.replies.len(), 1);
         assert!(committed.reset_timer_seq.is_none());
 
@@ -303,14 +304,14 @@ mod tests {
         let sk = key(0);
         let f1 = node("f1");
 
-        let repl1 = pending_repl(sk, vec![f1.clone()], 100);
+        let repl1 = pending_repl(sk, vec![f1.clone()], 0);
         let first_seq = state.begin_replication(&repl1).unwrap();
 
-        let repl2 = pending_repl(sk, vec![f1.clone()], 200);
+        let repl2 = pending_repl(sk, vec![f1.clone()], 1);
         assert!(state.begin_replication(&repl2).is_none());
 
         let committed = state.process_ack(&sk, &f1).unwrap();
-        assert_eq!(committed.batch_end_offset, 100);
+        assert_eq!(committed.entry_id, 0);
         let new_seq = committed.reset_timer_seq.unwrap();
         assert_ne!(first_seq, new_seq);
         assert!(state.is_active_timer(&sk, new_seq));
@@ -330,10 +331,10 @@ mod tests {
         let sk = key(0);
         let f1 = node("f1");
 
-        let repl1 = pending_repl(sk, vec![f1.clone()], 100);
+        let repl1 = pending_repl(sk, vec![f1.clone()], 0);
         let first_seq = state.begin_replication(&repl1).unwrap();
 
-        let repl2 = pending_repl(sk, vec![f1.clone()], 200);
+        let repl2 = pending_repl(sk, vec![f1.clone()], 1);
         state.begin_replication(&repl2);
 
         state.process_ack(&sk, &f1).unwrap();

--- a/src/data_plane/states/segment/cache.rs
+++ b/src/data_plane/states/segment/cache.rs
@@ -4,14 +4,15 @@ use std::sync::{
 };
 
 use arc_swap::ArcSwapOption;
-use bytes::Bytes;
 use tokio::sync::Notify;
 
+use crate::data_plane::EntryPayload;
+
 #[derive(Debug, Clone)]
-pub struct CachedBatch {
-    pub records: Vec<Bytes>,
-    pub start_offset: u64,
-    pub end_offset: u64,
+pub struct CachedEntry {
+    pub data: EntryPayload,
+    pub record_count: u32,
+    pub entry_id: u64,
     pub lsn: u64,
 }
 #[cfg(any(test, debug_assertions))]
@@ -40,7 +41,7 @@ const DEFAULT_CAPACITY: usize = 1024;
 //     is logically evicted (readers rejected by frontier check) but the
 //     memory is reclaimed when the publisher physically reaches that slot.
 pub(crate) struct SegmentRingBuffer {
-    batches: Box<[ArcSwapOption<CachedBatch>]>,
+    batches: Box<[ArcSwapOption<CachedEntry>]>,
     capacity: usize,
     write_cursor: AtomicU64,
     read_cursor: AtomicU64,
@@ -79,10 +80,10 @@ impl SegmentRingBuffer {
 
     // Write path (called by DataPlane)
 
-    pub(super) fn publish(&self, batch: Arc<CachedBatch>) {
+    pub(super) fn publish(&self, entry: Arc<CachedEntry>) {
         let tail = self.write_cursor.load(Ordering::Acquire);
         let idx = self.slot_index(tail);
-        self.batches[idx].store(Some(batch));
+        self.batches[idx].store(Some(entry));
 
         // ! SAFETY: why not self.write_cursor.fetch_add(1)?
         // ! because there is only one writer thread
@@ -108,8 +109,8 @@ impl SegmentRingBuffer {
         self.notify.notified().await;
     }
 
-    /// Consumer read: only returns committed, non-evicted batches.
-    pub(super) fn read_committed(&self, position: u64) -> Option<Arc<CachedBatch>> {
+    /// Consumer read: only returns committed, non-evicted entries.
+    pub(super) fn read_committed(&self, position: u64) -> Option<Arc<CachedEntry>> {
         let commit = self.read_cursor.load(Ordering::Acquire);
         let frontier = self.eviction_frontier.load(Ordering::Acquire);
 
@@ -121,8 +122,8 @@ impl SegmentRingBuffer {
         self.batches[idx].load_full()
     }
 
-    /// Internal read: returns any published batch (committed or uncommitted).
-    pub(super) fn load_published(&self, position: u64) -> Option<Arc<CachedBatch>> {
+    /// Internal read: returns any published entry (committed or uncommitted).
+    pub(super) fn load_published(&self, position: u64) -> Option<Arc<CachedEntry>> {
         let tail = self.write_cursor.load(Ordering::Acquire);
         let frontier = self.eviction_frontier.load(Ordering::Acquire);
 
@@ -168,7 +169,7 @@ impl SegmentRingBuffer {
 }
 
 pub(crate) struct CheckpointBatch {
-    pub batches: Vec<Arc<CachedBatch>>,
+    pub batches: Vec<Arc<CachedEntry>>,
     pub new_frontier: u64,
 }
 
@@ -207,14 +208,15 @@ impl TAssertInvariant for SegmentRingBuffer {
 
 #[cfg(test)]
 mod tests {
+    use crate::data_plane::EntryPayload;
     use bytes::Bytes;
 
     use super::*;
-    fn make_batch(start: u64, end: u64, lsn: u64) -> Arc<CachedBatch> {
-        Arc::new(CachedBatch {
-            records: vec![Bytes::from("test")],
-            start_offset: start,
-            end_offset: end,
+    fn make_entry(entry_id: u64, lsn: u64) -> Arc<CachedEntry> {
+        Arc::new(CachedEntry {
+            data: EntryPayload::from(Bytes::from("test")),
+            record_count: 1,
+            entry_id,
             lsn,
         })
     }
@@ -223,20 +225,19 @@ mod tests {
     fn publish_and_read() {
         let cache = SegmentRingBuffer::with_capacity(4);
 
-        let batch = make_batch(0, 10, 1);
-        cache.publish(batch.clone());
+        let entry = make_entry(0, 1);
+        cache.publish(entry.clone());
         cache.advance_read_cursor(1);
 
         let read = cache.read_committed(0).unwrap();
-        assert_eq!(read.start_offset, 0);
-        assert_eq!(read.end_offset, 10);
+        assert_eq!(read.entry_id, 0);
     }
 
     #[test]
     fn read_beyond_commit_returns_none() {
         let cache = SegmentRingBuffer::with_capacity(4);
 
-        cache.publish(make_batch(0, 10, 1));
+        cache.publish(make_entry(0, 1));
         assert!(cache.read_committed(0).is_none());
     }
 
@@ -244,7 +245,7 @@ mod tests {
     fn read_behind_eviction_returns_none() {
         let cache = SegmentRingBuffer::with_capacity(4);
 
-        cache.publish(make_batch(0, 10, 1));
+        cache.publish(make_entry(0, 1));
         cache.advance_read_cursor(1);
         cache.advance_eviction_frontier(1);
 
@@ -256,13 +257,13 @@ mod tests {
         let cache = SegmentRingBuffer::with_capacity(4);
 
         for i in 0..3u64 {
-            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+            cache.publish(make_entry(i, i + 1));
         }
         cache.advance_read_cursor(3);
 
         for i in 0..3u64 {
-            let batch = cache.read_committed(i).unwrap();
-            assert_eq!(batch.start_offset, i * 10);
+            let entry = cache.read_committed(i).unwrap();
+            assert_eq!(entry.entry_id, i);
         }
     }
 
@@ -270,8 +271,8 @@ mod tests {
     fn eviction_frontier_advances() {
         let cache = SegmentRingBuffer::with_capacity(4);
 
-        cache.publish(make_batch(0, 10, 1));
-        cache.publish(make_batch(10, 20, 2));
+        cache.publish(make_entry(0, 1));
+        cache.publish(make_entry(1, 2));
         cache.advance_read_cursor(2);
 
         cache.advance_eviction_frontier(1);
@@ -285,7 +286,7 @@ mod tests {
         let cache = SegmentRingBuffer::with_capacity(4);
 
         for i in 0..3u64 {
-            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+            cache.publish(make_entry(i, i + 1));
         }
         cache.advance_read_cursor(3);
 
@@ -299,15 +300,15 @@ mod tests {
         let cache = SegmentRingBuffer::with_capacity(4);
 
         for i in 0..6u64 {
-            cache.publish(make_batch(i * 10, (i + 1) * 10, i + 1));
+            cache.publish(make_entry(i, i + 1));
             if i >= 1 {
                 cache.advance_eviction_frontier(i - 1);
             }
         }
         cache.advance_read_cursor(6);
 
-        let batch = cache.read_committed(5).unwrap();
-        assert_eq!(batch.start_offset, 50);
+        let entry = cache.read_committed(5).unwrap();
+        assert_eq!(entry.entry_id, 5);
     }
 
     #[test]
@@ -315,7 +316,7 @@ mod tests {
         let cache = SegmentRingBuffer::with_capacity(8);
 
         for i in 0..5u64 {
-            cache.publish(make_batch(i, i + 1, i + 1));
+            cache.publish(make_entry(i, i + 1));
         }
         cache.advance_read_cursor(5);
         cache.advance_eviction_frontier(2);

--- a/src/data_plane/states/segment/record.rs
+++ b/src/data_plane/states/segment/record.rs
@@ -4,25 +4,27 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::clusters::metadata::{RangeId, SegmentId};
 use crate::clusters::swims::ShardGroupId;
-use crate::data_plane::SegmentKey;
+use crate::data_plane::{EntryPayload, SegmentKey};
 
-const ROUTING_HEADER_SIZE: usize = 32;
+const ROUTING_HEADER_SIZE: usize = 36;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RoutingHeader {
+pub(crate) struct RoutingHeader {
     shard_group_id: ShardGroupId,
     range_id: RangeId,
     segment_id: SegmentId,
-    pub(crate) logical_offset: u64,
+    pub(crate) entry_id: u64,
+    pub(crate) record_count: u32,
 }
 
 impl RoutingHeader {
-    fn new(key: SegmentKey, offset: u64) -> Self {
+    pub(crate) fn new(key: SegmentKey, entry_id: u64, record_count: u32) -> Self {
         Self {
             shard_group_id: key.shard_group_id,
             range_id: key.range_id,
             segment_id: key.segment_id,
-            logical_offset: offset,
+            entry_id,
+            record_count,
         }
     }
 
@@ -30,17 +32,18 @@ impl RoutingHeader {
         buf.put_u64(self.shard_group_id.0);
         buf.put_u64(*self.range_id);
         buf.put_u64(self.segment_id.0);
-        buf.put_u64(self.logical_offset);
+        buf.put_u64(self.entry_id);
+        buf.put_u32(self.record_count);
     }
 
-    fn build_wal_payload(&self, user_data: &[u8]) -> Bytes {
-        let mut buf = BytesMut::with_capacity(ROUTING_HEADER_SIZE + user_data.len());
+    pub(crate) fn build_wal_payload(&self, entry_data: &[u8]) -> Bytes {
+        let mut buf = BytesMut::with_capacity(ROUTING_HEADER_SIZE + entry_data.len());
         self.encode(&mut buf);
-        buf.put_slice(user_data);
+        buf.put_slice(entry_data);
         buf.freeze()
     }
 
-    fn decode(data: &[u8]) -> io::Result<Self> {
+    pub(crate) fn decode(data: &[u8]) -> io::Result<Self> {
         if data.len() < ROUTING_HEADER_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
@@ -51,30 +54,29 @@ impl RoutingHeader {
             shard_group_id: ShardGroupId(u64::from_be_bytes(data[0..8].try_into().unwrap())),
             range_id: RangeId(u64::from_be_bytes(data[8..16].try_into().unwrap())),
             segment_id: SegmentId(u64::from_be_bytes(data[16..24].try_into().unwrap())),
-            logical_offset: u64::from_be_bytes(data[24..32].try_into().unwrap()),
+            entry_id: u64::from_be_bytes(data[24..32].try_into().unwrap()),
+            record_count: u32::from_be_bytes(data[32..36].try_into().unwrap()),
         })
     }
 }
 
-pub(crate) struct StagingRecord {
-    pub(crate) user_data: Bytes,
-    header: RoutingHeader,
+pub(crate) struct StagedEntry {
+    pub(crate) data: EntryPayload,
+    pub(crate) record_count: u32,
+    pub(crate) segment_key: SegmentKey,
 }
 
-impl StagingRecord {
-    pub(crate) fn new(payload: Bytes, segment_key: SegmentKey, offset: u64) -> Self {
+impl StagedEntry {
+    pub(crate) fn new(data: EntryPayload, record_count: u32, segment_key: SegmentKey) -> Self {
         Self {
-            user_data: payload,
-            header: RoutingHeader::new(segment_key, offset),
+            data,
+            record_count,
+            segment_key,
         }
     }
 
-    pub(crate) fn logical_offset(&self) -> u64 {
-        self.header.logical_offset
-    }
-
-    pub(crate) fn build_wal_payload(&self) -> Bytes {
-        self.header.build_wal_payload(&self.user_data)
+    pub(crate) fn byte_len(&self) -> usize {
+        self.data.len()
     }
 }
 
@@ -88,10 +90,12 @@ mod tests {
             shard_group_id: ShardGroupId(42),
             range_id: RangeId(7),
             segment_id: SegmentId(3),
-            logical_offset: 999,
+            entry_id: 999,
+            record_count: 50,
         };
         let mut buf = BytesMut::new();
         header.encode(&mut buf);
+        assert_eq!(buf.len(), ROUTING_HEADER_SIZE);
         let decoded = RoutingHeader::decode(&buf).unwrap();
         assert_eq!(header, decoded);
     }
@@ -102,15 +106,16 @@ mod tests {
             shard_group_id: ShardGroupId(1),
             range_id: RangeId(2),
             segment_id: SegmentId(3),
-            logical_offset: 100,
+            entry_id: 100,
+            record_count: 5,
         };
-        let user_data = b"user payload";
-        let payload = header.build_wal_payload(user_data);
+        let entry_data = b"opaque entry payload";
+        let payload = header.build_wal_payload(entry_data);
 
         let decoded_header = RoutingHeader::decode(&payload).expect("valid routing header");
         let decoded_data = payload.slice(ROUTING_HEADER_SIZE..);
 
         assert_eq!(header, decoded_header);
-        assert_eq!(&decoded_data[..], user_data);
+        assert_eq!(&decoded_data[..], entry_data);
     }
 }

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -1,13 +1,11 @@
 use std::{path::PathBuf, sync::Arc};
 
-use bytes::Bytes;
-
 use crate::clusters::NodeId;
-use crate::data_plane::{SegmentKey, checkpoint::CheckpointJob, wal::WalRecord};
+use crate::data_plane::{EntryPayload, SegmentKey, checkpoint::CheckpointJob, wal::WalRecord};
 
-use super::cache::CachedBatch;
+use super::cache::CachedEntry;
 
-use super::record::StagingRecord;
+use super::record::{RoutingHeader, StagedEntry};
 
 use super::*;
 
@@ -26,9 +24,9 @@ pub(crate) struct SegmentTracker {
     segment_file_path: PathBuf,
     role: SegmentRole,
     replica_set: Vec<NodeId>,
-    committed_end_offset: u64,
-    next_offset: u64,
-    staged_records: Vec<StagingRecord>,
+    committed_entry_id: u64,
+    next_entry_id: u64,
+    staged_entries: Vec<StagedEntry>,
 }
 
 impl SegmentTracker {
@@ -40,20 +38,20 @@ impl SegmentTracker {
             segment_file_path: path,
             role,
             replica_set,
-            committed_end_offset: 0,
-            next_offset: 0,
-            staged_records: Vec::new(),
+            committed_entry_id: 0,
+            next_entry_id: 0,
+            staged_entries: Vec::new(),
         }
     }
-    pub(crate) fn new_with_offset(
+    pub(crate) fn new_with_start_entry_id(
         path: PathBuf,
         role: SegmentRole,
         replica_set: Vec<NodeId>,
-        start_offset: u64,
+        start_entry_id: u64,
     ) -> Self {
-        let mut segmnet = Self::new(path, role, replica_set);
-        segmnet.next_offset = start_offset;
-        segmnet
+        let mut tracker = Self::new(path, role, replica_set);
+        tracker.next_entry_id = start_entry_id;
+        tracker
     }
     pub(crate) fn replica_set(&self) -> Vec<NodeId> {
         self.replica_set.clone()
@@ -78,53 +76,43 @@ impl SegmentTracker {
         self.cache.load_write_cursor() - self.cache.load_eviction_frontier()
     }
 
-    /// Encodes staged_records contents into the shared WAL buffer.
-    /// Records stay in staged_records until publish_staged drains them.
     pub(crate) fn stage_to_wal(&mut self, wal_buf: &mut Vec<u8>) {
-        for rec in &self.staged_records {
-            let _ = WalRecord::data(rec.build_wal_payload()).encode_to(wal_buf);
+        for (i, staged) in self.staged_entries.iter().enumerate() {
+            let entry_id = self.next_entry_id + i as u64;
+            let header = RoutingHeader::new(staged.segment_key, entry_id, staged.record_count);
+            let _ = WalRecord::data(header.build_wal_payload(&staged.data)).encode_to(wal_buf);
         }
     }
 
     pub(crate) fn has_staged(&self) -> bool {
-        !self.staged_records.is_empty()
+        !self.staged_entries.is_empty()
     }
 
-    /// Drains staged_records into a CachedBatch and publishes to cache.
-    pub(crate) fn publish_staged(&mut self, lsn: u64) -> Arc<CachedBatch> {
-        let start_offset = self
-            .staged_records
-            .first()
-            .map(|r| r.logical_offset())
-            .unwrap_or(0);
-        let end_offset = self
-            .staged_records
-            .last()
-            .map(|r| r.logical_offset())
-            .unwrap_or(0);
-        let records: Vec<Bytes> = std::mem::take(&mut self.staged_records)
-            .into_iter()
-            .map(|r| r.user_data)
-            .collect();
-
-        let batch = Arc::new(CachedBatch {
-            records,
-            start_offset,
-            end_offset,
-            lsn,
-        });
-        self.cache.publish(batch.clone());
-        batch
+    pub(crate) fn publish_staged(&mut self, lsn: u64) -> Vec<Arc<CachedEntry>> {
+        self.staged_entries
+            .drain(..)
+            .map(|s| {
+                let entry_id = self.next_entry_id;
+                self.next_entry_id += 1;
+                let entry = Arc::new(CachedEntry {
+                    data: s.data,
+                    record_count: s.record_count,
+                    entry_id,
+                    lsn,
+                });
+                self.cache.publish(entry.clone());
+                entry
+            })
+            .collect()
     }
 
-    pub(crate) fn uncommitted_records(&self) -> impl Iterator<Item = Bytes> + '_ {
+    pub(crate) fn uncommitted_entries(&self) -> impl Iterator<Item = (EntryPayload, u32)> + '_ {
         let commit = self.cache.load_read_cursor();
         let tail = self.cache.load_write_cursor();
-        (commit..tail).flat_map(|pos| {
+        (commit..tail).filter_map(|pos| {
             self.cache
                 .load_published(pos)
-                .into_iter()
-                .flat_map(|batch| batch.records.clone())
+                .map(|entry| (entry.data.clone(), entry.record_count))
         })
     }
 
@@ -136,19 +124,19 @@ impl SegmentTracker {
         }
     }
 
-    pub(crate) fn commit_batch(&mut self, batch_end_offset: u64) {
+    pub(crate) fn commit_entry(&mut self, entry_id: u64) {
         let commit = self.cache.load_read_cursor();
 
         #[cfg(debug_assertions)]
-        if let Some(batch) = self.cache.load_published(commit) {
+        if let Some(entry) = self.cache.load_published(commit) {
             assert_eq!(
-                batch.end_offset, batch_end_offset,
-                "commit end_offset mismatch: batch has {}, caller passed {}",
-                batch.end_offset, batch_end_offset
+                entry.entry_id, entry_id,
+                "commit entry_id mismatch: cached entry has {}, caller passed {}",
+                entry.entry_id, entry_id
             );
         }
         self.cache.advance_read_cursor(commit + 1);
-        self.committed_end_offset = batch_end_offset;
+        self.committed_entry_id = entry_id;
     }
 
     pub(crate) fn advance_checkpoint(&mut self, checkpointed_lsn: u64) {
@@ -159,34 +147,39 @@ impl SegmentTracker {
         self.checkpoint_lsn
     }
 
-    pub(crate) fn committed_end_offset(&self) -> u64 {
-        self.committed_end_offset
+    pub(crate) fn committed_entry_id(&self) -> u64 {
+        self.committed_entry_id
     }
 
-    pub(crate) fn buffer_record(&mut self, segment_key: SegmentKey, user_data: Bytes) {
-        self.size_bytes += user_data.len() as u64;
-        self.staged_records
-            .push(StagingRecord::new(user_data, segment_key, self.next_offset));
-        self.next_offset += 1;
-    }
-
-    pub(crate) fn buffer_record_in_bulk(
+    pub(crate) fn stage_entry(
         &mut self,
         segment_key: SegmentKey,
-        user_data: Vec<Vec<u8>>,
-        start_offset: u64,
+        data: EntryPayload,
+        record_count: u32,
     ) {
-        if start_offset < self.next_offset {
+        self.size_bytes += data.len() as u64;
+        self.staged_entries
+            .push(StagedEntry::new(data, record_count, segment_key));
+    }
+
+    pub(crate) fn stage_entry_from_replica(
+        &mut self,
+        segment_key: SegmentKey,
+        data: EntryPayload,
+        record_count: u32,
+        entry_id: u64,
+    ) {
+        let expected = self.next_entry_id + self.staged_entries.len() as u64;
+        if entry_id < expected {
             return;
         }
         debug_assert_eq!(
-            start_offset, self.next_offset,
-            "offset gap: expected {}, got {start_offset}",
-            self.next_offset
+            entry_id, expected,
+            "entry_id gap: expected {expected}, got {entry_id}",
         );
-        for data in user_data {
-            self.buffer_record(segment_key, Bytes::from(data));
-        }
+        self.size_bytes += data.len() as u64;
+        self.staged_entries
+            .push(StagedEntry::new(data, record_count, segment_key));
     }
 
     pub(crate) fn size_limit_reached(&self) -> bool {
@@ -195,75 +188,58 @@ impl SegmentTracker {
 }
 
 #[cfg(any(test, debug_assertions))]
-impl crate::test_traits::TAssertInvariant for SegmentTracker {
-    fn assert_invariants(&self) {
-        crate::test_traits::TAssertInvariant::assert_invariants(&*self.cache);
-
-        let frontier = self.cache.load_eviction_frontier();
-        let tail = self.cache.load_write_cursor();
-
-        if frontier == tail && tail > 0 {
-            assert!(
-                self.checkpoint_lsn > 0,
-                "all batches evicted but checkpoint_lsn is 0 — \
-                 eviction happened without reporting checkpoint"
-            );
-        }
-
-        // Cached batches must be offset-contiguous
-        let read = self.cache.load_read_cursor();
-        for pos in frontier..read.saturating_sub(1) {
-            if let (Some(curr), Some(next)) = (
-                self.cache.load_published(pos),
-                self.cache.load_published(pos + 1),
-            ) {
-                assert_eq!(
-                    curr.end_offset + 1,
-                    next.start_offset,
-                    "batch offset gap: batch at pos {pos} ends at {}, \
-                     batch at pos {} starts at {}",
-                    curr.end_offset,
-                    pos + 1,
-                    next.start_offset
-                );
-            }
-        }
-
-        // Staged records must be offset-contiguous with each other and with the last cached batch
-        let buf_len = self.staged_records.len() as u64;
-        for (i, rec) in self.staged_records.iter().enumerate() {
-            let expected = self.next_offset - buf_len + i as u64;
-            assert_eq!(
-                rec.logical_offset(),
-                expected,
-                "staged_records[{i}] offset {} != expected {expected}",
-                rec.logical_offset()
-            );
-        }
-    }
-}
-
-#[cfg(any(test, debug_assertions))]
-impl SegmentTracker {
-    pub fn staged_records(&self) -> &Vec<StagingRecord> {
-        &self.staged_records
-    }
-}
-
-#[cfg(test)]
 pub mod tests {
+    #![allow(unused)]
+
     use super::*;
     use crate::clusters::metadata::{RangeId, SegmentId};
     use crate::clusters::swims::ShardGroupId;
     use crate::test_traits::TAssertInvariant;
+    use bytes::Bytes;
     use std::sync::Arc;
+
+    impl crate::test_traits::TAssertInvariant for SegmentTracker {
+        fn assert_invariants(&self) {
+            crate::test_traits::TAssertInvariant::assert_invariants(&*self.cache);
+
+            let frontier = self.cache.load_eviction_frontier();
+            let tail = self.cache.load_write_cursor();
+
+            if frontier == tail && tail > 0 {
+                assert!(
+                    self.checkpoint_lsn > 0,
+                    "all entries evicted but checkpoint_lsn is 0 — \
+                 eviction happened without reporting checkpoint"
+                );
+            }
+
+            // Cached entries must have contiguous entry_ids
+            let read = self.cache.load_read_cursor();
+            for pos in frontier..read.saturating_sub(1) {
+                if let (Some(curr), Some(next)) = (
+                    self.cache.load_published(pos),
+                    self.cache.load_published(pos + 1),
+                ) {
+                    assert_eq!(
+                        curr.entry_id + 1,
+                        next.entry_id,
+                        "entry_id gap: entry at pos {pos} has id {}, \
+                     entry at pos {} has id {}",
+                        curr.entry_id,
+                        pos + 1,
+                        next.entry_id
+                    );
+                }
+            }
+        }
+    }
 
     impl SegmentTracker {
         pub fn cache(&self) -> Arc<SegmentRingBuffer> {
             self.cache.clone()
         }
-        pub fn next_offset(&self) -> u64 {
-            self.next_offset
+        pub fn next_entry_id(&self) -> u64 {
+            self.next_entry_id
         }
 
         pub fn cache_write_cursor(&self) -> u64 {
@@ -274,6 +250,9 @@ pub mod tests {
         }
         pub fn size_bytes(&self) -> u64 {
             self.size_bytes
+        }
+        pub fn staged_entries(&self) -> &[StagedEntry] {
+            &self.staged_entries
         }
     }
 
@@ -289,56 +268,36 @@ pub mod tests {
         )
     }
 
-    fn make_batch(start: u64, end: u64, lsn: u64) -> CachedBatch {
-        CachedBatch {
-            records: vec![],
-            start_offset: start,
-            end_offset: end,
-            lsn,
-        }
-    }
-
     #[test]
-    fn buffer_record_tracks_offset_and_size_independently() {
+    fn stage_entry_tracks_size() {
         let mut t = make_tracker(SegmentRole::Leader);
-        t.buffer_record(test_key(), Bytes::from("abc"));
-        t.buffer_record(test_key(), Bytes::from("de"));
+        t.stage_entry(test_key(), Bytes::from("abcde").into(), 2);
 
-        assert_eq!(t.next_offset, 2);
         assert_eq!(t.size_bytes, 5);
+        assert!(t.has_staged());
         t.assert_invariants();
     }
 
     #[test]
-    fn buffer_record_in_bulk_continues_from_tracker_offset() {
-        let mut t = SegmentTracker::new_with_offset(
+    fn stage_from_replica_skips_duplicate() {
+        let mut t = SegmentTracker::new_with_start_entry_id(
             PathBuf::from("/tmp/test.seg"),
             SegmentRole::Follower,
             vec![NodeId::new("leader"), NodeId::new("follower")],
-            100,
+            5,
         );
-        t.buffer_record_in_bulk(test_key(), vec![b"a".to_vec(), b"b".to_vec()], 100);
+        t.stage_entry_from_replica(test_key(), Bytes::from("data").into(), 1, 5);
+        assert!(t.has_staged());
 
-        assert_eq!(t.next_offset, 102);
-        assert_eq!(t.size_bytes, 2);
-        t.assert_invariants();
-    }
+        // Publish to advance next_entry_id
+        let mut wal_buf = Vec::new();
+        t.stage_to_wal(&mut wal_buf);
+        t.publish_staged(1);
 
-    #[test]
-    fn buffer_record_in_bulk_skips_duplicate_offsets() {
-        let mut t = SegmentTracker::new_with_offset(
-            PathBuf::from("/tmp/test.seg"),
-            SegmentRole::Follower,
-            vec![NodeId::new("leader"), NodeId::new("follower")],
-            100,
-        );
-        t.buffer_record_in_bulk(test_key(), vec![b"a".to_vec(), b"b".to_vec()], 100);
-        assert_eq!(t.next_offset, 102);
-
-        // Duplicate batch — should be no-op
-        t.buffer_record_in_bulk(test_key(), vec![b"a".to_vec(), b"b".to_vec()], 100);
-        assert_eq!(t.next_offset, 102);
-        assert_eq!(t.size_bytes, 2);
+        // Duplicate entry_id (5) should be skipped since next is now 6
+        t.stage_entry_from_replica(test_key(), Bytes::from("dup").into(), 1, 5);
+        assert!(!t.has_staged());
+        assert_eq!(t.next_entry_id, 6);
         t.assert_invariants();
     }
 
@@ -348,7 +307,7 @@ pub mod tests {
         let mut wal_buf = Vec::new();
 
         for i in 0..3u64 {
-            t.buffer_record(test_key(), Bytes::from(format!("rec-{i}")));
+            t.stage_entry(test_key(), Bytes::from(format!("entry-{i}")).into(), 1);
             t.stage_to_wal(&mut wal_buf);
             t.publish_staged(i + 1);
         }
@@ -357,30 +316,30 @@ pub mod tests {
         assert_eq!(t.cache_read_cursor(), 0);
 
         for i in 0..3u64 {
-            t.commit_batch(i);
+            t.commit_entry(i);
             assert_eq!(t.cache_read_cursor(), i + 1);
-            assert_eq!(t.committed_end_offset(), i);
+            assert_eq!(t.committed_entry_id(), i);
         }
         t.assert_invariants();
     }
 
     #[test]
-    fn stage_then_publish_drains_buffer() {
+    fn stage_then_publish_drains() {
         let mut t = make_tracker(SegmentRole::Leader);
         let mut wal_buf = Vec::new();
-        t.buffer_record(test_key(), Bytes::from("a"));
-        t.buffer_record(test_key(), Bytes::from("b"));
+        t.stage_entry(test_key(), Bytes::from("payload").into(), 3);
         t.stage_to_wal(&mut wal_buf);
 
         assert!(!wal_buf.is_empty());
         assert!(t.has_staged());
-        assert_eq!(t.next_offset, 2);
+        assert_eq!(t.next_entry_id, 0);
 
-        let batch = t.publish_staged(1);
-        assert_eq!(batch.start_offset, 0);
-        assert_eq!(batch.end_offset, 1);
-        assert!(t.staged_records.is_empty());
+        let entries = t.publish_staged(1);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].entry_id, 0);
+        assert_eq!(entries[0].record_count, 3);
         assert!(!t.has_staged());
+        assert_eq!(t.next_entry_id, 1);
         t.assert_invariants();
     }
 


### PR DESCRIPTION
## Summary

Replace per-record offsets with per-entry (batch) offsets across the data plane, aligning with Northguard/Pulsar's offset model.

### Offset model change

- Offsets are now **per-entry, not per-record**. Each `Produce` = one entry = one `entry_id`. Individual records addressed by `(SegmentKey, entry_id, record_index)` — maps to Pulsar's `(ledgerId, entryId, batchIndex)`.
- `next_offset` (per-record counter) → `next_entry_id` (increments once per entry in `publish_staged`)
- `committed_end_offset` → `committed_entry_id`
- `commit_batch()` → `commit_entry()`

### Opaque entry payload

- `EntryPayload` wrapper type with bincode `Encode`/`Decode`/`BorrowDecode` — wraps `Bytes` for zero-copy on the send path (Arc refcount bump instead of `.to_vec()` memcpy)
- `Produce.data`: `Vec<Bytes>` → `EntryPayload` (opaque blob from producer client)
- `ReplicaAppend.data`: `Vec<Vec<u8>>` → `EntryPayload` (zero-copy replication)
- `CachedEntry.data`: `Vec<Bytes>` → `EntryPayload` (broker never parses)
- `StagingRecord` → `StagedEntry` (opaque blob + record_count + segment_key)

### WAL format

- One WAL record per entry (was one per record). Routing header: 36B per entry (was 32B × N records)
- `RoutingHeader` fields: `shard_group_id`, `range_id`, `segment_id`, `entry_id`, `record_count`

### Accumulation fix

- `staged_entry: Option<StagedEntry>` → `staged_entries: Vec<StagedEntry>` — multiple produces accumulate correctly before flush (previous `Option` would overwrite)
- `publish_staged` returns `Vec<Arc<CachedEntry>>`, each with its own `entry_id`
- Uses `drain(..)` to preserve Vec allocation across flushes

### Flush triggers simplified

- Removed `buffer_record_count` and `BATCH_MAX_RECORDS` (20k threshold)
- Flush now triggered by bytes (10MB) + time (10ms) only

### Wire protocol

- `ReplicaAppend`: `records: Vec<Vec<u8>>` + `start_offset` → `data: EntryPayload` + `record_count` + `entry_id`
- `ReplicaAck`: `end_offset` → `entry_id`
- `CommitAdvance`: `committed_end_offset` → `committed_entry_id`
- `SealRequest`: `end_offset` → `end_entry_id`
- `SegmentAssignment`: `start_offset` → `start_entry_id`

### Docs

- D1 spec rewritten with offset model section, entry format (header + opaque payload), `EntryPayload`, invariants 17-18
- D2 spec updated: all terminology aligned with entry-id model
- `d1_batch_offset_model.md` deleted — content retrofitted into D1

## Test plan

- [x] 278 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Multiple produces to same segment accumulate separate staged entries
- [x] Each entry gets its own `entry_id` on flush
- [x] No-follower fast path commits all entries immediately
- [x] Follower self-authorization works with entry-id model
- [x] Replication gap: write_cursor advances per entry, read_cursor stays until ack
- [x] Seal response replays uncommitted entries
- [x] Invariant assertions pass after every command