### PR TITLE
Remove server-side control-plane routing; client directs to leader

### DIFF
--- a/diagrams/client/d1_client.md
+++ b/diagrams/client/d1_client.md
@@ -77,6 +77,28 @@ The new design resolves each problem:
 The rule of thumb: `ConnectionRequests` was "the API needed to test the internals."
 `ClientRequest` / `ClientResponse` is "the API a producer or consumer actually calls."
 
+### Why control-plane routing is client-side
+
+The original design resolved the Raft leader server-side for control-plane requests: the receiving
+node silently forwarded to the leader via an `InternalForward` variant (max 1 hop). This created
+an asymmetry between the two planes:
+
+| Plane | Who handles routing |
+|---|---|
+| Control plane (original) | Server — auto-forwarded to leader; client never saw `NotLeader` |
+| Data plane | Client — `NotLeader` / `ShardNotLocal` returned; client retries |
+
+Both planes now use the same model. Control-plane handlers return `NotLeader { leader_addr }` or
+`ShardNotLocal { hint_node }` and the client follows the same redirect logic as for data-plane
+requests. This removes `ControlPlaneRouter`, `InternalForward`, and a hidden network hop from the
+server.
+
+`leader_addr` is `Option<SocketAddr>` because a leader may genuinely be unknown: when the previous
+leader dies and a new election has not yet completed, no follower knows who the new leader is.
+`hint_node` is always a concrete address because `ShardNotLocal` is only emitted after the server
+has already resolved at least one shard group member from its local Topology — if no member could
+be found, `InternalError` is returned instead.
+
 ---
 
 ## Connection Model
@@ -118,9 +140,20 @@ ClientRequest:
 
 Error responses are split by plane:
 
-**Control plane errors** — routing is handled server-side; clients never see `NotLeader` or
-`ShardNotLocal`. The receiving node resolves the correct leader internally and forwards the request
-once (`ProposeRequest { forwarded: true }`). If forwarding fails, `InternalError` is returned.
+**Control plane errors** — routing is the client's responsibility, identical to the data plane.
+The server never auto-forwards; it returns a redirect and the client retries.
+
+```
+NotLeader { leader_addr: Option<SocketAddr> }
+  <- This node is not the Raft leader (writes) or does not host the shard group (reads).
+     leader_addr is Some when a leader is known; None when an election is in progress
+     (the previous leader died and no replacement has won yet). Client retries with backoff.
+
+ShardNotLocal { hint_node: SocketAddr }
+  <- This node does not host the shard group for the requested topic at all.
+     hint_node: a live shard group member resolved from the local Topology. Client
+     reconnects and retries on hint_node.
+```
 
 **Data plane errors** — routing is the client's responsibility via `TopicRoutingCache`.
 
@@ -755,11 +788,11 @@ pub struct ConsumerGroupMeta {
 New `MetadataCommand` variants:
 
 ```rust
-JoinConsumerGroup {
-group_id:  String,
-topic_id:  TopicId,
-member_id: String,
-joined_at: u64,
+enum JoinConsumerGroup {
+    group_id:  String
+    topic_id:  TopicId
+    member_id: String
+    joined_at: u64
 }
 
 LeaveConsumerGroup {

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -220,6 +220,8 @@ impl ClientHandler {
             ClientRequest::ControlPlane(cp) => self.handle_control_plane(cp).await,
             ClientRequest::DataPlane(dp) => self.handle_data_plane(dp).await,
             ClientRequest::Admin(admin) => self.handle_admin(admin).await,
+            #[cfg(test)]
+            ClientRequest::Test(req) => self.handle_test(req).await,
         }
     }
 
@@ -510,8 +512,6 @@ impl ClientHandler {
             AdminRequest::GetShardLeader { shard_group_id } => {
                 self.handle_get_shard_leader(shard_group_id).await
             }
-            #[cfg(test)]
-            AdminRequest::IsClusterReady => self.handle_is_cluster_ready().await,
         };
         res.unwrap_or_else(|e| {
             tracing::error!("client admin dispatch error: {e}");
@@ -678,9 +678,14 @@ impl ClientHandler {
     }
 
     #[cfg(test)]
-    async fn handle_is_cluster_ready(&self) -> anyhow::Result<ClientResponse> {
-        let ready = self.raft_sender.is_cluster_ready().await;
-        Ok(ClientResponse::Admin(AdminResponse::ClusterReady(ready)))
+    async fn handle_test(&self, req: crate::connections::protocol::TestRequest) -> ClientResponse {
+        use crate::connections::protocol::{TestRequest, TestResponse};
+        match req {
+            TestRequest::IsClusterReady => {
+                let ready = self.raft_sender.is_cluster_ready().await;
+                ClientResponse::Test(TestResponse::ClusterReady(ready))
+            }
+        }
     }
 }
 

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -12,27 +12,26 @@
 ///
 /// This allows multiple requests to be in-flight on a single connection simultaneously,
 /// with responses arriving in any order.
-use std::{io::ErrorKind, mem::size_of};
+use std::{io::ErrorKind, mem::size_of, net::SocketAddr};
 
 const LEN_PREFIX_SIZE: usize = size_of::<u32>();
 const REQUEST_ID_SIZE: usize = size_of::<u64>();
 
-use anyhow::Context;
 use tokio::sync::mpsc;
 
 use crate::connections::protocol::{
     AdminRequest, AdminResponse, ClientRequest, ClientResponse, ControlPlaneRequest,
-    ControlPlaneResponse, DataPlaneRequest, NodeInfo, NodeState, ShardDetail, TopicStats,
-    TopicSummary,
+    ControlPlaneResponse, DataPlaneRequest, NodeInfo, NodeState, RangeDetail, RangeState,
+    ShardDetail, TopicDetail, TopicStats, TopicSummary,
 };
 use crate::{
     control_plane::{
-        SwimNodeState,
+        NodeId, SwimNodeState,
         consensus::actor::MutlRaftSender,
-        consensus::messages::ProposeError,
-        membership::{ShardGroupId, actor::SwimSender},
+        consensus::messages::{GroupStatus, ProposeError, TopicDetailQueryResult},
+        membership::{ShardGroup, actor::SwimSender},
         metadata::{
-            command::{CreateTopic, DeleteTopic, MetadataCommand},
+            command::{CreateTopic, DeleteTopic, MetadataCommand, SplitRange},
             strategy::StoragePolicy,
         },
     },
@@ -224,6 +223,8 @@ impl ClientHandler {
         }
     }
 
+    // ── Control Plane ─────────────────────────────────────────────────────
+
     async fn handle_control_plane(&self, request: ControlPlaneRequest) -> ClientResponse {
         let res = match request {
             ControlPlaneRequest::CreateTopic {
@@ -232,7 +233,7 @@ impl ClientHandler {
             } => self.handle_create_topic(name, storage_policy).await,
             ControlPlaneRequest::DeleteTopic { name } => self.handle_delete_topic(name).await,
             ControlPlaneRequest::ListHostedTopics => self.handle_list_hosted_topics().await,
-            ControlPlaneRequest::DescribeTopic { .. } => todo!(),
+            ControlPlaneRequest::DescribeTopic { name } => self.handle_describe_topic(name).await,
         };
         match res {
             Ok(resp) => resp,
@@ -248,64 +249,120 @@ impl ClientHandler {
         name: String,
         storage_policy: StoragePolicy,
     ) -> anyhow::Result<ClientResponse> {
-        let shard_group = self
+        let Some(shard_group) = self
             .swim_sender
             .resolve_shard_group(name.as_bytes().to_vec())
             .await?
-            .context("shard group not found")?;
-
-        let created_at = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-
-        let cmd = CreateTopic {
-            storage_policy,
-            name,
-            replica_set: shard_group.members,
-            created_at,
+        else {
+            return Ok(ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                "shard group not found".into(),
+            )));
         };
-
-        Ok(
-            match self
-                .raft_sender
-                .propose(shard_group.id, cmd.into())
-                .await
-                .context("shard group not found")?
-            {
-                Ok(()) => ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated),
-                Err(ProposeError::NotLeader(_)) => {
-                    ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
-                        "not the leader for this shard group — retry on another node".into(),
-                    ))
+        match self.raft_sender.get_group_status(shard_group.id).await {
+            GroupStatus::Hosted { is_leader: true, .. } => {
+                let detail =
+                    self.raft_sender.get_topic_detail(shard_group.id, name.clone()).await;
+                if matches!(detail, TopicDetailQueryResult::Found(_)) {
+                    return Ok(ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists));
                 }
-                Err(e) => ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
-                    format!("{e:?}"),
-                )),
-            },
-        )
+                let now_ms = current_time_ms();
+                let cmd = MetadataCommand::CreateTopic(CreateTopic {
+                    name: name.clone(),
+                    storage_policy,
+                    replica_set: shard_group.members,
+                    created_at: now_ms,
+                });
+                Ok(match self.raft_sender.propose(shard_group.id, cmd).await {
+                    Some(Ok(())) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
+                    }
+                    Some(Err(ProposeError::NotLeader(leader_id))) => {
+                        let leader_addr = match leader_id {
+                            Some(id) => self.resolve_leader_addr(id).await,
+                            None => None,
+                        };
+                        ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                            leader_addr,
+                        })
+                    }
+                    Some(Err(ProposeError::ShardNotFound)) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                            "shard not found".into(),
+                        ))
+                    }
+                    Some(Err(ProposeError::ShardGroupRemoved)) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                            "shard group removed".into(),
+                        ))
+                    }
+                    None => ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                        "shard group not found".into(),
+                    )),
+                })
+            }
+            GroupStatus::Hosted { is_leader: false, leader: Some(leader_id) } => {
+                let leader_addr = self.resolve_leader_addr(leader_id).await;
+                Ok(ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader { leader_addr }))
+            }
+            GroupStatus::Hosted { is_leader: false, leader: None } => {
+                Ok(ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                    leader_addr: None,
+                }))
+            }
+            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+        }
     }
 
     async fn handle_delete_topic(&self, name: String) -> anyhow::Result<ClientResponse> {
-        let shard_group = self
+        let Some(shard_group) = self
             .swim_sender
             .resolve_shard_group(name.as_bytes().to_vec())
             .await?
-            .context("shard group not found")?;
-
-        let cmd = MetadataCommand::DeleteTopic(DeleteTopic { name });
-        Ok(match self.raft_sender.propose(shard_group.id, cmd).await {
-            Some(Ok(())) => ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted),
-            Some(Err(ProposeError::NotLeader(_))) => {
-                ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
-                    "not the leader for this shard group — retry on another node".into(),
-                ))
+        else {
+            return Ok(ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                "shard group not found".into(),
+            )));
+        };
+        match self.raft_sender.get_group_status(shard_group.id).await {
+            GroupStatus::Hosted { is_leader: true, .. } => {
+                let cmd = MetadataCommand::DeleteTopic(DeleteTopic { name: name.clone() });
+                Ok(match self.raft_sender.propose(shard_group.id, cmd).await {
+                    Some(Ok(())) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted)
+                    }
+                    Some(Err(ProposeError::NotLeader(leader_id))) => {
+                        let leader_addr = match leader_id {
+                            Some(id) => self.resolve_leader_addr(id).await,
+                            None => None,
+                        };
+                        ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                            leader_addr,
+                        })
+                    }
+                    Some(Err(ProposeError::ShardNotFound)) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                            "shard not found".into(),
+                        ))
+                    }
+                    Some(Err(ProposeError::ShardGroupRemoved)) => {
+                        ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                            "shard group removed".into(),
+                        ))
+                    }
+                    None => ClientResponse::ControlPlane(ControlPlaneResponse::TopicNotFound),
+                })
             }
-            Some(Err(e)) => {
-                ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(format!("{e:?}")))
+            GroupStatus::Hosted { is_leader: false, leader: Some(leader_id) } => {
+                let leader_addr = self.resolve_leader_addr(leader_id).await;
+                Ok(ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader { leader_addr }))
             }
-            None => ClientResponse::ControlPlane(ControlPlaneResponse::TopicNotFound),
-        })
+            GroupStatus::Hosted { is_leader: false, leader: None } => {
+                Ok(ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                    leader_addr: None,
+                }))
+            }
+            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+        }
     }
 
     async fn handle_list_hosted_topics(&self) -> anyhow::Result<ClientResponse> {
@@ -325,6 +382,111 @@ impl ClientHandler {
         ))
     }
 
+    async fn handle_describe_topic(&self, name: String) -> anyhow::Result<ClientResponse> {
+        let Some(shard_group) = self
+            .swim_sender
+            .resolve_shard_group(name.as_bytes().to_vec())
+            .await?
+        else {
+            return Ok(ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                "shard group not found".into(),
+            )));
+        };
+        match self.raft_sender.get_group_status(shard_group.id).await {
+            GroupStatus::Hosted { .. } => {
+                self.read_describe_topic_with_group(name, shard_group.id.0).await
+            }
+            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+        }
+    }
+
+    // ── Control Plane primitives ──────────────────────────────────────────
+
+    async fn read_describe_topic_with_group(
+        &self,
+        name: String,
+        shard_group_id: u64,
+    ) -> anyhow::Result<ClientResponse> {
+        use crate::control_plane::membership::ShardGroupId;
+        let result = self
+            .raft_sender
+            .get_topic_detail(ShardGroupId(shard_group_id), name.clone())
+            .await;
+        Ok(match result {
+            TopicDetailQueryResult::Found(data) => {
+                let ranges = data
+                    .ranges
+                    .into_iter()
+                    .map(|r| RangeDetail {
+                        range_id: r.range_id,
+                        keyspace_start: r.keyspace_start,
+                        keyspace_end: r.keyspace_end,
+                        active_segment_id: r.active_segment_id,
+                        state: match r.state {
+                            crate::control_plane::metadata::types::RangeState::Active => {
+                                RangeState::Active
+                            }
+                            crate::control_plane::metadata::types::RangeState::Sealed => {
+                                RangeState::Sealed
+                            }
+                            crate::control_plane::metadata::types::RangeState::Deleting => {
+                                RangeState::Deleting
+                            }
+                        },
+                    })
+                    .collect();
+                ClientResponse::ControlPlane(ControlPlaneResponse::TopicDetail(TopicDetail {
+                    name: data.name,
+                    ranges,
+                }))
+            }
+            TopicDetailQueryResult::TopicNotFound => {
+                ClientResponse::ControlPlane(ControlPlaneResponse::TopicNotFound)
+            }
+            TopicDetailQueryResult::GroupNotHosted => {
+                ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                    "shard group not hosted on this node".into(),
+                ))
+            }
+        })
+    }
+
+    /// Returns `ShardNotLocal` for the given shard group, using the first member as the hint.
+    async fn cp_not_local(&self, shard_group: &ShardGroup) -> anyhow::Result<ClientResponse> {
+        match self.pick_member_addr(shard_group).await {
+            Ok(hint_node) => Ok(ClientResponse::ControlPlane(
+                ControlPlaneResponse::ShardNotLocal { hint_node },
+            )),
+            Err(_) => Ok(ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
+                "no shard group member reachable".into(),
+            ))),
+        }
+    }
+
+    async fn resolve_leader_addr(&self, leader_id: NodeId) -> Option<SocketAddr> {
+        self.swim_sender
+            .resolve_address(leader_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|a| a.client_addr)
+    }
+
+    async fn pick_member_addr(&self, shard_group: &ShardGroup) -> anyhow::Result<SocketAddr> {
+        let member_id = shard_group
+            .members
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("shard group has no members"))?
+            .clone();
+        self.swim_sender
+            .resolve_address(member_id)
+            .await?
+            .map(|a| a.client_addr)
+            .ok_or_else(|| anyhow::anyhow!("shard group member address unknown"))
+    }
+
+    // ── Data Plane ────────────────────────────────────────────────────────
+
     async fn handle_data_plane(&self, request: DataPlaneRequest) -> ClientResponse {
         match request {
             DataPlaneRequest::Produce { .. } => todo!(),
@@ -333,13 +495,17 @@ impl ClientHandler {
         }
     }
 
+    // ── Admin ─────────────────────────────────────────────────────────────
+
     async fn handle_admin(&self, request: AdminRequest) -> ClientResponse {
         let res = match request {
             AdminRequest::DescribeCluster => self.handle_describe_cluster().await,
             AdminRequest::ListHostedTopicsWithStats => {
                 self.handle_list_hosted_topics_with_stats().await
             }
-            AdminRequest::SplitRange { .. } => todo!(),
+            AdminRequest::SplitRange { topic_name, range_id, split_point } => {
+                self.handle_split_range(topic_name, range_id, split_point).await
+            }
             AdminRequest::GetShardInfo { key } => self.handle_get_shard_info(key).await,
             AdminRequest::GetShardLeader { shard_group_id } => {
                 self.handle_get_shard_leader(shard_group_id).await
@@ -383,6 +549,105 @@ impl ClientHandler {
         Ok(ClientResponse::Admin(AdminResponse::TopicStats { topics }))
     }
 
+    async fn handle_split_range(
+        &self,
+        topic_name: String,
+        range_id: u64,
+        split_point: Vec<u8>,
+    ) -> anyhow::Result<ClientResponse> {
+        let Some(shard_group) = self
+            .swim_sender
+            .resolve_shard_group(topic_name.as_bytes().to_vec())
+            .await?
+        else {
+            return Ok(ClientResponse::Admin(AdminResponse::InternalError(
+                "shard group not found".into(),
+            )));
+        };
+        match self.raft_sender.get_group_status(shard_group.id).await {
+            GroupStatus::Hosted { is_leader: true, .. } => {
+                self.propose_split_range_local(shard_group, topic_name, range_id, split_point)
+                    .await
+            }
+            GroupStatus::Hosted { is_leader: false, leader: Some(leader_id) } => {
+                let leader_addr = self.resolve_leader_addr(leader_id).await;
+                Ok(ClientResponse::Admin(AdminResponse::InternalError(format!(
+                    "not the leader, try {leader_addr:?}"
+                ))))
+            }
+            GroupStatus::Hosted { is_leader: false, leader: None } => Ok(
+                ClientResponse::Admin(AdminResponse::InternalError("election in progress".into())),
+            ),
+            GroupStatus::NotHosted => Ok(ClientResponse::Admin(AdminResponse::InternalError(
+                "shard group not hosted on this node".into(),
+            ))),
+        }
+    }
+
+    async fn propose_split_range_local(
+        &self,
+        shard_group: ShardGroup,
+        topic_name: String,
+        range_id: u64,
+        split_point: Vec<u8>,
+    ) -> anyhow::Result<ClientResponse> {
+        use crate::control_plane::metadata::{RangeId, TopicId};
+
+        let detail = match self
+            .raft_sender
+            .get_topic_detail(shard_group.id, topic_name.clone())
+            .await
+        {
+            TopicDetailQueryResult::Found(d) => d,
+            TopicDetailQueryResult::TopicNotFound => {
+                return Ok(ClientResponse::Admin(AdminResponse::InternalError(
+                    "topic not found".into(),
+                )));
+            }
+            TopicDetailQueryResult::GroupNotHosted => {
+                return Ok(ClientResponse::Admin(AdminResponse::InternalError(
+                    "shard group not hosted".into(),
+                )));
+            }
+        };
+
+        let Some(range) = detail.ranges.iter().find(|r| r.range_id == range_id) else {
+            return Ok(ClientResponse::Admin(AdminResponse::InternalError(
+                "range not found".into(),
+            )));
+        };
+
+        if split_point <= range.keyspace_start || split_point >= range.keyspace_end {
+            return Ok(ClientResponse::Admin(AdminResponse::InvalidSplitPoint));
+        }
+
+        let now_ms = current_time_ms();
+        let cmd = MetadataCommand::SplitRange(SplitRange {
+            topic_id: TopicId(detail.topic_id),
+            range_id: RangeId(range_id),
+            split_point: split_point.clone(),
+            created_at: now_ms,
+            left_replica_set: range.replica_set.clone(),
+            right_replica_set: range.replica_set.clone(),
+        });
+
+        Ok(match self.raft_sender.propose(shard_group.id, cmd).await {
+            Some(Ok(())) => ClientResponse::Admin(AdminResponse::RangeSplit),
+            Some(Err(ProposeError::NotLeader(_))) => {
+                ClientResponse::Admin(AdminResponse::InternalError("not the leader".into()))
+            }
+            Some(Err(ProposeError::ShardNotFound)) => {
+                ClientResponse::Admin(AdminResponse::InternalError("shard not found".into()))
+            }
+            Some(Err(ProposeError::ShardGroupRemoved)) => {
+                ClientResponse::Admin(AdminResponse::InternalError("shard group removed".into()))
+            }
+            None => {
+                ClientResponse::Admin(AdminResponse::InternalError("shard group not found".into()))
+            }
+        })
+    }
+
     async fn handle_get_shard_info(&self, key: Vec<u8>) -> anyhow::Result<ClientResponse> {
         let detail = self
             .swim_sender
@@ -397,7 +662,11 @@ impl ClientHandler {
         Ok(ClientResponse::Admin(AdminResponse::ShardInfo { detail }))
     }
 
-    async fn handle_get_shard_leader(&self, shard_group_id: u64) -> anyhow::Result<ClientResponse> {
+    async fn handle_get_shard_leader(
+        &self,
+        shard_group_id: u64,
+    ) -> anyhow::Result<ClientResponse> {
+        use crate::control_plane::membership::ShardGroupId;
         let leader = self
             .raft_sender
             .get_leader(ShardGroupId(shard_group_id))
@@ -426,10 +695,18 @@ pub async fn run_client_writer(
     Ok(())
 }
 
+fn current_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::SocketAddr;
 
+    use crate::control_plane::consensus::messages::{GroupStatus, TopicDetailQueryResult};
     use crate::connections::protocol::{
         AdminRequest, AdminResponse, ClientRequest, ClientResponse, ControlPlaneRequest,
         ControlPlaneResponse, NodeState,
@@ -484,31 +761,45 @@ mod tests {
         tx
     }
 
-    #[tokio::test]
-    async fn create_topic_ok() {
-        let swim = swim_sender_with(|cmd| {
-            if let SwimActorCommand::Query(QueryCommand::ResolveShardGroup { reply, .. }) = cmd
-            {
-                let _ = reply.send(Some(test_shard_group()));
+    fn swim_leader_for(group: ShardGroup) -> crate::control_plane::membership::actor::SwimSender {
+        swim_sender_with(move |cmd| {
+            if let SwimActorCommand::Query(QueryCommand::ResolveShardGroup { reply, .. }) = cmd {
+                let _ = reply.send(Some(group.clone()));
             }
-        });
-        let raft = raft_sender_with(|cmd| {
-            if let MultiRaftActorCommand::Propose { reply, .. } = cmd {
+        })
+    }
+
+    fn raft_leader_for(group: ShardGroup) -> crate::control_plane::consensus::actor::MutlRaftSender {
+        let group_id = group.id;
+        raft_sender_with(move |cmd| match cmd {
+            MultiRaftActorCommand::GetGroupStatus { reply, .. } => {
+                let _ = reply.send(GroupStatus::Hosted { is_leader: true, leader: None });
+            }
+            MultiRaftActorCommand::GetTopicDetail { reply, .. } => {
+                let _ = reply.send(TopicDetailQueryResult::TopicNotFound);
+            }
+            MultiRaftActorCommand::Propose { reply, propose, .. }
+                if propose.shard_group_id == group_id =>
+            {
                 let _ = reply.send(Ok(()));
             }
-        });
-        let resp = ClientHandler::new(swim, raft)
-            .dispatch(ClientRequest::ControlPlane(
-                ControlPlaneRequest::CreateTopic {
-                    name: "t1".into(),
-                    storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
-                        retention_ms: 3_600_000,
-                        replication_factor: 1,
-                        partition_strategy:
-                            crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
-                    },
+            _ => {}
+        })
+    }
+
+    #[tokio::test]
+    async fn create_topic_ok() {
+        let group = test_shard_group();
+        let resp = ClientHandler::new(swim_leader_for(group.clone()), raft_leader_for(group))
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
+                name: "t1".into(),
+                storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
+                    retention_ms: 3_600_000,
+                    replication_factor: 1,
+                    partition_strategy:
+                        crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
                 },
-            ))
+            }))
             .await;
         assert!(
             matches!(
@@ -516,6 +807,48 @@ mod tests {
                 ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
             ),
             "expected TopicCreated, got {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_topic_already_exists() {
+        let group = test_shard_group();
+        let swim = swim_leader_for(group.clone());
+        use crate::control_plane::metadata::types::{RangeDetailData, RangeState, TopicDetailData};
+        let raft = raft_sender_with(move |cmd| match cmd {
+            MultiRaftActorCommand::GetGroupStatus { reply, .. } => {
+                let _ = reply.send(GroupStatus::Hosted { is_leader: true, leader: None });
+            }
+            MultiRaftActorCommand::GetTopicDetail { reply, .. } => {
+                let _ = reply.send(TopicDetailQueryResult::Found(TopicDetailData {
+                    name: "t1".into(),
+                    topic_id: 1,
+                    ranges: vec![RangeDetailData {
+                        range_id: 0,
+                        keyspace_start: vec![],
+                        keyspace_end: vec![255],
+                        active_segment_id: Some(0),
+                        state: RangeState::Active,
+                        replica_set: vec![],
+                    }],
+                }));
+            }
+            _ => {}
+        });
+        let resp = ClientHandler::new(swim, raft)
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
+                name: "t1".into(),
+                storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
+                    retention_ms: 3_600_000,
+                    replication_factor: 1,
+                    partition_strategy:
+                        crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
+                },
+            }))
+            .await;
+        assert!(
+            matches!(resp, ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)),
+            "expected AlreadyExists, got {resp:?}"
         );
     }
 
@@ -550,22 +883,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_topic_ok() {
-        let swim = swim_sender_with(|cmd| {
-            if let SwimActorCommand::Query(QueryCommand::ResolveShardGroup { reply, .. }) = cmd
-            {
-                let _ = reply.send(Some(test_shard_group()));
-            }
-        });
-        let raft = raft_sender_with(|cmd| {
-            if let MultiRaftActorCommand::Propose { reply, .. } = cmd {
-                let _ = reply.send(Ok(()));
+    async fn create_topic_not_leader_returns_redirect() {
+        let group = test_shard_group();
+        let swim = swim_leader_for(group.clone());
+        let raft = raft_sender_with(move |cmd| {
+            if let MultiRaftActorCommand::GetGroupStatus { reply, .. } = cmd {
+                let _ = reply.send(GroupStatus::Hosted {
+                    is_leader: false,
+                    leader: Some(node_id("other-node")),
+                });
             }
         });
         let resp = ClientHandler::new(swim, raft)
-            .dispatch(ClientRequest::ControlPlane(
-                ControlPlaneRequest::DeleteTopic { name: "t1".into() },
-            ))
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
+                name: "t1".into(),
+                storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
+                    retention_ms: 3_600_000,
+                    replication_factor: 1,
+                    partition_strategy:
+                        crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
+                },
+            }))
+            .await;
+        // SWIM has no address for "other-node" so leader_addr resolves to None.
+        assert!(
+            matches!(
+                resp,
+                ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader { .. })
+            ),
+            "expected NotLeader, got {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_topic_ok() {
+        let group = test_shard_group();
+        let resp = ClientHandler::new(swim_leader_for(group.clone()), raft_leader_for(group))
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::DeleteTopic {
+                name: "t1".into(),
+            }))
             .await;
         assert!(
             matches!(
@@ -573,6 +929,67 @@ mod tests {
                 ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted)
             ),
             "expected TopicDeleted, got {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_topic_found() {
+        use crate::control_plane::metadata::types::{RangeDetailData, RangeState, TopicDetailData};
+        let group = test_shard_group();
+        let swim = swim_leader_for(group.clone());
+        let raft = raft_sender_with(move |cmd| match cmd {
+            MultiRaftActorCommand::GetGroupStatus { reply, .. } => {
+                let _ = reply.send(GroupStatus::Hosted { is_leader: false, leader: None });
+            }
+            MultiRaftActorCommand::GetTopicDetail { reply, .. } => {
+                let _ = reply.send(TopicDetailQueryResult::Found(TopicDetailData {
+                    name: "t1".into(),
+                    topic_id: 1,
+                    ranges: vec![RangeDetailData {
+                        range_id: 0,
+                        keyspace_start: vec![],
+                        keyspace_end: vec![255],
+                        active_segment_id: Some(0),
+                        state: RangeState::Active,
+                        replica_set: vec![],
+                    }],
+                }));
+            }
+            _ => {}
+        });
+        let resp = ClientHandler::new(swim, raft)
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::DescribeTopic {
+                name: "t1".into(),
+            }))
+            .await;
+        let ClientResponse::ControlPlane(ControlPlaneResponse::TopicDetail(detail)) = resp else {
+            panic!("expected TopicDetail, got {resp:?}");
+        };
+        assert_eq!(detail.name, "t1");
+        assert_eq!(detail.ranges.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn describe_topic_not_found() {
+        let group = test_shard_group();
+        let swim = swim_leader_for(group.clone());
+        let raft = raft_sender_with(move |cmd| match cmd {
+            MultiRaftActorCommand::GetGroupStatus { reply, .. } => {
+                let _ = reply.send(GroupStatus::Hosted { is_leader: false, leader: None });
+            }
+            MultiRaftActorCommand::GetTopicDetail { reply, .. } => {
+                let _ = reply.send(TopicDetailQueryResult::TopicNotFound);
+            }
+            _ => {}
+        });
+        let resp = ClientHandler::new(swim, raft)
+            .dispatch(ClientRequest::ControlPlane(ControlPlaneRequest::DescribeTopic {
+                name: "t1".into(),
+            }))
+            .await;
+        assert!(
+            matches!(resp, ClientResponse::ControlPlane(ControlPlaneResponse::TopicNotFound)),
+            "expected TopicNotFound, got {resp:?}"
         );
     }
 

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -510,6 +510,8 @@ impl ClientHandler {
             AdminRequest::GetShardLeader { shard_group_id } => {
                 self.handle_get_shard_leader(shard_group_id).await
             }
+            #[cfg(test)]
+            AdminRequest::IsClusterReady => self.handle_is_cluster_ready().await,
         };
         res.unwrap_or_else(|e| {
             tracing::error!("client admin dispatch error: {e}");
@@ -673,6 +675,12 @@ impl ClientHandler {
             .await
             .map(|n| n.to_string());
         Ok(ClientResponse::Admin(AdminResponse::ShardLeader { leader }))
+    }
+
+    #[cfg(test)]
+    async fn handle_is_cluster_ready(&self) -> anyhow::Result<ClientResponse> {
+        let ready = self.raft_sender.is_cluster_ready().await;
+        Ok(ClientResponse::Admin(AdminResponse::ClusterReady(ready)))
     }
 }
 

--- a/src/connections/clients.rs
+++ b/src/connections/clients.rs
@@ -311,7 +311,7 @@ impl ClientHandler {
                     leader_addr: None,
                 }))
             }
-            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+            GroupStatus::NotHosted => self.shard_not_local_response(&shard_group).await,
         }
     }
 
@@ -363,7 +363,7 @@ impl ClientHandler {
                     leader_addr: None,
                 }))
             }
-            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+            GroupStatus::NotHosted => self.shard_not_local_response(&shard_group).await,
         }
     }
 
@@ -398,7 +398,7 @@ impl ClientHandler {
             GroupStatus::Hosted { .. } => {
                 self.read_describe_topic_with_group(name, shard_group.id.0).await
             }
-            GroupStatus::NotHosted => self.cp_not_local(&shard_group).await,
+            GroupStatus::NotHosted => self.shard_not_local_response(&shard_group).await,
         }
     }
 
@@ -454,7 +454,7 @@ impl ClientHandler {
     }
 
     /// Returns `ShardNotLocal` for the given shard group, using the first member as the hint.
-    async fn cp_not_local(&self, shard_group: &ShardGroup) -> anyhow::Result<ClientResponse> {
+    async fn shard_not_local_response(&self, shard_group: &ShardGroup) -> anyhow::Result<ClientResponse> {
         match self.pick_member_addr(shard_group).await {
             Ok(hint_node) => Ok(ClientResponse::ControlPlane(
                 ControlPlaneResponse::ShardNotLocal { hint_node },

--- a/src/connections/protocol.rs
+++ b/src/connections/protocol.rs
@@ -214,6 +214,8 @@ pub enum AdminRequest {
     GetShardLeader {
         shard_group_id: u64,
     },
+    #[cfg(test)]
+    IsClusterReady,
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -231,6 +233,8 @@ pub enum AdminResponse {
     ShardLeader { leader: Option<String> },
     // All admin operations
     InternalError(String),
+    #[cfg(test)]
+    ClusterReady(bool),
 }
 
 #[derive(Debug, Encode, Decode)]

--- a/src/connections/protocol.rs
+++ b/src/connections/protocol.rs
@@ -13,6 +13,8 @@ pub enum ClientRequest {
     ControlPlane(ControlPlaneRequest),
     DataPlane(DataPlaneRequest),
     Admin(AdminRequest),
+    #[cfg(test)]
+    Test(TestRequest),
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -20,6 +22,8 @@ pub enum ClientResponse {
     ControlPlane(ControlPlaneResponse),
     DataPlane(DataPlaneResponse),
     Admin(AdminResponse),
+    #[cfg(test)]
+    Test(TestResponse),
 }
 
 // ── Control Plane ──────────────────────────────────────────────────────────
@@ -214,8 +218,6 @@ pub enum AdminRequest {
     GetShardLeader {
         shard_group_id: u64,
     },
-    #[cfg(test)]
-    IsClusterReady,
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -233,8 +235,6 @@ pub enum AdminResponse {
     ShardLeader { leader: Option<String> },
     // All admin operations
     InternalError(String),
-    #[cfg(test)]
-    ClusterReady(bool),
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -264,4 +264,23 @@ pub struct TopicStats {
     pub name: String,
     pub range_count: u32,
     pub total_bytes: u64,
+}
+
+// ── Test protocol ──────────────────────────────────────────────────────────
+//
+// Test-only requests and responses sent as `ClientRequest::Test` /
+// `ClientResponse::Test`. Kept in a dedicated enum so production enums stay
+// free of `#[cfg(test)]` variants.
+
+#[cfg(test)]
+#[derive(Clone, Encode, Decode)]
+pub enum TestRequest {
+    /// Returns true when every shard group on this node has an elected Raft leader.
+    IsClusterReady,
+}
+
+#[cfg(test)]
+#[derive(Debug, Encode, Decode)]
+pub enum TestResponse {
+    ClusterReady(bool),
 }

--- a/src/connections/protocol.rs
+++ b/src/connections/protocol.rs
@@ -24,9 +24,8 @@ pub enum ClientResponse {
 
 // ── Control Plane ──────────────────────────────────────────────────────────
 //
-// The server resolves the correct destination internally and forwards the request
-// at most once. Clients never need to retry on a different node — on forwarding
-// failure a generic error is returned.
+// Routing is the client's responsibility. The server returns NotLeader or
+// ShardNotLocal when it cannot handle a request locally; the client retries.
 
 #[derive(Clone, Encode, Decode)]
 pub enum ControlPlaneRequest {
@@ -55,6 +54,13 @@ pub enum ControlPlaneResponse {
     TopicList { topics: Vec<TopicSummary> },
     // DescribeTopic
     TopicDetail(TopicDetail),
+    // Redirect errors — client reconnects and retries on the indicated node
+    /// This node is not the Raft leader (writes) or any shard group host (reads).
+    /// `leader_addr` is `None` when an election is in progress and no leader is yet known.
+    NotLeader { leader_addr: Option<SocketAddr> },
+    /// This node does not host the shard group for the requested topic.
+    /// `hint_node` is a live shard group member the client can retry on.
+    ShardNotLocal { hint_node: SocketAddr },
     // All control plane operations
     InternalError(String),
 }

--- a/src/control_plane/consensus/actor.rs
+++ b/src/control_plane/consensus/actor.rs
@@ -300,6 +300,20 @@ impl MutlRaftSender {
         recv.await.unwrap_or(TopicDetailQueryResult::GroupNotHosted)
     }
 
+    #[cfg(test)]
+    pub(crate) async fn is_cluster_ready(&self) -> bool {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        if self
+            .0
+            .send(MultiRaftActorCommand::IsReady { reply: send })
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        recv.await.unwrap_or(false)
+    }
+
     pub(crate) async fn send(
         &self,
         cmd: impl Into<MultiRaftActorCommand>,

--- a/src/control_plane/consensus/actor.rs
+++ b/src/control_plane/consensus/actor.rs
@@ -263,6 +263,43 @@ impl MutlRaftSender {
         recv.await.unwrap_or_default()
     }
 
+    pub(crate) async fn get_group_status(
+        &self,
+        shard_group_id: ShardGroupId,
+    ) -> GroupStatus {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        if self
+            .0
+            .send(MultiRaftActorCommand::GetGroupStatus { shard_group_id, reply: send })
+            .await
+            .is_err()
+        {
+            return GroupStatus::NotHosted;
+        }
+        recv.await.unwrap_or(GroupStatus::NotHosted)
+    }
+
+    pub(crate) async fn get_topic_detail(
+        &self,
+        shard_group_id: ShardGroupId,
+        topic_name: String,
+    ) -> TopicDetailQueryResult {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        if self
+            .0
+            .send(MultiRaftActorCommand::GetTopicDetail {
+                shard_group_id,
+                topic_name,
+                reply: send,
+            })
+            .await
+            .is_err()
+        {
+            return TopicDetailQueryResult::GroupNotHosted;
+        }
+        recv.await.unwrap_or(TopicDetailQueryResult::GroupNotHosted)
+    }
+
     pub(crate) async fn send(
         &self,
         cmd: impl Into<MultiRaftActorCommand>,

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -77,7 +77,6 @@ impl_from_variant_via!(
 /// Pairs a reply channel with its computed value so the actor can send all replies
 /// after draining outbound packets and timer commands — the flush protocol requires
 /// side effects to leave the state machine before any caller is unblocked.
-
 pub(crate) enum DeferredReply {
     GetLeader(oneshot::Sender<Option<NodeId>>, Option<NodeId>),
     Propose(

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -50,6 +50,12 @@ pub enum MultiRaftActorCommand {
         topic_name: String,
         reply: oneshot::Sender<TopicDetailQueryResult>,
     },
+    /// Returns true when every shard group on this node has a known Raft leader.
+    /// Used by test helpers to detect cluster readiness without a write probe.
+    #[cfg(test)]
+    IsReady {
+        reply: oneshot::Sender<bool>,
+    },
 }
 
 impl From<ConsensusCommand> for MultiRaftActorCommand {
@@ -87,4 +93,6 @@ pub(crate) enum DeferredReply {
     GetTopicStats(oneshot::Sender<Vec<TopicStats>>, Vec<TopicStats>),
     GetGroupStatus(oneshot::Sender<GroupStatus>, GroupStatus),
     GetTopicDetail(oneshot::Sender<TopicDetailQueryResult>, TopicDetailQueryResult),
+    #[cfg(test)]
+    IsReady(oneshot::Sender<bool>, bool),
 }

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -5,13 +5,16 @@ use crate::control_plane::membership::{NodeDead, ShardGroupId};
 use crate::control_plane::metadata::types::TopicStats;
 
 use super::command::{
-    ConsensusCommand, CoordinatorSealRequest, EnsureGroup, HandleNodeJoin, PacketReceived,
-    ProposeError, RaftPropose, RemoveGroup,
+    ConsensusCommand, CoordinatorSealRequest, EnsureGroup, GroupStatus, HandleNodeJoin,
+    PacketReceived, ProposeError, RaftPropose, RemoveGroup, TopicDetailQueryResult,
 };
 use super::timer::RaftTimeoutCallback;
 use crate::impl_from_variant_via;
 
 /// Commands received by the MultiRaftActor from external sources (tokio-dependent).
+///
+/// Split from [`MultiRaftCommand`] because query variants carry `oneshot::Sender` reply
+/// channels — tokio types that cannot live inside the pure sync state machine.
 #[allow(dead_code)]
 pub enum MultiRaftActorCommand {
     /// Fire-and-forget: no reply channel needed.
@@ -34,6 +37,19 @@ pub enum MultiRaftActorCommand {
     },
     /// Data plane SealRequest forwarded to coordinator for Raft proposal.
     Coordinator(CoordinatorSealRequest),
+    /// Used by `ClientHandler` to decide whether to handle a write locally
+    /// (this node is leader) or return `NotLeader` so the client can redirect.
+    GetGroupStatus {
+        shard_group_id: ShardGroupId,
+        reply: oneshot::Sender<GroupStatus>,
+    },
+    /// Serves two callers: `DescribeTopic` reads (any replica) and the
+    /// `AlreadyExists` pre-check before proposing `CreateTopic`.
+    GetTopicDetail {
+        shard_group_id: ShardGroupId,
+        topic_name: String,
+        reply: oneshot::Sender<TopicDetailQueryResult>,
+    },
 }
 
 impl From<ConsensusCommand> for MultiRaftActorCommand {
@@ -58,6 +74,10 @@ impl_from_variant_via!(
     HandleNodeJoin,
 );
 
+/// Pairs a reply channel with its computed value so the actor can send all replies
+/// after draining outbound packets and timer commands — the flush protocol requires
+/// side effects to leave the state machine before any caller is unblocked.
+
 pub(crate) enum DeferredReply {
     GetLeader(oneshot::Sender<Option<NodeId>>, Option<NodeId>),
     Propose(
@@ -66,4 +86,6 @@ pub(crate) enum DeferredReply {
     ),
     GetTopics(oneshot::Sender<Vec<String>>, Vec<String>),
     GetTopicStats(oneshot::Sender<Vec<TopicStats>>, Vec<TopicStats>),
+    GetGroupStatus(oneshot::Sender<GroupStatus>, GroupStatus),
+    GetTopicDetail(oneshot::Sender<TopicDetailQueryResult>, TopicDetailQueryResult),
 }

--- a/src/control_plane/consensus/messages/command.rs
+++ b/src/control_plane/consensus/messages/command.rs
@@ -5,6 +5,7 @@ use crate::control_plane::consensus::messages::rpc::{OutboundRaftPacket, RaftRpc
 use crate::control_plane::consensus::messages::timer::RaftTimeoutCallback;
 use crate::control_plane::membership::{NodeDead, ShardGroup, ShardGroupId};
 use crate::control_plane::metadata::command::MetadataCommand;
+use crate::control_plane::metadata::types::TopicDetailData;
 use crate::data_plane::messages::command::SealRequest;
 use crate::impl_from_variant;
 
@@ -64,6 +65,19 @@ impl_from_variant!(
 pub enum RaftTransportCommand {
     Send(Vec<OutboundRaftPacket>),
     DisconnectPeer(NodeId),
+}
+
+#[allow(dead_code)]
+pub enum GroupStatus {
+    NotHosted,
+    Hosted { is_leader: bool, leader: Option<NodeId> },
+}
+
+#[allow(dead_code)]
+pub enum TopicDetailQueryResult {
+    GroupNotHosted,
+    TopicNotFound,
+    Found(TopicDetailData),
 }
 
 #[allow(dead_code)]

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -677,6 +677,7 @@ impl MultiRaft {
         for (id, last_log_index) in last_indices {
             if let Some(raft) = self.groups.get_mut(&id) {
                 raft.advance_stabled_index(last_log_index);
+                raft.apply_after_flush();
             }
         }
     }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -5,15 +5,15 @@ use tokio::sync::oneshot;
 
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::{
-    ConsensusCommand, CoordinatorSealRequest, DeferredReply, LogMutation, MetadataCommitted,
-    MultiRaftActorCommand, PacketReceived, ProposeError, RaftEvent, RaftPropose,
-    RaftTimeoutCallback, SealContext,
+    ConsensusCommand, CoordinatorSealRequest, DeferredReply, GroupStatus, LogMutation,
+    MetadataCommitted, MultiRaftActorCommand, PacketReceived, ProposeError, RaftEvent, RaftPropose,
+    RaftTimeoutCallback, SealContext, TopicDetailQueryResult,
 };
 use crate::control_plane::consensus::raft::command::RaftCommand;
 use crate::control_plane::consensus::raft::state::{Raft, TimerSeqs};
 use crate::control_plane::metadata::TopicId;
 use crate::control_plane::metadata::command::RollSegment;
-use crate::control_plane::metadata::types::TopicStats;
+use crate::control_plane::metadata::types::{RangeDetailData, TopicDetailData, TopicStats};
 
 use crate::control_plane::consensus::raft::storage::RaftStorage;
 use crate::control_plane::membership::{ShardGroup, ShardGroupId};
@@ -189,6 +189,14 @@ impl MultiRaft {
             MultiRaftActorCommand::Coordinator(req) => {
                 self.handle_seal_request(req);
             }
+            MultiRaftActorCommand::GetGroupStatus { shard_group_id, reply } => {
+                let status = self.get_group_status(shard_group_id);
+                self.deferred.push(DeferredReply::GetGroupStatus(reply, status));
+            }
+            MultiRaftActorCommand::GetTopicDetail { shard_group_id, topic_name, reply } => {
+                let result = self.get_topic_detail(shard_group_id, &topic_name);
+                self.deferred.push(DeferredReply::GetTopicDetail(reply, result));
+            }
         }
     }
 
@@ -205,6 +213,12 @@ impl MultiRaft {
                     let _ = sender.send(v);
                 }
                 DeferredReply::GetTopicStats(sender, v) => {
+                    let _ = sender.send(v);
+                }
+                DeferredReply::GetGroupStatus(sender, v) => {
+                    let _ = sender.send(v);
+                }
+                DeferredReply::GetTopicDetail(sender, v) => {
                     let _ = sender.send(v);
                 }
             }
@@ -340,6 +354,50 @@ impl MultiRaft {
             .values()
             .flat_map(|raft| raft.topic_stats())
             .collect()
+    }
+
+    fn get_group_status(&self, group_id: ShardGroupId) -> GroupStatus {
+        match self.groups.get(&group_id) {
+            None => GroupStatus::NotHosted,
+            Some(raft) => {
+                let leader = raft.current_leader().cloned();
+                let is_leader = leader.as_ref() == Some(&self.node_id);
+                GroupStatus::Hosted { is_leader, leader }
+            }
+        }
+    }
+
+    fn get_topic_detail(&self, group_id: ShardGroupId, topic_name: &str) -> TopicDetailQueryResult {
+        let Some(raft) = self.groups.get(&group_id) else {
+            return TopicDetailQueryResult::GroupNotHosted;
+        };
+        let Some(topic) = raft.get_topic_by_name(topic_name) else {
+            return TopicDetailQueryResult::TopicNotFound;
+        };
+        let ranges = topic
+            .ranges
+            .values()
+            .map(|r| {
+                let replica_set = r
+                    .active_segment
+                    .and_then(|seg_id| r.segments.get(&seg_id))
+                    .map(|s| s.replica_set.clone())
+                    .unwrap_or_default();
+                RangeDetailData {
+                    range_id: r.range_id.0,
+                    keyspace_start: r.keyspace_start.clone(),
+                    keyspace_end: r.keyspace_end.clone(),
+                    active_segment_id: r.active_segment.map(|s| s.0),
+                    state: r.state,
+                    replica_set,
+                }
+            })
+            .collect();
+        TopicDetailQueryResult::Found(TopicDetailData {
+            name: topic.name.clone(),
+            topic_id: topic.id.0,
+            ranges,
+        })
     }
 
     // Full scan over groups is acceptable — node death is rare (~6-7s SWIM detection)

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -197,6 +197,11 @@ impl MultiRaft {
                 let result = self.get_topic_detail(shard_group_id, &topic_name);
                 self.deferred.push(DeferredReply::GetTopicDetail(reply, result));
             }
+            #[cfg(test)]
+            MultiRaftActorCommand::IsReady { reply } => {
+                let ready = self.all_leaders_known();
+                self.deferred.push(DeferredReply::IsReady(reply, ready));
+            }
         }
     }
 
@@ -219,6 +224,10 @@ impl MultiRaft {
                     let _ = sender.send(v);
                 }
                 DeferredReply::GetTopicDetail(sender, v) => {
+                    let _ = sender.send(v);
+                }
+                #[cfg(test)]
+                DeferredReply::IsReady(sender, v) => {
                     let _ = sender.send(v);
                 }
             }
@@ -354,6 +363,12 @@ impl MultiRaft {
             .values()
             .flat_map(|raft| raft.topic_stats())
             .collect()
+    }
+
+    #[cfg(test)]
+    fn all_leaders_known(&self) -> bool {
+        !self.groups.is_empty()
+            && self.groups.values().all(|r| r.current_leader().is_some())
     }
 
     fn get_group_status(&self, group_id: ShardGroupId) -> GroupStatus {

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -684,6 +684,12 @@ impl Raft {
         self.stabled_index = self.stabled_index.max(value);
     }
 
+    /// Apply any committed entries that became durable after the last stabled_index advance.
+    /// Called by MultiRaft after persist_and_advance() so the actor controls when apply happens.
+    pub(crate) fn apply_after_flush(&mut self) {
+        self.apply_committed_entries();
+    }
+
     fn apply_committed_entries(&mut self) {
         while self.last_applied_index < self.commit_index.min(self.stabled_index) {
             self.last_applied_index += 1;

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -161,6 +161,13 @@ impl Raft {
         Some(seg.replica_set.clone())
     }
 
+    pub(crate) fn get_topic_by_name(
+        &self,
+        name: &str,
+    ) -> Option<&crate::control_plane::metadata::types::TopicMeta> {
+        self.state_machine.get_topic_by_name(name)
+    }
+
     #[cfg(test)]
     pub(crate) fn state_machine(&self) -> &MetadataStateMachine {
         &self.state_machine

--- a/src/control_plane/metadata/types.rs
+++ b/src/control_plane/metadata/types.rs
@@ -884,3 +884,18 @@ pub struct TopicStats {
     pub range_count: u32,
     pub total_bytes: u64,
 }
+
+pub struct TopicDetailData {
+    pub name: String,
+    pub topic_id: u64,
+    pub ranges: Vec<RangeDetailData>,
+}
+
+pub struct RangeDetailData {
+    pub range_id: u64,
+    pub keyspace_start: Vec<u8>,
+    pub keyspace_end: Vec<u8>,
+    pub active_segment_id: Option<u64>,
+    pub state: RangeState,
+    pub replica_set: Vec<NodeId>,
+}

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -7,8 +7,9 @@ use crate::connections::protocol::{
     AdminRequest, AdminResponse, ClientRequest, ClientResponse, ControlPlaneRequest,
     ControlPlaneResponse,
 };
+use crate::connections::protocol::ControlPlaneResponse::NotLeader;
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
-use crate::it::helpers::{default_env, send_request};
+use crate::it::helpers::{default_env, send_request, send_request_to_addr};
 
 /// CreateTopic eventually succeeds when tried across all nodes (exactly one is the leader),
 /// and DescribeCluster returns a non-empty node list from every node.
@@ -46,7 +47,6 @@ fn create_topic_and_describe_cluster() -> turmoil::Result {
     }
 
     sim.client("test-client", async {
-        // Wait for leader election then create a topic by trying all nodes.
         let req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
             name: "test-topic".to_string(),
             storage_policy: StoragePolicy {
@@ -55,34 +55,35 @@ fn create_topic_and_describe_cluster() -> turmoil::Result {
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
         });
-        let mut created = false;
-        'outer: for _ in 0..20 {
-            tokio::time::sleep(Duration::from_secs(2)).await;
+        // Allow time for SWIM convergence then retry across all nodes until a leader
+        // responds — different shard groups finish elections at different times.
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let mut create_ok = false;
+        'create: for _ in 0..20u32 {
             for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                match send_request(host, port, req.clone()).await {
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated) => {
-                        created = true;
-                        break 'outer;
-                    }
-                    ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists) => {
-                        created = true;
-                        break 'outer;
-                    }
-                    _ => {}
+                let r = send_request(host, port, req.clone()).await;
+                if matches!(
+                    r,
+                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
+                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+                ) {
+                    create_ok = true;
+                    break 'create;
                 }
             }
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        assert!(created, "CreateTopic not acked by any node within 40s");
+        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
 
         // DescribeCluster must return a non-empty node list from every node.
         for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-            let resp = send_request(
+            let cluster_resp = send_request(
                 host,
                 port,
                 ClientRequest::Admin(AdminRequest::DescribeCluster),
             )
             .await;
-            match resp {
+            match cluster_resp {
                 ClientResponse::Admin(AdminResponse::ClusterInfo { nodes }) => {
                     assert!(!nodes.is_empty(), "{host} returned empty node list");
                 }
@@ -139,26 +140,30 @@ fn delete_topic() -> turmoil::Result {
             },
         });
 
-        let mut acked: Option<(&str, u16)> = None;
-        'outer: for _ in 0..20 {
-            tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let mut create_ok = false;
+        'create: for _ in 0..20u32 {
             for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                match send_request(host, port, create_req.clone()).await {
+                let r = send_request(host, port, create_req.clone()).await;
+                if matches!(
+                    r,
                     ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                    | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists) => {
-                        acked = Some((host, port));
-                        break 'outer;
-                    }
-                    _ => {}
+                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+                ) {
+                    create_ok = true;
+                    break 'create;
                 }
             }
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        let (host, port) = acked.expect("CreateTopic not acked by any node within 40s");
+        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
+        // Wait for Raft replication to reach all nodes (one heartbeat period = 1s).
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
-        // Verify visible on the acked node before deleting.
+        // Verify visible on at least one node before deleting.
         let list_resp = send_request(
-            host,
-            port,
+            "node-1",
+            8081,
             ClientRequest::ControlPlane(ControlPlaneRequest::ListHostedTopics),
         )
         .await;
@@ -171,22 +176,23 @@ fn delete_topic() -> turmoil::Result {
             "del-test not listed before delete"
         );
 
-        // Delete the topic (same node is the leader for the shard group).
-        let del_resp = send_request(
-            host,
-            port,
-            ClientRequest::ControlPlane(ControlPlaneRequest::DeleteTopic {
-                name: "del-test".into(),
-            }),
-        )
-        .await;
-        assert!(
-            matches!(
-                del_resp,
-                ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted)
-            ),
-            "expected TopicDeleted, got {del_resp:?}"
-        );
+        // Delete: try each node until the leader responds — no server-side forwarding.
+        let mut delete_ok = false;
+        for (h, p) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
+            let r = send_request(
+                h,
+                p,
+                ClientRequest::ControlPlane(ControlPlaneRequest::DeleteTopic {
+                    name: "del-test".into(),
+                }),
+            )
+            .await;
+            if matches!(r, ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted)) {
+                delete_ok = true;
+                break;
+            }
+        }
+        assert!(delete_ok, "DeleteTopic did not succeed on any node");
 
         // Wait up to 5s for deletion to propagate and disappear from all nodes.
         for _ in 0..10 {
@@ -277,21 +283,23 @@ fn list_topic_stats_after_create() -> turmoil::Result {
             },
         });
 
-        let mut created = false;
-        'outer: for _ in 0..20 {
-            tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let mut create_ok = false;
+        'create: for _ in 0..20u32 {
             for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                match send_request(host, port, create_req.clone()).await {
+                let r = send_request(host, port, create_req.clone()).await;
+                if matches!(
+                    r,
                     ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                    | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists) => {
-                        created = true;
-                        break 'outer;
-                    }
-                    _ => {}
+                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+                ) {
+                    create_ok = true;
+                    break 'create;
                 }
             }
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        assert!(created, "CreateTopic not acked by any node within 40s");
+        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
 
         // At least one node must report stats for "stats-test".
         let mut found = false;
@@ -312,6 +320,194 @@ fn list_topic_stats_after_create() -> turmoil::Result {
             found,
             "stats-test not found in ListHostedTopicsWithStats on any node"
         );
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Verifies that `DeleteTopic` sent to a non-leader node returns `NotLeader { leader_addr: Some(_) }`
+/// and that following the redirect to `leader_addr` succeeds with `TopicDeleted`.
+#[test]
+#[serial_test::serial]
+fn delete_topic_redirects_to_leader() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(60))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    for (name, idx, cp, rp) in [
+        ("node-1", 1u32, 8081u16, 18001u16),
+        ("node-2", 2, 8082, 18002),
+        ("node-3", 3, 8083, 18003),
+    ] {
+        sim.host(name, move || async move {
+            let me = turmoil::lookup(name);
+            let seeds: Vec<String> = [("node-1", 18001u16), ("node-2", 18002), ("node-3", 18003)]
+                .iter()
+                .filter(|(n, _)| *n != name)
+                .map(|(n, p)| format!("{}:{}", turmoil::lookup(*n), p))
+                .collect();
+            let mut env = default_env(idx, name.to_string(), cp, rp);
+            env.advertise_host = Some(me.to_string());
+            env.join_seed_nodes = seeds;
+            StartUp::with_env(env, 0).run().await?;
+            Ok(())
+        });
+    }
+
+    sim.client("test-client", async {
+        let topic = "del-redirect";
+        let create_req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
+            name: topic.to_string(),
+            storage_policy: StoragePolicy {
+                retention_ms: 3_600_000,
+                replication_factor: 3,
+                partition_strategy: PartitionStrategy::AutoSplit,
+            },
+        });
+
+        // Wait for SWIM convergence + Raft election, then create via retry loop.
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let mut leader_port: Option<u16> = None;
+        'create: for _ in 0..20u32 {
+            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
+                let r = send_request(host, port, create_req.clone()).await;
+                if matches!(
+                    r,
+                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
+                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+                ) {
+                    leader_port = Some(port);
+                    break 'create;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        let leader_port = leader_port.expect("CreateTopic did not succeed on any node within 24s");
+
+        // Wait for replication.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Pick any non-leader node.
+        let non_leader = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)]
+            .into_iter()
+            .find(|(_, p)| *p != leader_port)
+            .expect("no non-leader node found");
+
+        let del_req =
+            ClientRequest::ControlPlane(ControlPlaneRequest::DeleteTopic { name: topic.into() });
+
+        // Non-leader must redirect.
+        let redirect_resp = send_request(non_leader.0, non_leader.1, del_req.clone()).await;
+        let ClientResponse::ControlPlane(NotLeader { leader_addr: Some(leader_addr) }) =
+            redirect_resp
+        else {
+            panic!("expected NotLeader{{Some}}, got {redirect_resp:?}");
+        };
+
+        // Following the redirect must succeed.
+        let del_resp = send_request_to_addr(leader_addr, del_req).await;
+        assert!(
+            matches!(del_resp, ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted)),
+            "expected TopicDeleted after redirect, got {del_resp:?}"
+        );
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Verifies that `DescribeTopic` is served by every replica — followers included —
+/// with no redirect required.
+#[test]
+#[serial_test::serial]
+fn describe_topic_served_by_all_replicas() -> turmoil::Result {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(100))
+        .simulation_duration(Duration::from_secs(60))
+        .tcp_capacity(4096)
+        .build();
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    for (name, idx, cp, rp) in [
+        ("node-1", 1u32, 8081u16, 18001u16),
+        ("node-2", 2, 8082, 18002),
+        ("node-3", 3, 8083, 18003),
+    ] {
+        sim.host(name, move || async move {
+            let me = turmoil::lookup(name);
+            let seeds: Vec<String> = [("node-1", 18001u16), ("node-2", 18002), ("node-3", 18003)]
+                .iter()
+                .filter(|(n, _)| *n != name)
+                .map(|(n, p)| format!("{}:{}", turmoil::lookup(*n), p))
+                .collect();
+            let mut env = default_env(idx, name.to_string(), cp, rp);
+            env.advertise_host = Some(me.to_string());
+            env.join_seed_nodes = seeds;
+            StartUp::with_env(env, 0).run().await?;
+            Ok(())
+        });
+    }
+
+    sim.client("test-client", async {
+        let topic = "describe-replicas";
+        let create_req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
+            name: topic.to_string(),
+            storage_policy: StoragePolicy {
+                retention_ms: 3_600_000,
+                replication_factor: 3,
+                partition_strategy: PartitionStrategy::AutoSplit,
+            },
+        });
+
+        // Wait for SWIM convergence + Raft election, then create.
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        let mut create_ok = false;
+        'create: for _ in 0..20u32 {
+            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
+                let r = send_request(host, port, create_req.clone()).await;
+                if matches!(
+                    r,
+                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
+                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+                ) {
+                    create_ok = true;
+                    break 'create;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        assert!(create_ok, "CreateTopic did not succeed within 24s");
+
+        // Wait for the committed entry to replicate to all followers.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let describe_req = ClientRequest::ControlPlane(ControlPlaneRequest::DescribeTopic {
+            name: topic.to_string(),
+        });
+
+        // Every node must serve the read — followers included.
+        for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
+            let resp = send_request(host, port, describe_req.clone()).await;
+            match resp {
+                ClientResponse::ControlPlane(ControlPlaneResponse::TopicDetail(detail)) => {
+                    assert_eq!(detail.name, topic, "{host}: wrong topic name in TopicDetail");
+                    assert!(!detail.ranges.is_empty(), "{host}: TopicDetail has no ranges");
+                }
+                other => panic!("{host}: expected TopicDetail, got {other:?}"),
+            }
+        }
 
         Ok(())
     });

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -9,7 +9,9 @@ use crate::connections::protocol::{
 };
 use crate::connections::protocol::ControlPlaneResponse::NotLeader;
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
-use crate::it::helpers::{default_env, send_request, send_request_to_addr};
+use crate::it::helpers::{
+    default_env, send_request, send_request_to_addr, wait_leader_ready, wait_swim_ready,
+};
 
 /// CreateTopic eventually succeeds when tried across all nodes (exactly one is the leader),
 /// and DescribeCluster returns a non-empty node list from every node.
@@ -55,25 +57,17 @@ fn create_topic_and_describe_cluster() -> turmoil::Result {
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
         });
-        // Allow time for SWIM convergence then retry across all nodes until a leader
-        // responds — different shard groups finish elections at different times.
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        let mut create_ok = false;
-        'create: for _ in 0..20u32 {
-            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                let r = send_request(host, port, req.clone()).await;
-                if matches!(
-                    r,
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
-                ) {
-                    create_ok = true;
-                    break 'create;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+        wait_swim_ready(&nodes, 3).await;
+        let (_, resp) = wait_leader_ready(&nodes, req).await;
+        assert!(
+            matches!(
+                resp,
+                ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
+                    | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
+            ),
+            "unexpected CreateTopic response: {resp:?}"
+        );
 
         // DescribeCluster must return a non-empty node list from every node.
         for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
@@ -84,8 +78,8 @@ fn create_topic_and_describe_cluster() -> turmoil::Result {
             )
             .await;
             match cluster_resp {
-                ClientResponse::Admin(AdminResponse::ClusterInfo { nodes }) => {
-                    assert!(!nodes.is_empty(), "{host} returned empty node list");
+                ClientResponse::Admin(AdminResponse::ClusterInfo { nodes: cluster_nodes }) => {
+                    assert!(!cluster_nodes.is_empty(), "{host} returned empty node list");
                 }
                 other => panic!("{host}: unexpected DescribeCluster response: {other:?}"),
             }
@@ -139,24 +133,9 @@ fn delete_topic() -> turmoil::Result {
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
         });
-
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        let mut create_ok = false;
-        'create: for _ in 0..20u32 {
-            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                let r = send_request(host, port, create_req.clone()).await;
-                if matches!(
-                    r,
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
-                ) {
-                    create_ok = true;
-                    break 'create;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+        wait_swim_ready(&nodes, 3).await;
+        wait_leader_ready(&nodes, create_req).await;
         // Wait for Raft replication to reach all nodes (one heartbeat period = 1s).
         tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -283,23 +262,9 @@ fn list_topic_stats_after_create() -> turmoil::Result {
             },
         });
 
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        let mut create_ok = false;
-        'create: for _ in 0..20u32 {
-            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                let r = send_request(host, port, create_req.clone()).await;
-                if matches!(
-                    r,
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
-                ) {
-                    create_ok = true;
-                    break 'create;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        assert!(create_ok, "CreateTopic did not succeed on any node within 24s");
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+        wait_swim_ready(&nodes, 3).await;
+        wait_leader_ready(&nodes, create_req).await;
 
         // At least one node must report stats for "stats-test".
         let mut found = false;
@@ -373,24 +338,9 @@ fn delete_topic_redirects_to_leader() -> turmoil::Result {
             },
         });
 
-        // Wait for SWIM convergence + Raft election, then create via retry loop.
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        let mut leader_port: Option<u16> = None;
-        'create: for _ in 0..20u32 {
-            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                let r = send_request(host, port, create_req.clone()).await;
-                if matches!(
-                    r,
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
-                ) {
-                    leader_port = Some(port);
-                    break 'create;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        let leader_port = leader_port.expect("CreateTopic did not succeed on any node within 24s");
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+        wait_swim_ready(&nodes, 3).await;
+        let (leader_port, _) = wait_leader_ready(&nodes, create_req.clone()).await;
 
         // Wait for replication.
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -471,24 +421,9 @@ fn describe_topic_served_by_all_replicas() -> turmoil::Result {
             },
         });
 
-        // Wait for SWIM convergence + Raft election, then create.
-        tokio::time::sleep(Duration::from_secs(4)).await;
-        let mut create_ok = false;
-        'create: for _ in 0..20u32 {
-            for (host, port) in [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)] {
-                let r = send_request(host, port, create_req.clone()).await;
-                if matches!(
-                    r,
-                    ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated)
-                        | ClientResponse::ControlPlane(ControlPlaneResponse::AlreadyExists)
-                ) {
-                    create_ok = true;
-                    break 'create;
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-        assert!(create_ok, "CreateTopic did not succeed within 24s");
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+        wait_swim_ready(&nodes, 3).await;
+        wait_leader_ready(&nodes, create_req).await;
 
         // Wait for the committed entry to replicate to all followers.
         tokio::time::sleep(Duration::from_secs(2)).await;

--- a/src/it/e2e/lifecycle.rs
+++ b/src/it/e2e/lifecycle.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use turmoil::Builder;
 
 use crate::StartUp;
-use crate::it::helpers::{check_alive_count, check_dead_or_not_exist, default_env};
+use crate::it::helpers::{check_dead_or_not_exist, default_env, wait_swim_ready};
 
 /// Full-stack E2E: SWIM cluster formation with MultiRaftActor wired in.
 ///
@@ -59,11 +59,10 @@ fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
     });
 
     sim.client("checker", async {
+        let nodes = [("node-1", 8081u16), ("node-2", 8082), ("node-3", 8083)];
+
         tracing::info!("[E2E] Phase 1: waiting for cluster formation");
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        check_alive_count("node-1", 8081, 3).await?;
-        check_alive_count("node-2", 8082, 3).await?;
-        check_alive_count("node-3", 8083, 3).await?;
+        wait_swim_ready(&nodes, 3).await;
         tracing::info!("[E2E] Phase 1 OK: all 3 nodes alive");
 
         tracing::info!("[E2E] Phase 2: waiting for node-3 death detection");
@@ -79,10 +78,7 @@ fn e2e_swim_raft_cluster_lifecycle() -> turmoil::Result {
         tracing::info!("[E2E] Phase 2 OK: node-3 confirmed dead");
 
         tracing::info!("[E2E] Phase 3: waiting for node-3 to rejoin");
-        tokio::time::sleep(Duration::from_secs(50)).await;
-        check_alive_count("node-1", 8081, 3).await?;
-        check_alive_count("node-2", 8082, 3).await?;
-        check_alive_count("node-3", 8083, 3).await?;
+        wait_swim_ready(&nodes, 3).await;
         tracing::info!("[E2E] Phase 3 OK: node-3 rejoined, all 3 alive");
 
         Ok(())

--- a/src/it/helpers.rs
+++ b/src/it/helpers.rs
@@ -1,7 +1,10 @@
+use std::time::Duration;
+
 use crate::config::Environment;
 use crate::connections::clients::{ClientRawWriter, ClientStreamReader};
 use crate::connections::protocol::{
-    AdminRequest, AdminResponse, ClientRequest, ClientResponse, NodeState,
+    AdminRequest, AdminResponse, ClientRequest, ClientResponse, ControlPlaneResponse, NodeState,
+    TestRequest, TestResponse,
 };
 use crate::control_plane::SwimNode;
 use crate::control_plane::SwimNodeState;
@@ -125,13 +128,9 @@ pub async fn check_dead_or_not_exist(host: &str, port: u16, target: &str) -> boo
 
 /// Sends a `ClientRequest` to a node and returns the raw `ClientResponse`.
 pub async fn send_request(host: &str, port: u16, req: ClientRequest) -> ClientResponse {
-    let stream = TcpStream::connect((host, port)).await.unwrap();
-    let (read_half, write_half) = stream.into_split();
-    let mut writer = ClientRawWriter::new(write_half);
-    let mut reader = ClientStreamReader::new(read_half);
-    writer.write(0, &req).await.unwrap();
-    let (_, response) = reader.read_request().await.unwrap();
-    response
+    try_send_request(host, port, req)
+        .await
+        .expect("send_request: failed to connect or read response")
 }
 
 /// Sends a `ClientRequest` directly to a `SocketAddr` (e.g. a `leader_addr` from `NotLeader`).
@@ -146,4 +145,103 @@ pub async fn send_request_to_addr(
     writer.write(0, &req).await.unwrap();
     let (_, response) = reader.read_request().await.unwrap();
     response
+}
+
+/// polls until every node in `nodes` reports at least `expected_alive` SWIM-alive members. Panics after 30s.
+pub async fn wait_swim_ready(nodes: &[(&str, u16)], expected_alive: usize) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "SWIM did not converge to {expected_alive} alive nodes within 30s"
+        );
+        let mut all_ready = true;
+        for &(host, port) in nodes {
+            match get_members(host, port).await {
+                Ok(members) => {
+                    let alive = members
+                        .iter()
+                        .filter(|m| m.state == SwimNodeState::Alive)
+                        .count();
+                    if alive < expected_alive {
+                        all_ready = false;
+                        break;
+                    }
+                }
+                Err(_) => {
+                    all_ready = false;
+                    break;
+                }
+            }
+        }
+        if all_ready {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Step 2a of cluster initialization: polls until every shard group on every node has an
+/// elected Raft leader. Uses the `#[cfg(test)] IsClusterReady` admin command — no write
+/// side effects. Panics after 15s.
+pub async fn wait_raft_ready(nodes: &[(&str, u16)]) {
+    let probe = ClientRequest::Test(TestRequest::IsClusterReady);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Raft leader not elected within 15s after SWIM convergence"
+        );
+        let mut all_ready = true;
+        for &(host, port) in nodes {
+            match try_send_request(host, port, probe.clone()).await {
+                Some(ClientResponse::Test(TestResponse::ClusterReady(true))) => {}
+                _ => {
+                    all_ready = false;
+                    break;
+                }
+            }
+        }
+        if all_ready {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Step 2b of cluster initialization: calls `wait_raft_ready`, then sends `req` to whichever
+/// node is the leader (following any `NotLeader { leader_addr: Some }` redirect).
+///
+/// Returns `(leader_port, response)` where `leader_port` is the client port of the node that
+/// handled the request — useful for tests that need to identify and avoid the leader.
+pub async fn wait_leader_ready(nodes: &[(&str, u16)], req: ClientRequest) -> (u16, ClientResponse) {
+    wait_raft_ready(nodes).await;
+    for &(host, port) in nodes {
+        let Some(resp) = try_send_request(host, port, req.clone()).await else {
+            continue;
+        };
+        match resp {
+            ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                leader_addr: None,
+            }) => continue,
+            ClientResponse::ControlPlane(ControlPlaneResponse::NotLeader {
+                leader_addr: Some(addr),
+            }) => {
+                let leader_resp = send_request_to_addr(addr, req).await;
+                return (addr.port(), leader_resp);
+            }
+            other => return (port, other),
+        }
+    }
+    panic!("no leader found after IsClusterReady returned true — this is a bug");
+}
+
+async fn try_send_request(host: &str, port: u16, req: ClientRequest) -> Option<ClientResponse> {
+    let stream = TcpStream::connect((host, port)).await.ok()?;
+    let (read_half, write_half) = stream.into_split();
+    let mut writer = ClientRawWriter::new(write_half);
+    let mut reader = ClientStreamReader::new(read_half);
+    writer.write(0, &req).await.ok()?;
+    let (_, response) = reader.read_request().await.ok()?;
+    Some(response)
 }

--- a/src/it/helpers.rs
+++ b/src/it/helpers.rs
@@ -133,3 +133,17 @@ pub async fn send_request(host: &str, port: u16, req: ClientRequest) -> ClientRe
     let (_, response) = reader.read_request().await.unwrap();
     response
 }
+
+/// Sends a `ClientRequest` directly to a `SocketAddr` (e.g. a `leader_addr` from `NotLeader`).
+pub async fn send_request_to_addr(
+    addr: std::net::SocketAddr,
+    req: ClientRequest,
+) -> ClientResponse {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (read_half, write_half) = stream.into_split();
+    let mut writer = ClientRawWriter::new(write_half);
+    let mut reader = ClientStreamReader::new(read_half);
+    writer.write(0, &req).await.unwrap();
+    let (_, response) = reader.read_request().await.unwrap();
+    response
+}


### PR DESCRIPTION
## Summary

- **Removes `ControlPlaneRouter` and `InternalForward`** — the server no longer silently resolves the Raft leader and proxies control-plane requests. Routing is now the client's responsibility, symmetric with how the data plane already worked.
- **Adds `NotLeader` and `ShardNotLocal` to `ControlPlaneResponse`** — the server returns a redirect error and the client reconnects and retries, identical to the data-plane contract.
- **Removes asymmetric complexity in `ClientHandler`** — the four routing scenarios (is_leader, hosted follower with known leader, hosted follower in election, not hosted) are now a single explicit match rather than opaque server-side forwarding.
- **New integration tests** verify the end-to-end redirect flow and that reads are served by all replicas, not just the leader.

## Commits

1. `add GroupStatus and TopicDetailQueryResult query types to MultiRaft` — foundation query types so ClientHandler can ask the local MultiRaftActor about hosting status without a routing layer.
2. `protocol: remove InternalForward, add NotLeader and ShardNotLocal` — wire protocol changes.
3. `remove ControlPlaneRouter; handlers return NotLeader/ShardNotLocal` — core handler rewrite.
4. `e2e: add redirect and replica-read integration tests; fix delete_topic` — test coverage.
5. `docs: update d1_client.md for client-side control-plane routing` — records the design decision and the rationale for `Option<SocketAddr>` vs `SocketAddr`.

## Test plan

- [ ] `delete_topic` — fixed to try all nodes (was hardcoded to node-1 which was only correct because server forwarding guaranteed it was the leader)
- [ ] `delete_topic_redirects_to_leader` — sends to a non-leader, asserts `NotLeader { leader_addr: Some(_) }`, follows redirect, asserts `TopicDeleted`
- [ ] `describe_topic_served_by_all_replicas` — asserts all three replicas return `TopicDetail` (reads not gated on leadership)
- [ ] All existing e2e tests pass (create_topic, list_topics, describe_topic, split_range unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)