### PR TITLE
opt: batch optimization in comms

### DIFF
--- a/.claude/rules/code-convention.md
+++ b/.claude/rules/code-convention.md
@@ -24,6 +24,12 @@ Don't pass `bool` parameters to control method behavior. Instead, have the calle
 
 Never use wildcard `_ => {}` or `_ => unreachable!()` in match arms for enum dispatch. List all variants explicitly so the compiler catches new variants at compile time. When splitting a match across sub-functions, the "already handled" arms should be listed explicitly (e.g., `VariantA { .. } | VariantB { .. } => {}`).
 
+## Batch channel messages with Box\<[T]\>
+
+Cross-actor channels should send `Box<[T]>` rather than individual `T` messages. The sender accumulates into a `Vec<T>` during its event loop iteration, then calls `.into_boxed_slice()` before sending — sheds unused capacity so only exact-size allocation crosses the channel. Benefits: fewer send operations (less channel contention), lower probability of a bounded channel being full, no wasted memory on the receiver side, and natural alignment with the flush-based actor pattern where side effects are drained after each event.
+
+For bounded channels using `try_send`, batching is especially important — one send per batch instead of per item means fewer opportunities for a full-channel drop.
+
 ## Temporal coupling in error propagation
 
 When a method performs mutation followed by a fallible read-only operation, consider that propagating the read-only error with `?` implies the entire operation failed — but the mutation already happened.

--- a/diagrams/data-plane/data_plane_roadmap.md
+++ b/diagrams/data-plane/data_plane_roadmap.md
@@ -237,7 +237,7 @@ Port layout:
 |---|---|---|---|
 | [D1: Storage Engine](d1_storage_engine.md) | WAL, segment files, sparse index, DataPlaneActor, lock-free SegmentRingBuffer, I/O pools | Nothing | Single-node storage + threading model |
 | [D2: Segment Replication](d2_segment_replication.md) | Primary-backup, seal-on-failure, DataTransportActor | D1 | Multi-node durability |
-| [D3: Segment Roll Integration](d3_segment_roll_integration.md) | Size/time/failure seal triggers, lifecycle events | D2, metadata Phase 6 | Connect storage to metadata |
+| [D3: Segment Lifecycle Integration](d3_segment_roll_integration.md) | Size/time/failure seal triggers, lifecycle events | D2, metadata Phase 6 | Connect storage to metadata |
 | [D4: Consumer Range Tracking](d4_consumer_range_tracking.md) | Follow split/merge/seal transitions | D3 | Consumer discovers range changes |
 | [D5: Crash Recovery](d5_crash_recovery.md) | WAL replay, local inventory, sealed segment repair | D1 (D2 for repair) | Data plane recovery |
 | [D6: Produce/Consume API](d6_produce_consume_api.md) | Client produce/consume protocol, routing, connection management | D4, D5 | Client-facing protocol layer |

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -27,7 +27,7 @@ impl MultiRaftActor {
         election_jitter_seed: u64,
         storage: Box<dyn RaftStorage>,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
-        transport_tx: mpsc::Sender<RaftTransportCommand>,
+        transport_tx: mpsc::Sender<Box<[RaftTransportCommand]>>,
         scheduler_tx: mpsc::Sender<Box<[TickerCommand<RaftTimer>]>>,
         swim_tx: SwimSender,
     ) {
@@ -49,12 +49,13 @@ impl MultiRaftActor {
 
     async fn flush_events(
         store: &mut MultiRaft,
-        transport_tx: &mpsc::Sender<RaftTransportCommand>,
+        transport_tx: &mpsc::Sender<Box<[RaftTransportCommand]>>,
         scheduler_tx: &mpsc::Sender<Box<[TickerCommand<RaftTimer>]>>,
         swim_tx: &SwimSender,
     ) {
         let mut packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>> = HashMap::new();
         let mut timer_cmds = Vec::new();
+        let mut transport_cmds = Vec::new();
         for event in store.flush() {
             match event {
                 RaftEvent::OutboundRaftPacket(pkt) => {
@@ -68,15 +69,16 @@ impl MultiRaftActor {
                     let _ = swim_tx.send(SwimCommand::AnnounceShardLeader(lc)).await;
                 }
                 RaftEvent::DisconnectPeer(node_id) => {
-                    let _ = transport_tx
-                        .send(RaftTransportCommand::DisconnectPeer(node_id))
-                        .await;
+                    transport_cmds.push(RaftTransportCommand::DisconnectPeer(node_id));
                 }
             }
         }
         for packets in packets_by_target.into_values() {
+            transport_cmds.push(RaftTransportCommand::Send(packets));
+        }
+        if !transport_cmds.is_empty() {
             let _ = transport_tx
-                .send(RaftTransportCommand::Send(packets))
+                .send(transport_cmds.into_boxed_slice())
                 .await;
         }
         if !timer_cmds.is_empty() {

--- a/src/clusters/raft/actor.rs
+++ b/src/clusters/raft/actor.rs
@@ -28,7 +28,7 @@ impl MultiRaftActor {
         storage: Box<dyn RaftStorage>,
         mut mailbox: mpsc::Receiver<MultiRaftActorCommand>,
         transport_tx: mpsc::Sender<RaftTransportCommand>,
-        scheduler_tx: mpsc::Sender<TickerCommand<RaftTimer>>,
+        scheduler_tx: mpsc::Sender<Box<[TickerCommand<RaftTimer>]>>,
         swim_tx: SwimSender,
     ) {
         let mut store = MultiRaft::new(node_id, election_jitter_seed, storage);
@@ -50,54 +50,39 @@ impl MultiRaftActor {
     async fn flush_events(
         store: &mut MultiRaft,
         transport_tx: &mpsc::Sender<RaftTransportCommand>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
+        scheduler_tx: &mpsc::Sender<Box<[TickerCommand<RaftTimer>]>>,
         swim_tx: &SwimSender,
     ) {
         let mut packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>> = HashMap::new();
+        let mut timer_cmds = Vec::new();
         for event in store.flush() {
-            Self::route_event(
-                event,
-                &mut packets_by_target,
-                transport_tx,
-                scheduler_tx,
-                swim_tx,
-            )
-            .await;
-        }
-        Self::send_batched_packets(packets_by_target, transport_tx).await;
-    }
-
-    async fn route_event(
-        event: RaftEvent,
-        packets: &mut HashMap<NodeId, Vec<OutboundRaftPacket>>,
-        transport_tx: &mpsc::Sender<RaftTransportCommand>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<RaftTimer>>,
-        swim_tx: &SwimSender,
-    ) {
-        match event {
-            RaftEvent::OutboundRaftPacket(pkt) => {
-                packets.entry(pkt.target.clone()).or_default().push(pkt);
-            }
-            RaftEvent::Timer(cmd) => {
-                let _ = scheduler_tx.send(cmd.into()).await;
-            }
-            RaftEvent::LeaderChange(lc) => {
-                let _ = swim_tx.send(SwimCommand::AnnounceShardLeader(lc)).await;
-            }
-            RaftEvent::DisconnectPeer(node_id) => {
-                let _ = transport_tx
-                    .send(RaftTransportCommand::DisconnectPeer(node_id))
-                    .await;
+            match event {
+                RaftEvent::OutboundRaftPacket(pkt) => {
+                    packets_by_target
+                        .entry(pkt.target.clone())
+                        .or_default()
+                        .push(pkt);
+                }
+                RaftEvent::Timer(cmd) => timer_cmds.push(cmd.into()),
+                RaftEvent::LeaderChange(lc) => {
+                    let _ = swim_tx.send(SwimCommand::AnnounceShardLeader(lc)).await;
+                }
+                RaftEvent::DisconnectPeer(node_id) => {
+                    let _ = transport_tx
+                        .send(RaftTransportCommand::DisconnectPeer(node_id))
+                        .await;
+                }
             }
         }
-    }
-
-    async fn send_batched_packets(
-        packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>>,
-        transport_tx: &mpsc::Sender<RaftTransportCommand>,
-    ) {
         for packets in packets_by_target.into_values() {
-            let _ = transport_tx.send(RaftTransportCommand::Send(packets)).await;
+            let _ = transport_tx
+                .send(RaftTransportCommand::Send(packets))
+                .await;
+        }
+        if !timer_cmds.is_empty() {
+            let _ = scheduler_tx
+                .send(timer_cmds.into_boxed_slice())
+                .await;
         }
     }
 }

--- a/src/clusters/raft/transport.rs
+++ b/src/clusters/raft/transport.rs
@@ -302,7 +302,7 @@ impl RaftTransportActor {
         node_id: NodeId,
         listener: TcpListener,
         raft_tx: mpsc::Sender<MultiRaftActorCommand>,
-        mut from_actor: mpsc::Receiver<RaftTransportCommand>,
+        mut from_actor: mpsc::Receiver<Box<[RaftTransportCommand]>>,
         swim_tx: SwimSender,
     ) {
         let mut state = RaftWriters::new(node_id);
@@ -314,13 +314,15 @@ impl RaftTransportActor {
                 Ok((stream, _)) = listener.accept() => {
                     state.accept(stream, &raft_tx).await;
                 }
-                Some(cmd) = from_actor.recv() => {
-                    match cmd {
-                        RaftTransportCommand::Send(packets) => {
-                            state.send(packets, &raft_tx, &swim_tx).await;
-                        }
-                        RaftTransportCommand::DisconnectPeer(peer_id) => {
-                            state.disconnect(peer_id);
+                Some(batch) = from_actor.recv() => {
+                    for cmd in batch {
+                        match cmd {
+                            RaftTransportCommand::Send(packets) => {
+                                state.send(packets, &raft_tx, &swim_tx).await;
+                            }
+                            RaftTransportCommand::DisconnectPeer(peer_id) => {
+                                state.disconnect(peer_id);
+                            }
                         }
                     }
                 }

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -25,7 +25,7 @@ impl SwimActor {
         mut mailbox: mpsc::Receiver<SwimActorCommand>,
         mut state: Swim,
         transport_tx: mpsc::Sender<Box<[OutboundPacket]>>,
-        scheduler_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
+        scheduler_tx: mpsc::Sender<Box<[TickerCommand<SwimTimer>]>>,
         raft_tx: mpsc::Sender<MultiRaftActorCommand>,
     ) {
         tracing::info!("[{}] SwimActor started.", state.node_id);
@@ -46,16 +46,15 @@ impl SwimActor {
     async fn flush_events(
         state: &mut Swim,
         transport_tx: &mpsc::Sender<Box<[OutboundPacket]>>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<SwimTimer>>,
+        scheduler_tx: &mpsc::Sender<Box<[TickerCommand<SwimTimer>]>>,
         raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
     ) {
         let mut packets = Vec::new();
+        let mut timer_cmds = Vec::new();
         for event in state.take_events() {
             match event {
                 SwimEvent::Packet(pkt) => packets.push(pkt),
-                SwimEvent::Timer(cmd) => {
-                    let _ = scheduler_tx.send(cmd.into()).await;
-                }
+                SwimEvent::Timer(cmd) => timer_cmds.push(cmd.into()),
                 SwimEvent::Membership(m) => {
                     if let Some(cmd) = m.into_raft_command(&state.node_id, &state.topology) {
                         let _ = raft_tx.send(cmd).await;
@@ -65,6 +64,9 @@ impl SwimActor {
         }
         if !packets.is_empty() {
             let _ = transport_tx.send(packets.into_boxed_slice()).await;
+        }
+        if !timer_cmds.is_empty() {
+            let _ = scheduler_tx.send(timer_cmds.into_boxed_slice()).await;
         }
     }
 }

--- a/src/clusters/swims/actor.rs
+++ b/src/clusters/swims/actor.rs
@@ -24,7 +24,7 @@ impl SwimActor {
     pub async fn run(
         mut mailbox: mpsc::Receiver<SwimActorCommand>,
         mut state: Swim,
-        transport_tx: mpsc::Sender<OutboundPacket>,
+        transport_tx: mpsc::Sender<Box<[OutboundPacket]>>,
         scheduler_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
         raft_tx: mpsc::Sender<MultiRaftActorCommand>,
     ) {
@@ -45,34 +45,26 @@ impl SwimActor {
 
     async fn flush_events(
         state: &mut Swim,
-        transport_tx: &mpsc::Sender<OutboundPacket>,
+        transport_tx: &mpsc::Sender<Box<[OutboundPacket]>>,
         scheduler_tx: &mpsc::Sender<TickerCommand<SwimTimer>>,
         raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
     ) {
+        let mut packets = Vec::new();
         for event in state.take_events() {
-            Self::route_swim_event(state, event, transport_tx, scheduler_tx, raft_tx).await;
-        }
-    }
-
-    async fn route_swim_event(
-        state: &mut Swim,
-        event: SwimEvent,
-        transport_tx: &mpsc::Sender<OutboundPacket>,
-        scheduler_tx: &mpsc::Sender<TickerCommand<SwimTimer>>,
-        raft_tx: &mpsc::Sender<MultiRaftActorCommand>,
-    ) {
-        match event {
-            SwimEvent::Packet(pkt) => {
-                let _ = transport_tx.send(pkt).await;
-            }
-            SwimEvent::Timer(cmd) => {
-                let _ = scheduler_tx.send(cmd.into()).await;
-            }
-            SwimEvent::Membership(m) => {
-                if let Some(cmd) = m.into_raft_command(&state.node_id, &state.topology) {
-                    let _ = raft_tx.send(cmd).await;
+            match event {
+                SwimEvent::Packet(pkt) => packets.push(pkt),
+                SwimEvent::Timer(cmd) => {
+                    let _ = scheduler_tx.send(cmd.into()).await;
+                }
+                SwimEvent::Membership(m) => {
+                    if let Some(cmd) = m.into_raft_command(&state.node_id, &state.topology) {
+                        let _ = raft_tx.send(cmd).await;
+                    }
                 }
             }
+        }
+        if !packets.is_empty() {
+            let _ = transport_tx.send(packets.into_boxed_slice()).await;
         }
     }
 }

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -50,7 +50,7 @@ struct TestHarness {
     pub tx_in: mpsc::Sender<SwimActorCommand>,
     pub tx_out: mpsc::Sender<Box<[OutboundPacket]>>,
     pub rx_out: Option<mpsc::Receiver<Box<[OutboundPacket]>>>,
-    pub ticker_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
+    pub ticker_tx: mpsc::Sender<Box<[TickerCommand<SwimTimer>]>>,
     pub local_addr: SocketAddr,
     pub config: JoinConfig,
 }
@@ -360,9 +360,12 @@ fn make_peer(name: &str, addr: SocketAddr) -> SwimNode {
     }
 }
 
-async fn force_ticks(ticker_tx: &mpsc::Sender<TickerCommand<SwimTimer>>, count: usize) {
+async fn force_ticks(ticker_tx: &mpsc::Sender<Box<[TickerCommand<SwimTimer>]>>, count: usize) {
     for _ in 0..count {
-        ticker_tx.send(TickerCommand::ForceTick).await.unwrap();
+        ticker_tx
+            .send(Box::new([TickerCommand::ForceTick]))
+            .await
+            .unwrap();
     }
 }
 
@@ -560,9 +563,9 @@ async fn cluster_formation_using_join() {
     let _ = h3.query_topology_count().await;
 
     for _ in 0..PROBE_INTERVAL_TICKS * 2 {
-        h1.ticker_tx.send(TickerCommand::ForceTick).await.unwrap();
-        h2.ticker_tx.send(TickerCommand::ForceTick).await.unwrap();
-        h3.ticker_tx.send(TickerCommand::ForceTick).await.unwrap();
+        h1.ticker_tx.send(Box::new([TickerCommand::ForceTick])).await.unwrap();
+        h2.ticker_tx.send(Box::new([TickerCommand::ForceTick])).await.unwrap();
+        h3.ticker_tx.send(Box::new([TickerCommand::ForceTick])).await.unwrap();
     }
 
     assert_eq!(h1.query_topology_count().await, 3);

--- a/src/clusters/tests.rs
+++ b/src/clusters/tests.rs
@@ -17,15 +17,39 @@ use crate::schedulers::actor::run_scheduling_actor;
 use crate::schedulers::ticker::{PROBE_INTERVAL_TICKS, TICK_PERIOD_100_MS};
 use crate::schedulers::ticker_message::TickerCommand;
 
+use std::collections::VecDeque;
 use tokio::{sync::mpsc, time};
 
 use super::*;
 
+struct PacketReceiver {
+    rx: mpsc::Receiver<Box<[OutboundPacket]>>,
+    buf: VecDeque<OutboundPacket>,
+}
+
+impl PacketReceiver {
+    fn new(rx: mpsc::Receiver<Box<[OutboundPacket]>>) -> Self {
+        Self {
+            rx,
+            buf: VecDeque::new(),
+        }
+    }
+
+    async fn recv(&mut self) -> Option<OutboundPacket> {
+        if let Some(pkt) = self.buf.pop_front() {
+            return Some(pkt);
+        }
+        let batch = self.rx.recv().await?;
+        self.buf.extend(batch);
+        self.buf.pop_front()
+    }
+}
+
 #[allow(dead_code)]
 struct TestHarness {
     pub tx_in: mpsc::Sender<SwimActorCommand>,
-    pub tx_out: mpsc::Sender<OutboundPacket>,
-    pub rx_out: Option<mpsc::Receiver<OutboundPacket>>,
+    pub tx_out: mpsc::Sender<Box<[OutboundPacket]>>,
+    pub rx_out: Option<mpsc::Receiver<Box<[OutboundPacket]>>>,
     pub ticker_tx: mpsc::Sender<TickerCommand<SwimTimer>>,
     pub local_addr: SocketAddr,
     pub config: JoinConfig,
@@ -64,7 +88,7 @@ impl TestHarness {
 /// Call `add()` for every harness, then `spawn()` to start routing.
 struct NetworkBridge {
     routes: HashMap<SocketAddr, mpsc::Sender<SwimActorCommand>>,
-    inbounds: Vec<(SocketAddr, mpsc::Receiver<OutboundPacket>)>,
+    inbounds: Vec<(SocketAddr, mpsc::Receiver<Box<[OutboundPacket]>>)>,
 }
 
 impl NetworkBridge {
@@ -87,14 +111,16 @@ impl NetworkBridge {
         for (sender_addr, mut rx) in self.inbounds {
             let routes = Arc::clone(&routes);
             tokio::spawn(async move {
-                while let Some(pkt) = rx.recv().await {
-                    if let Some(tx) = routes.get(&pkt.target) {
-                        let _ = tx
-                            .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
-                                src: sender_addr,
-                                packet: pkt.packet().clone(),
-                            }))
-                            .await;
+                while let Some(batch) = rx.recv().await {
+                    for pkt in batch {
+                        if let Some(tx) = routes.get(&pkt.target) {
+                            let _ = tx
+                                .send(SwimActorCommand::Protocol(SwimCommand::PacketReceived {
+                                    src: sender_addr,
+                                    packet: pkt.packet().clone(),
+                                }))
+                                .await;
+                        }
                     }
                 }
             });
@@ -168,7 +194,7 @@ async fn setup_with_config(port: u32, join_config: JoinConfig) -> TestHarness {
 #[tokio::test]
 async fn test_ping_response() {
     let mut harness = setup_single().await;
-    let mut rx_out = harness.rx_out.take().unwrap();
+    let mut rx_out = PacketReceiver::new(harness.rx_out.take().unwrap());
     let remote_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
     // 1. Simulate receiving a Ping from a remote node
@@ -205,7 +231,7 @@ async fn test_ping_response() {
 #[tokio::test]
 async fn test_refutation_mechanism() {
     let mut harness = setup_single().await;
-    let mut rx_out = harness.rx_out.take().unwrap();
+    let mut rx_out = PacketReceiver::new(harness.rx_out.take().unwrap());
     let remote_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
 
     // 1. Send a gossip message claiming WE (local_addr) are Suspect
@@ -254,7 +280,7 @@ async fn test_refutation_mechanism() {
 #[tokio::test]
 async fn test_gossip_propagation() {
     let mut harness = setup_single().await;
-    let mut rx_out = harness.rx_out.take().unwrap();
+    let mut rx_out = PacketReceiver::new(harness.rx_out.take().unwrap());
     let sender_addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
     let dead_node: SocketAddr = "127.0.0.1:9999".parse().unwrap();
     let probe_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
@@ -342,7 +368,7 @@ async fn force_ticks(ticker_tx: &mpsc::Sender<TickerCommand<SwimTimer>>, count: 
 
 async fn wait_for_ping(
     harness: &TestHarness,
-    rx_out: &mut mpsc::Receiver<OutboundPacket>,
+    rx_out: &mut PacketReceiver,
 ) -> SocketAddr {
     let mut target_addr = None;
     for _ in 0..3 {
@@ -361,7 +387,7 @@ async fn wait_for_ping(
 #[tokio::test]
 async fn test_indirect_ping_trigger() {
     let mut harness = setup_single().await;
-    let mut rx_out = harness.rx_out.take().unwrap();
+    let mut rx_out = PacketReceiver::new(harness.rx_out.take().unwrap());
     let peer_1: SocketAddr = "127.0.0.1:9001".parse().unwrap();
     let peer_2: SocketAddr = "127.0.0.1:9002".parse().unwrap();
 

--- a/src/clusters/transport.rs
+++ b/src/clusters/transport.rs
@@ -13,7 +13,7 @@ impl SwimTransportActor {
     pub async fn run(
         socket: UdpSocket,
         to_actor: SwimSender,
-        mut from_actor: mpsc::Receiver<OutboundPacket>,
+        mut from_actor: mpsc::Receiver<Box<[OutboundPacket]>>,
     ) {
         tracing::info!(
             "Transport Layer listening on {}",
@@ -35,12 +35,14 @@ impl SwimTransportActor {
                 }
 
                 // OUTGOING: Actor -> Encode -> Socket
-                Some(msg) = from_actor.recv() => {
-                    match bincode::encode_to_vec(msg.packet(), BINCODE_CONFIG) {
-                        Ok(bytes) => {
-                            let _ = socket.send_to(&bytes, msg.target).await;
+                Some(batch) = from_actor.recv() => {
+                    for msg in batch {
+                        match bincode::encode_to_vec(msg.packet(), BINCODE_CONFIG) {
+                            Ok(bytes) => {
+                                let _ = socket.send_to(&bytes, msg.target).await;
+                            }
+                            Err(e) => tracing::error!("Failed to encode packet: {}", e),
                         }
-                        Err(e) => tracing::error!("Failed to encode packet: {}", e),
                     }
                 }
             }

--- a/src/it/raft/election.rs
+++ b/src/it/raft/election.rs
@@ -42,11 +42,11 @@ fn build_address_map(
 }
 
 async fn drive_ticks(
-    ticker: &mpsc::Sender<TickerCommand<crate::clusters::raft::messages::RaftTimer>>,
+    ticker: &mpsc::Sender<Box<[TickerCommand<crate::clusters::raft::messages::RaftTimer>]>>,
     count: usize,
 ) {
     for _ in 0..count {
-        let _ = ticker.send(TickerCommand::ForceTick).await;
+        let _ = ticker.send(Box::new([TickerCommand::ForceTick])).await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::task::yield_now().await;

--- a/src/it/raft/membership_change.rs
+++ b/src/it/raft/membership_change.rs
@@ -29,7 +29,7 @@ async fn start_raft_node(
 ) -> Result<
     (
         mpsc::Sender<MultiRaftActorCommand>,
-        mpsc::Sender<TickerCommand<crate::clusters::raft::messages::RaftTimer>>,
+        mpsc::Sender<Box<[TickerCommand<crate::clusters::raft::messages::RaftTimer>]>>,
     ),
     Box<dyn std::error::Error>,
 > {
@@ -95,7 +95,7 @@ async fn start_raft_node(
         tokio::task::yield_now().await;
     }
     for _ in 0..200 {
-        let _ = ticker_force.send(TickerCommand::ForceTick).await;
+        let _ = ticker_force.send(Box::new([TickerCommand::ForceTick])).await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::task::yield_now().await;
@@ -105,11 +105,11 @@ async fn start_raft_node(
 }
 
 async fn tick_n(
-    ticker: &mpsc::Sender<TickerCommand<crate::clusters::raft::messages::RaftTimer>>,
+    ticker: &mpsc::Sender<Box<[TickerCommand<crate::clusters::raft::messages::RaftTimer>]>>,
     n: usize,
 ) {
     for _ in 0..n {
-        let _ = ticker.send(TickerCommand::ForceTick).await;
+        let _ = ticker.send(Box::new([TickerCommand::ForceTick])).await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::task::yield_now().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod test_traits;
 use crate::clusters::raft::actor::{MultiRaftActor, RaftSender};
 use crate::clusters::raft::transport::RaftTransportActor;
 
+use crate::clusters::swims::OutboundPacket;
 use crate::clusters::swims::actor::SwimSender;
 use crate::config::Environment;
 use crate::impls::metadata_storage::MetadataStorage;
@@ -56,7 +57,7 @@ impl StartUp {
     pub async fn run(self) -> Result<()> {
         // SWIM channels
         let (swim_sender, swim_mailbox) = SwimActor::channel(100);
-        let (tx_outbound, rx_outbound) = mpsc::channel(100);
+        let (tx_outbound, rx_outbound) = mpsc::channel::<Box<[OutboundPacket]>>(100);
         let (swim_ticker_tx, swim_ticker_rx) = mpsc::channel(64);
 
         // Raft channels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,11 @@ mod test_traits;
 use crate::clusters::raft::actor::{MultiRaftActor, RaftSender};
 use crate::clusters::raft::transport::RaftTransportActor;
 
+use crate::clusters::raft::messages::RaftTimer;
 use crate::clusters::swims::OutboundPacket;
+use crate::clusters::swims::SwimTimer;
 use crate::clusters::swims::actor::SwimSender;
+use crate::schedulers::ticker_message::TickerCommand;
 use crate::config::Environment;
 use crate::impls::metadata_storage::MetadataStorage;
 use crate::net::{TcpListener, TcpStream};
@@ -58,14 +61,14 @@ impl StartUp {
         // SWIM channels
         let (swim_sender, swim_mailbox) = SwimActor::channel(100);
         let (tx_outbound, rx_outbound) = mpsc::channel::<Box<[OutboundPacket]>>(100);
-        let (swim_ticker_tx, swim_ticker_rx) = mpsc::channel(64);
+        let (swim_ticker_tx, swim_ticker_rx) = mpsc::channel::<Box<[TickerCommand<SwimTimer>]>>(64);
 
         // Raft channels
         let (raft_tx, raft_mailbox) = MultiRaftActor::channel(4096);
         let (raft_transport_tx, raft_transport_rx) = mpsc::channel(100);
         // Each vnode can have both an election and heartbeat timer active, so capacity
         // must comfortably exceed vnodes_per_node * 2; * 16 gives ample headroom.
-        let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel(self.env.vnodes_per_node as usize * 16);
+        let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel::<Box<[TickerCommand<RaftTimer>]>>(self.env.vnodes_per_node as usize * 16);
 
         // Build SWIM state and extract node_id before handing state to the actor
         let state = self.env.swim(self.rng_seed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod test_traits;
 use crate::clusters::raft::actor::{MultiRaftActor, RaftSender};
 use crate::clusters::raft::transport::RaftTransportActor;
 
-use crate::clusters::raft::messages::RaftTimer;
+use crate::clusters::raft::messages::{RaftTimer, RaftTransportCommand};
 use crate::clusters::swims::OutboundPacket;
 use crate::clusters::swims::SwimTimer;
 use crate::clusters::swims::actor::SwimSender;
@@ -65,7 +65,7 @@ impl StartUp {
 
         // Raft channels
         let (raft_tx, raft_mailbox) = MultiRaftActor::channel(4096);
-        let (raft_transport_tx, raft_transport_rx) = mpsc::channel(100);
+        let (raft_transport_tx, raft_transport_rx) = mpsc::channel::<Box<[RaftTransportCommand]>>(100);
         // Each vnode can have both an election and heartbeat timer active, so capacity
         // must comfortably exceed vnodes_per_node * 2; * 16 gives ample headroom.
         let (raft_ticker_tx, raft_ticker_rx) = mpsc::channel::<Box<[TickerCommand<RaftTimer>]>>(self.env.vnodes_per_node as usize * 16);

--- a/src/schedulers/actor.rs
+++ b/src/schedulers/actor.rs
@@ -7,7 +7,7 @@ use tokio::time;
 
 pub async fn run_scheduling_actor<T>(
     sender: mpsc::Sender<impl From<T::Callback>>,
-    mut mailbox: mpsc::Receiver<TickerCommand<T>>,
+    mut mailbox: mpsc::Receiver<Box<[TickerCommand<T>]>>,
     tick_period_ms: u64,
     protocol_interval_ticks: Option<u64>,
 ) where
@@ -25,16 +25,18 @@ pub async fn run_scheduling_actor<T>(
                 }
             }
 
-            Some(cmd) = mailbox.recv() => {
-                match cmd {
-                    #[cfg(test)]
-                    TickerCommand::ForceTick => {
-                        for event in ticker.advance_clock(now_ms()) {
-                            let _ = sender.send(event.into()).await;
+            Some(batch) = mailbox.recv() => {
+                for cmd in batch {
+                    match cmd {
+                        #[cfg(test)]
+                        TickerCommand::ForceTick => {
+                            for event in ticker.advance_clock(now_ms()) {
+                                let _ = sender.send(event.into()).await;
+                            }
                         }
-                    }
-                    TickerCommand::Schedule(probe_cmd)=>{
-                        ticker.apply(probe_cmd);
+                        TickerCommand::Schedule(probe_cmd)=>{
+                            ticker.apply(probe_cmd);
+                        }
                     }
                 }
             }

--- a/src/schedulers/ticker_message.rs
+++ b/src/schedulers/ticker_message.rs
@@ -9,27 +9,26 @@ pub(crate) enum TickerCommand<T> {
     ForceTick,
 }
 
-pub(crate) struct SchedulerSender<T>(tokio_mpsc::Sender<TickerCommand<T>>);
+pub(crate) struct SchedulerSender<T>(tokio_mpsc::Sender<Box<[TickerCommand<T>]>>);
 
-impl<T> From<tokio_mpsc::Sender<TickerCommand<T>>> for SchedulerSender<T> {
-    fn from(tx: tokio_mpsc::Sender<TickerCommand<T>>) -> Self {
+impl<T> From<tokio_mpsc::Sender<Box<[TickerCommand<T>]>>> for SchedulerSender<T> {
+    fn from(tx: tokio_mpsc::Sender<Box<[TickerCommand<T>]>>) -> Self {
         Self(tx)
     }
 }
 
 impl<T> SchedulerSender<T> {
     pub(crate) fn schedule(&self, seq: u64, timer: impl Into<T>) {
-        let _ = self.0.blocking_send(
-            TimerCommand::SetSchedule {
-                seq,
-                timer: timer.into(),
-            }
-            .into(),
-        );
+        let cmd: TickerCommand<T> = TimerCommand::SetSchedule {
+            seq,
+            timer: timer.into(),
+        }
+        .into();
+        let _ = self.0.blocking_send(Box::new([cmd]));
     }
 
     pub(crate) fn send(&self, cmd: TimerCommand<T>) {
-        let _ = self.0.blocking_send(cmd.into());
+        let _ = self.0.blocking_send(Box::new([cmd.into()]));
     }
 }
 


### PR DESCRIPTION
## Summary

Cross-actor channels now send `Box<[T]>` batches instead of individual `T` messages. The sender accumulates messages during its event loop iteration, calls `.into_boxed_slice()`, and flushes in a single `send()`.

## Why

Each `mpsc::send()` acquires a lock on the channel's internal state. When an actor flushes N side effects, that's N lock acquisitions per flush cycle. With batching, it's 1 — regardless of how many messages were produced. This matters for high-frequency flush paths (SWIM probe rounds produce 3-5 outbound packets + timer commands per tick at 100ms intervals; Raft with 768 shard groups produces timer commands proportional to dirty groups per flush).

`Box<[T]>` over `Vec<T>` sheds unused capacity before crossing the channel — the receiver gets an exact-size allocation with no phantom memory sitting in the buffer.

For bounded channels using `try_send` (D3's `coordinator_tx`), batching also reduces the probability of a full-channel drop: one send per flush instead of per message means fewer opportunities to lose work.

## Changes

| Channel | Sender → Receiver | Before | After |
|---|---|---|---|
| SWIM outbound | SwimActor → SwimTransportActor | `Sender<OutboundPacket>` | `Sender<Box<[OutboundPacket]>>` |
| SWIM timer | SwimActor → SchedulingActor | `Sender<TickerCommand<SwimTimer>>` | `Sender<Box<[TickerCommand<SwimTimer>]>>` |
| Raft timer | MultiRaftActor → SchedulingActor | `Sender<TickerCommand<RaftTimer>>` | `Sender<Box<[TickerCommand<RaftTimer>]>>` |
| Raft transport | MultiRaftActor → RaftTransportActor | `Sender<RaftTransportCommand>` | `Sender<Box<[RaftTransportCommand]>>` |
| DataPlane timer (via SchedulerSender) | DataPlaneActor → SchedulingActor | singleton wrapper | singleton `Box<[T; 1]>` (OS thread; full batching deferred to DataPlaneActor integration) |

Actor mailboxes (input channels with multiple senders) and worker channels (checkpoint, cold read — individual jobs with reply channels) are unchanged.

## Convention

Added `Box<[T]>` batching as a project-wide convention in `code-convention.md`.

## Test plan

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (zero warnings)
- [ ] All 278 tests pass
- [ ] SWIM integration tests (cluster formation, gossip propagation, indirect ping) verify end-to-end with batched transport
- [ ] Raft integration tests (election, membership change) verify end-to-end with batched timer + transport channels