### PR TITLE
fix: re-randomize election jitter to prevent vote-split livelock

### DIFF
--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -24,13 +24,14 @@ impl MultiRaftActor {
 
     pub async fn run(
         node_id: NodeId,
+        election_jitter_seed: u64,
         storage: Box<dyn RaftStorage>,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
         scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
         swim_tx: SwimSender,
     ) {
-        let mut store = MultiRaft::new(node_id, storage);
+        let mut store = MultiRaft::new(node_id, election_jitter_seed, storage);
         let mut buf = Vec::with_capacity(64);
 
         loop {

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -147,12 +147,7 @@ impl MultiRaft {
             .cloned()
             .collect();
 
-        let election_jitter_seed = {
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            self.election_jitter_seed.hash(&mut hasher);
-            group.id.hash(&mut hasher);
-            hasher.finish()
-        };
+        let election_jitter_seed = self.create_election_jitter_seed(&group);
 
         let election_seq = self.seq_counter.generate();
         let heartbeat_seq = self.seq_counter.generate();
@@ -182,6 +177,13 @@ impl MultiRaft {
 
         self.groups.insert(group.id, raft);
         self.dirty.insert(group.id);
+    }
+
+    fn create_election_jitter_seed(&mut self, group: &ShardGroup) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.election_jitter_seed.hash(&mut hasher);
+        group.id.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn remove_group(&mut self, group_id: ShardGroupId) {
@@ -313,7 +315,10 @@ impl MultiRaft {
     fn collect_mutations(
         &mut self,
         dirty: &[ShardGroupId],
-    ) -> (Vec<(ShardGroupId, LogMutation)>, BTreeMap<ShardGroupId, u64>) {
+    ) -> (
+        Vec<(ShardGroupId, LogMutation)>,
+        BTreeMap<ShardGroupId, u64>,
+    ) {
         let mut mutations = vec![];
         let mut last_indices = BTreeMap::new();
         for id in dirty {

--- a/src/clusters/raft/multi_raft.rs
+++ b/src/clusters/raft/multi_raft.rs
@@ -16,6 +16,7 @@ use crate::clusters::swims::{ShardGroup, ShardGroupId};
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
     node_id: NodeId,
+    election_jitter_seed: u64,
     storage: Box<dyn RaftStorage>,
     groups: BTreeMap<ShardGroupId, Raft>,
     seq_counter: RaftTimerTokenGenerator,
@@ -27,9 +28,14 @@ pub(crate) struct MultiRaft {
 }
 
 impl MultiRaft {
-    pub(crate) fn new(node_id: NodeId, storage: Box<dyn RaftStorage>) -> Self {
+    pub(crate) fn new(
+        node_id: NodeId,
+        election_jitter_seed: u64,
+        storage: Box<dyn RaftStorage>,
+    ) -> Self {
         Self {
             node_id,
+            election_jitter_seed,
             storage,
             groups: BTreeMap::new(),
             seq_counter: RaftTimerTokenGenerator::default(),
@@ -141,11 +147,11 @@ impl MultiRaft {
             .cloned()
             .collect();
 
-        let jitter = {
+        let election_jitter_seed = {
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            self.node_id.hash(&mut hasher);
+            self.election_jitter_seed.hash(&mut hasher);
             group.id.hash(&mut hasher);
-            (hasher.finish() % 20) as u32
+            hasher.finish()
         };
 
         let election_seq = self.seq_counter.generate();
@@ -158,7 +164,7 @@ impl MultiRaft {
             self.node_id.clone(),
             peers,
             persistent,
-            jitter,
+            election_jitter_seed,
             group.id,
             TimerSeqs {
                 election: election_seq,
@@ -430,7 +436,7 @@ mod tests {
     }
 
     fn new_store(node_id: NodeId, storage: Box<dyn RaftStorage>) -> MultiRaft {
-        MultiRaft::new(node_id, storage)
+        MultiRaft::new(node_id, 0, storage)
     }
 
     #[test]

--- a/src/clusters/raft/state.rs
+++ b/src/clusters/raft/state.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 use crate::clusters::NodeId;
 use crate::clusters::metadata::state_machine::MetadataStateMachine;
@@ -11,6 +12,27 @@ use crate::clusters::swims::ShardGroupId;
 use crate::schedulers::ticker_message::TimerCommand;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
+
+const ELECTION_JITTER_RANGE: u32 = 20;
+
+struct ElectionJitter {
+    seed: u64,
+    counter: u64,
+}
+
+impl ElectionJitter {
+    fn new(seed: u64) -> Self {
+        Self { seed, counter: 0 }
+    }
+
+    fn next(&mut self) -> u32 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.seed.hash(&mut hasher);
+        self.counter.hash(&mut hasher);
+        self.counter += 1;
+        (hasher.finish() % ELECTION_JITTER_RANGE as u64) as u32
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
@@ -63,7 +85,7 @@ pub struct Raft {
     peer_states: HashMap<NodeId, PeerState>,
     state_machine: MetadataStateMachine,
     pending_proposals: Vec<RaftCommand>,
-    election_jitter: u32,
+    election_jitter: ElectionJitter,
     timer_seqs: TimerSeqs,
 }
 
@@ -78,7 +100,7 @@ impl Raft {
         node_id: NodeId,
         peers: HashSet<NodeId>,
         persistent: RaftPersistentState,
-        election_jitter: u32,
+        election_jitter_seed: u64,
         shard_group_id: ShardGroupId,
         timer_seqs: TimerSeqs,
     ) -> Self {
@@ -99,7 +121,7 @@ impl Raft {
             state_machine: MetadataStateMachine::default(),
             pending_proposals: Vec::new(),
             peer_states: HashMap::new(),
-            election_jitter,
+            election_jitter: ElectionJitter::new(election_jitter_seed),
             timer_seqs,
         };
         raft.reset_election_timer();
@@ -751,10 +773,11 @@ impl Raft {
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.timer_seqs.election,
             }));
+        let jitter = self.election_jitter.next();
         self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
                 seq: self.timer_seqs.election,
-                timer: RaftTimer::election(self.election_jitter, self.shard_group_id),
+                timer: RaftTimer::election(jitter, self.shard_group_id),
             }));
     }
 

--- a/src/it/raft/election.rs
+++ b/src/it/raft/election.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -112,8 +113,14 @@ async fn run_raft_node(
         swim_tx.clone(),
     ));
     let db = MetadataStorage::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let election_jitter_seed = {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        node_id.hash(&mut h);
+        h.finish()
+    };
     tokio::spawn(MultiRaftActor::run(
         node_id,
+        election_jitter_seed,
         Box::new(db),
         raft_mailbox,
         transport_tx,

--- a/src/it/raft/leader_event.rs
+++ b/src/it/raft/leader_event.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -122,8 +123,14 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                 let db = MetadataStorage::open(
                     std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()),
                 );
+                let election_jitter_seed = {
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    node_id.hash(&mut h);
+                    h.finish()
+                };
                 tokio::spawn(MultiRaftActor::run(
                     node_id,
+                    election_jitter_seed,
                     Box::new(db),
                     raft_mailbox,
                     transport_tx,

--- a/src/it/raft/membership_change.rs
+++ b/src/it/raft/membership_change.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -71,8 +72,14 @@ async fn start_raft_node(
         swim_tx.clone(),
     ));
     let db = MetadataStorage::open(std::env::temp_dir().join(uuid::Uuid::new_v4().to_string()));
+    let election_jitter_seed = {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        node_id.hash(&mut h);
+        h.finish()
+    };
     tokio::spawn(MultiRaftActor::run(
         node_id,
+        election_jitter_seed,
         Box::new(db),
         raft_mailbox,
         transport_tx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,15 @@ impl StartUp {
             raft_tx.clone().into(),
         ));
         let raft_db = MetadataStorage::open(self.env.raft_db_path());
+        let election_jitter_seed = {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(&self.env.node_id_prefix, &mut hasher);
+            std::hash::Hash::hash(&self.rng_seed, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        };
         tokio::spawn(MultiRaftActor::run(
             node_id,
+            election_jitter_seed,
             Box::new(raft_db),
             raft_mailbox,
             raft_transport_tx,


### PR DESCRIPTION
## Summary

- Fixed a Raft liveness bug where two nodes in a 2-node group (after peer removal on node death) could permanently split votes if they had the same fixed election jitter value (1/20 probability per group)
- Replaced fixed election jitter with `ElectionJitter` generator that produces a new random value on each `reset_election_timer()` call via counter-seeded hashing
- Separated jitter seed from `NodeId` (which contains a random UUID) so the seed is derived from stable inputs (`node_id_prefix` + `rng_seed`), making sim tests deterministic

## Root cause

Election jitter was computed once at group creation (`hash(node_id, group_id) % 20`) and reused for every election attempt. When `HandleNodeDeath` directly removes a peer (reducing a 3-node group to 2 nodes), if the two survivors had the same jitter value, they would start elections simultaneously on every round, permanently splitting votes.

## Test plan

- [x] `leader_elects_after_kill`: 0/200 failures (was ~3% flake rate, i.e. ~6/200)
- [x] Full test suite: 278 passed, 0 failed
- [x] Clippy clean