### PR TITLE
fix: issue 133

### DIFF
--- a/.claude/rules/code-convention.md
+++ b/.claude/rules/code-convention.md
@@ -24,6 +24,10 @@ Legitimate `Option` uses: simple lookups where "not found" is the only possible 
 
 Don't pass `bool` parameters to control method behavior. Instead, have the caller check the condition and only call the method when appropriate. Boolean parameters hide branching from the call site and make APIs harder to read.
 
+## `Box<[T]>` over `Vec<T>`
+* Use `Box<[T]>` when the collection has been built and its size will never change again.
+* Use `Vec<T>` when it is mutable state.
+
 ## Compile-time exhaustiveness over runtime defaults
 
 Never use wildcard `_ => {}` or `_ => unreachable!()` in match arms for enum dispatch. List all variants explicitly so the compiler catches new variants at compile time. When splitting a match across sub-functions, the "already handled" arms should be listed explicitly (e.g., `VariantA { .. } | VariantB { .. } => {}`).

--- a/scripts/stress_test.sh
+++ b/scripts/stress_test.sh
@@ -68,9 +68,12 @@ for i in $(seq 1 "$N"); do
   elif grep -q "test result: FAILED" "$log"; then
     fail=$((fail+1))
     mode=$(grep -oE "client_protocol.rs:[0-9]+" "$log" | head -1)
+    [ -z "$mode" ] && mode=$(grep -oE "phase[0-9]: [a-zA-Z0-9 -]+" "$log" | head -1)
+    [ -z "$mode" ] && mode=$(grep -oE "did not converge on a single replacement leader" "$log" | head -1)
     [ -z "$mode" ] && mode=$(grep -oE "Ran for duration[^\"]*" "$log" | head -1 | sed 's/ .*/-duration/')
-    echo "run=$i ${mode:-unknown}" >> "$SUMMARY"
-    echo "  run $i: FAIL ${mode:-unknown} (kept $log)"
+    seed=$(grep -oE "turmoil seed: [0-9]+" "$log" | head -1 | tr -dc '0-9')
+    echo "run=$i ${mode:-unknown} seed=${seed:-?}" >> "$SUMMARY"
+    echo "  run $i: FAIL ${mode:-unknown} seed=${seed:-?} (kept $log)"
   else
     pass=$((pass+1))
     rm -f "$log"   # keep only failing logs
@@ -82,9 +85,9 @@ echo "==================== RESULT ===================="
 echo "test=$TEST  pass=$pass  fail=$fail  /  $N"
 if [ "$fail" -gt 0 ]; then
   echo "---- failure breakdown ----"
-  sed -E 's/^run=[0-9]+ //' "$SUMMARY" | sort | uniq -c | sort -rn
+  sed -E 's/^run=[0-9]+ //; s/ seed=[0-9?]+$//' "$SUMMARY" | sort | uniq -c | sort -rn
   echo "---- failing logs kept in: $OUTDIR ----"
-  echo "(panic line guide: 503=produce never acked, 543=fetch timeout, *-duration=sim timeout)"
+  echo "(panic line guide: 503=produce never acked, 543=fetch timeout, phaseN:*=leader_elects_after_kill phase, *-duration=sim timeout)"
 else
   rm -rf "$OUTDIR"
 fi

--- a/scripts/stress_test.sh
+++ b/scripts/stress_test.sh
@@ -12,7 +12,9 @@
 #   scripts/stress_test.sh e2e_swim_raft_cluster_lifecycle 50 90
 #
 # Env:
-#   RUST_LOG   passed through to each run (default: off). e.g.
+#   RUST_LOG   passed through to each run. Defaults to east_guard=debug so
+#              kept failure logs always carry the election flight recorder
+#              (#133); set RUST_LOG= to disable. e.g.
 #              RUST_LOG=east_guard::data_plane::state=warn scripts/stress_test.sh
 #
 # Notes:
@@ -47,7 +49,7 @@ pass=0; fail=0
 for i in $(seq 1 "$N"); do
   log="$OUTDIR/run_$i.log"
   # Run with a wall-clock watchdog so a hung run can't wedge the sweep.
-  RUST_LOG="${RUST_LOG:-}" cargo test --lib "$TEST" >"$log" 2>&1 &
+  RUST_LOG="${RUST_LOG:-east_guard=debug}" cargo test --lib "$TEST" >"$log" 2>&1 &
   pid=$!
   killed=0
   for _ in $(seq 1 "$PER_RUN_TIMEOUT"); do

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -4,15 +4,15 @@ use tokio::sync::mpsc;
 pub(crate) struct BatchSender<T>(mpsc::Sender<Box<[T]>>);
 
 impl<T> BatchSender<T> {
-    pub(crate) async fn send_batch(&self, cmds: Vec<T>) {
+    pub(crate) async fn send_batch(&self, cmds: Box<[T]>) {
         if !cmds.is_empty() {
-            let _ = self.0.send(cmds.into_boxed_slice()).await;
+            let _ = self.0.send(cmds).await;
         }
     }
 
-    pub(crate) fn blocking_send_batch(&self, cmds: Vec<T>) {
+    pub(crate) fn blocking_send_batch(&self, cmds: Box<[T]>) {
         if !cmds.is_empty() {
-            let _ = self.0.blocking_send(cmds.into_boxed_slice());
+            let _ = self.0.blocking_send(cmds);
         }
     }
 }

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -611,7 +611,7 @@ mod tests {
     async fn list_hosted_topics() {
         let raft = raft_sender_with(|cmd| {
             if let MultiRaftActorCommand::GetTopics { reply } = cmd {
-                let _ = reply.send(vec!["alpha".into(), "beta".into()]);
+                let _ = reply.send(Box::new(["alpha".into(), "beta".into()]));
             }
         });
         let resp =
@@ -774,7 +774,8 @@ mod tests {
         assert_eq!(d.shard_group_id, 42);
         assert_eq!(d.leader_node_id.as_deref(), Some("n1"));
         assert_eq!(d.leader_addr, Some(addr(8081)));
-        assert_eq!(d.member_node_ids, vec!["node-1"]);
+        assert_eq!(d.member_node_ids[0], "node-1");
+        assert_eq!(d.member_node_ids.len(), 1);
     }
 
     #[tokio::test]
@@ -822,11 +823,11 @@ mod tests {
     async fn list_topic_stats() {
         let raft = raft_sender_with(|cmd| {
             if let MultiRaftActorCommand::GetTopicStats { reply } = cmd {
-                let _ = reply.send(vec![MetadataTopicStats {
+                let _ = reply.send(Box::new([MetadataTopicStats {
                     name: "t1".into(),
                     range_count: 2,
                     total_bytes: 1024,
-                }]);
+                }]));
             }
         });
         let resp =

--- a/src/connections/protocol/admin.rs
+++ b/src/connections/protocol/admin.rs
@@ -18,9 +18,9 @@ pub enum AdminRequest {
 #[derive(Debug, Encode, Decode)]
 pub enum AdminResponse {
     // DescribeCluster
-    ClusterInfo { nodes: Vec<NodeInfo> },
+    ClusterInfo { nodes: Box<[NodeInfo]> },
     // ListHostedTopicsWithStats
-    TopicStats { topics: Vec<TopicStats> },
+    TopicStats { topics: Box<[TopicStats]> },
     // SplitRange
     RangeSplit,
     InvalidSplitPoint,
@@ -37,7 +37,7 @@ pub struct ShardDetail {
     pub shard_group_id: u64,
     pub leader_node_id: Option<String>,
     pub leader_addr: Option<SocketAddr>,
-    pub member_node_ids: Vec<String>,
+    pub member_node_ids: Box<[String]>,
 }
 
 #[derive(Debug, Encode, Decode)]

--- a/src/connections/protocol/control_plane.rs
+++ b/src/connections/protocol/control_plane.rs
@@ -43,7 +43,7 @@ pub enum ControlPlaneResponse {
     TopicDeleted,
     TopicNotFound,
     // ListHostedTopics
-    TopicList { topics: Vec<TopicSummary> },
+    TopicList { topics: Box<[TopicSummary]> },
     // DescribeTopic — when this node owns the topic's metadata
     TopicDetail(TopicDetail),
     // DescribeTopic — when this node does not own the topic's metadata.
@@ -72,7 +72,7 @@ pub enum TopicState {
 pub struct TopicDetail {
     pub name: String,
     pub state: TopicState,
-    pub ranges: Vec<RangeDetail>,
+    pub ranges: Box<[RangeDetail]>,
 }
 
 /// Per-range metadata. Lineage fields (`split_into`, `merged_into`, `merged_from`)

--- a/src/connections/protocol/data_plane.rs
+++ b/src/connections/protocol/data_plane.rs
@@ -75,11 +75,11 @@ pub enum DataPlaneResponse {
     RangeSplitting {
         left_range_id: u64,
         right_range_id: u64,
-        split_point: Vec<u8>,
+        split_point: Box<[u8]>,
     },
     // Fetch
     Fetched {
-        entries: Vec<Entry>,
+        entries: Box<[Entry]>,
         next_entry_id: u64,
         progress_signal: RangeProgressSignal,
     },

--- a/src/consumer/bootstrap.rs
+++ b/src/consumer/bootstrap.rs
@@ -135,7 +135,7 @@ mod tests {
         TopicDetail {
             name: "t".into(),
             state: TopicState::Active,
-            ranges,
+            ranges: ranges.into_boxed_slice(),
         }
     }
 

--- a/src/consumer/cursor_set.rs
+++ b/src/consumer/cursor_set.rs
@@ -28,8 +28,8 @@ pub enum CursorAction {
     /// The fetched range was sealed and drained; cursors transitioned per
     /// the lineage rule.
     Transitioned {
-        dropped: Vec<RangeId>,
-        added: Vec<RangeCursor>,
+        dropped: Box<[RangeId]>,
+        added: Box<[RangeCursor]>,
     },
 }
 
@@ -109,7 +109,7 @@ impl RangeCursorSet {
                 self.cursors.extend(added.clone());
 
                 CursorAction::Transitioned {
-                    dropped: vec![range_id],
+                    dropped: Box::new([range_id]),
                     added,
                 }
             }
@@ -125,7 +125,7 @@ impl RangeCursorSet {
         &mut self,
         drained: RangeCursor,
         transition: RangeTransition,
-    ) -> Vec<RangeCursor> {
+    ) -> Box<[RangeCursor]> {
         match transition {
             RangeTransition::Split {
                 left_range_id,
@@ -145,7 +145,7 @@ impl RangeCursorSet {
                     .parked_merges
                     .try_complete_merge(merged_range_id, &drained)
                 {
-                    return vec![merged];
+                    return Box::new([merged]);
                 }
 
                 // - (b) Both parents tracked, the other still tracked. Park M pending
@@ -157,7 +157,7 @@ impl RangeCursorSet {
                         merged_id: merged_range_id,
                         drained: vec![drained],
                     });
-                    return Vec::new();
+                    return Box::new([]);
                 }
 
                 // - (c) Only this parent ever tracked
@@ -165,7 +165,7 @@ impl RangeCursorSet {
                 //      P1 [a, b)
                 //      P2 [b, c) -> M [a, c).
                 //  Consumer is reading only [a, b). Their CursorSet has only P1 (P2 was never relevant).
-                vec![drained.into_merged_cursor(merged_range_id)]
+                Box::new([drained.into_merged_cursor(merged_range_id)])
             }
         }
     }
@@ -314,7 +314,7 @@ mod tests {
         );
         match action {
             CursorAction::Transitioned { dropped, added } => {
-                assert_eq!(dropped, vec![RangeId(0)]);
+                assert_eq!(dropped[0], RangeId(0));
                 assert_eq!(added.len(), 2);
                 assert_eq!(added[0], cursor(RangeId(1), 0, b"a", b"b"));
                 assert_eq!(added[1], cursor(RangeId(2), 0, b"b", b"c"));
@@ -342,8 +342,8 @@ mod tests {
         assert_eq!(
             action,
             CursorAction::Transitioned {
-                dropped: vec![RangeId(1)],
-                added: vec![],
+                dropped: Box::new([RangeId(1)]),
+                added: Box::new([]),
             }
         );
         // P1 dropped; P2 still tracked; M not yet a fetchable cursor.
@@ -375,8 +375,8 @@ mod tests {
         assert_eq!(
             action,
             CursorAction::Transitioned {
-                dropped: vec![RangeId(2)],
-                added: vec![cursor(RangeId(3), 0, b"a", b"c")],
+                dropped: Box::new([RangeId(2)]),
+                added: Box::new([cursor(RangeId(3), 0, b"a", b"c")]),
             }
         );
         // Only M remains, spanning both pre-merge keyspaces.

--- a/src/control_plane/consensus/actor.rs
+++ b/src/control_plane/consensus/actor.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::channels::BatchSender;
 use crate::control_plane::NodeId;
@@ -21,7 +21,7 @@ pub struct MultiRaftActor {
     scheduler_tx: SchedulerSender<RaftTimer>,
     swim_tx: SwimSender,
     data_transport_tx: BatchSender<DataTransportCommand>,
-    packets_by_target: HashMap<NodeId, Vec<OutboundRaftPacket>>,
+    packets_by_target: BTreeMap<NodeId, Vec<OutboundRaftPacket>>,
     timer_cmds: Vec<TickerCommand<RaftTimer>>,
     transport_cmds: Vec<RaftTransportCommand>,
     data_transport_cmds: Vec<DataTransportCommand>,
@@ -58,7 +58,7 @@ impl MultiRaftActor {
                 scheduler_tx,
                 swim_tx,
                 data_transport_tx: data_transport_tx.into(),
-                packets_by_target: HashMap::new(),
+                packets_by_target: BTreeMap::new(),
                 timer_cmds: Vec::new(),
                 transport_cmds: Vec::new(),
                 data_transport_cmds: Vec::new(),
@@ -95,7 +95,7 @@ impl MultiRaftActor {
                 self.route_event(event).await;
             }
         }
-        for packets in self.packets_by_target.drain() {
+        for packets in std::mem::take(&mut self.packets_by_target) {
             self.transport_cmds
                 .push(RaftTransportCommand::Send(packets.1));
         }

--- a/src/control_plane/consensus/actor.rs
+++ b/src/control_plane/consensus/actor.rs
@@ -97,16 +97,16 @@ impl MultiRaftActor {
         }
         for packets in std::mem::take(&mut self.packets_by_target) {
             self.transport_cmds
-                .push(RaftTransportCommand::Send(packets.1));
+                .push(RaftTransportCommand::Send(packets.1.into_boxed_slice()));
         }
 
         tokio::join!(
             self.transport_tx
-                .send_batch(std::mem::take(&mut self.transport_cmds)),
+                .send_batch(std::mem::take(&mut self.transport_cmds).into_boxed_slice()),
             self.scheduler_tx
-                .send_batch(std::mem::take(&mut self.timer_cmds)),
+                .send_batch(std::mem::take(&mut self.timer_cmds).into_boxed_slice()),
             self.data_transport_tx
-                .send_batch(std::mem::take(&mut self.data_transport_cmds)),
+                .send_batch(std::mem::take(&mut self.data_transport_cmds).into_boxed_slice()),
         );
 
         self.store.fire_deferred();
@@ -178,7 +178,7 @@ impl MutlRaftSender {
         recv.await.ok().flatten()
     }
 
-    pub(crate) async fn get_peers(&self, group_id: ShardGroupId) -> Vec<NodeId> {
+    pub(crate) async fn get_peers(&self, group_id: ShardGroupId) -> Box<[NodeId]> {
         let (reply, recv) = tokio::sync::oneshot::channel();
         let _ = self
             .send(MultiRaftActorCommand::GetPeers { group_id, reply })
@@ -187,14 +187,14 @@ impl MutlRaftSender {
         recv.await.unwrap_or_default()
     }
 
-    pub(crate) async fn get_topics(&self) -> Vec<String> {
+    pub(crate) async fn get_topics(&self) -> Box<[String]> {
         let (reply, recv) = tokio::sync::oneshot::channel();
         let _ = self.send(MultiRaftActorCommand::GetTopics { reply }).await;
 
         recv.await.unwrap_or_default()
     }
 
-    pub(crate) async fn get_topic_stats(&self) -> Vec<TopicStats> {
+    pub(crate) async fn get_topic_stats(&self) -> Box<[TopicStats]> {
         let (reply, recv) = tokio::sync::oneshot::channel();
         let _ = self
             .send(MultiRaftActorCommand::GetTopicStats { reply })

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -12,8 +12,6 @@ use super::command::{
 use super::timer::RaftTimeoutCallback;
 use crate::impl_from_variant_via;
 
-/// Commands received by the MultiRaftActor from external sources (tokio-dependent).
-
 pub enum MultiRaftActorCommand {
     /// Fire-and-forget: internal Raft protocol messages, timeouts, and SWIM topology updates.
     ProtocolMessage(RaftProtocolMessage),

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -23,7 +23,7 @@ pub enum MultiRaftActorCommand {
 
     GetPeers {
         group_id: ShardGroupId,
-        reply: oneshot::Sender<Vec<NodeId>>,
+        reply: oneshot::Sender<Box<[NodeId]>>,
     },
     /// Propose a command to a shard group's Raft log. Leader-only.
     ClientProposal {
@@ -31,10 +31,12 @@ pub enum MultiRaftActorCommand {
         reply: oneshot::Sender<Result<(), ClientProposalError>>,
     },
     /// Query all topic names from all shard groups on this node.
-    GetTopics { reply: oneshot::Sender<Vec<String>> },
+    GetTopics {
+        reply: oneshot::Sender<Box<[String]>>,
+    },
     /// Query per-topic stats from all shard groups on this node.
     GetTopicStats {
-        reply: oneshot::Sender<Vec<TopicStats>>,
+        reply: oneshot::Sender<Box<[TopicStats]>>,
     },
     /// Query full metadata for a single topic by name. Returns `None` when the
     /// topic's metadata is not hosted on this node (i.e. this node is not in
@@ -76,12 +78,12 @@ impl_from_variant_via!(
 
 pub(crate) enum DeferredReply {
     GetLeader(oneshot::Sender<Option<NodeId>>, Option<NodeId>),
-    GetPeers(oneshot::Sender<Vec<NodeId>>, Vec<NodeId>),
+    GetPeers(oneshot::Sender<Box<[NodeId]>>, Box<[NodeId]>),
     Propose(
         oneshot::Sender<Result<(), ClientProposalError>>,
         Result<(), ClientProposalError>,
     ),
-    GetTopics(oneshot::Sender<Vec<String>>, Vec<String>),
-    GetTopicStats(oneshot::Sender<Vec<TopicStats>>, Vec<TopicStats>),
+    GetTopics(oneshot::Sender<Box<[String]>>, Box<[String]>),
+    GetTopicStats(oneshot::Sender<Box<[TopicStats]>>, Box<[TopicStats]>),
     GetTopicMetadata(oneshot::Sender<Option<TopicMeta>>, Option<TopicMeta>),
 }

--- a/src/control_plane/consensus/messages/command.rs
+++ b/src/control_plane/consensus/messages/command.rs
@@ -60,7 +60,7 @@ impl_from_variant!(
 /// Commands sent from MultiRaftActor to RaftTransportActor.
 #[derive(Debug)]
 pub enum RaftTransportCommand {
-    Send(Vec<OutboundRaftPacket>),
+    Send(Box<[OutboundRaftPacket]>),
     DisconnectPeer(NodeId),
 }
 

--- a/src/control_plane/consensus/messages/rpc.rs
+++ b/src/control_plane/consensus/messages/rpc.rs
@@ -26,7 +26,7 @@ pub struct AppendEntries {
     pub leader_id: NodeId,
     pub prev_log_index: u64,
     pub prev_log_term: u64,
-    pub entries: Vec<LogEntry>,
+    pub entries: Box<[LogEntry]>,
     pub leader_commit: u64,
 }
 

--- a/src/control_plane/consensus/messages/timer.rs
+++ b/src/control_plane/consensus/messages/timer.rs
@@ -10,8 +10,6 @@ pub struct RaftTimer {
     pub(crate) shard_group_id: ShardGroupId,
     kind: RaftTimerKind,
     ticks_remaining: u32,
-    /// Election-timer generation (see `Raft::election_epoch`, #133). Only
-    /// meaningful for `RaftTimerKind::Election`; 0 otherwise.
     epoch: u64,
 }
 
@@ -28,10 +26,6 @@ pub enum RaftTimeoutCallback {
     Ignored,
     ElectionTimeout {
         shard_group_id: ShardGroupId,
-        /// Generation of the timer that fired. A `CancelSchedule` cannot
-        /// retract a callback already emitted and in flight to the actor, so
-        /// `Raft::handle_timeout` drops fires whose epoch is stale (#133).
-        /// `u64::MAX` bypasses the check for direct invocations in tests.
         epoch: u64,
     },
     RpcTimeout {

--- a/src/control_plane/consensus/messages/timer.rs
+++ b/src/control_plane/consensus/messages/timer.rs
@@ -10,6 +10,9 @@ pub struct RaftTimer {
     pub(crate) shard_group_id: ShardGroupId,
     kind: RaftTimerKind,
     ticks_remaining: u32,
+    /// Election-timer generation (see `Raft::election_epoch`, #133). Only
+    /// meaningful for `RaftTimerKind::Election`; 0 otherwise.
+    epoch: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -25,6 +28,11 @@ pub enum RaftTimeoutCallback {
     Ignored,
     ElectionTimeout {
         shard_group_id: ShardGroupId,
+        /// Generation of the timer that fired. A `CancelSchedule` cannot
+        /// retract a callback already emitted and in flight to the actor, so
+        /// `Raft::handle_timeout` drops fires whose epoch is stale (#133).
+        /// `u64::MAX` bypasses the check for direct invocations in tests.
+        epoch: u64,
     },
     RpcTimeout {
         shard_group_id: ShardGroupId,
@@ -47,6 +55,7 @@ impl TTimer for RaftTimer {
         match self.kind {
             RaftTimerKind::Election => RaftTimeoutCallback::ElectionTimeout {
                 shard_group_id: self.shard_group_id,
+                epoch: self.epoch,
             },
             RaftTimerKind::Rpc => RaftTimeoutCallback::RpcTimeout {
                 shard_group_id: self.shard_group_id,
@@ -65,11 +74,12 @@ impl TTimer for RaftTimer {
 }
 
 impl RaftTimer {
-    pub fn election(jitter_ticks: u32, shard_group_id: ShardGroupId) -> Self {
+    pub fn election(jitter_ticks: u32, shard_group_id: ShardGroupId, epoch: u64) -> Self {
         Self {
             shard_group_id,
             kind: RaftTimerKind::Election,
             ticks_remaining: ELECTION_TIMEOUT_BASE_TICKS + jitter_ticks,
+            epoch,
         }
     }
 
@@ -78,6 +88,7 @@ impl RaftTimer {
             shard_group_id,
             kind: RaftTimerKind::Rpc,
             ticks_remaining: RAFT_RPC_INTERVAL_TICKS,
+            epoch: 0,
         }
     }
 
@@ -86,6 +97,7 @@ impl RaftTimer {
             shard_group_id,
             kind: RaftTimerKind::MergeCheck,
             ticks_remaining: MERGE_CHECK_INTERVAL_TICKS,
+            epoch: 0,
         }
     }
 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -318,7 +318,7 @@ impl MultiRaft {
         raft.cancel_all_timers();
         self.pending_events.extend(raft.take_events());
 
-        let pending_keys: Vec<_> = self
+        let pending_keys: Box<[_]> = self
             .pending_proposes
             .keys()
             .filter(|(gid, _)| *gid == group_id)
@@ -369,21 +369,21 @@ impl MultiRaft {
             .and_then(|r| r.current_leader().cloned())
     }
 
-    fn get_peers(&self, group_id: ShardGroupId) -> Vec<NodeId> {
+    fn get_peers(&self, group_id: ShardGroupId) -> Box<[NodeId]> {
         self.groups
             .get(&group_id)
             .map(|r| r.peers_iter().cloned().collect())
             .unwrap_or_default()
     }
 
-    fn get_topics(&self) -> Vec<String> {
+    fn get_topics(&self) -> Box<[String]> {
         self.groups
             .values()
             .flat_map(|raft| raft.topic_names())
             .collect()
     }
 
-    fn get_topic_stats(&self) -> Vec<TopicStats> {
+    fn get_topic_stats(&self) -> Box<[TopicStats]> {
         self.groups
             .values()
             .flat_map(|raft| raft.topic_stats())
@@ -679,7 +679,7 @@ impl MultiRaft {
         if mutations.is_empty() {
             return;
         }
-        self.storage.persist_mutations(mutations);
+        self.storage.persist_mutations(mutations.into_boxed_slice());
         for (id, last_log_index) in last_indices {
             if let Some(raft) = self.groups.get_mut(&id) {
                 // Advancing the durability gate re-attempts apply for entries that
@@ -969,7 +969,7 @@ mod tests {
                 leader_id: n2.clone(),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![
+                entries: Box::new([
                     LogEntry {
                         term: 1,
                         index: 1,
@@ -980,7 +980,7 @@ mod tests {
                         index: 2,
                         command: RaftCommand::Noop,
                     },
-                ],
+                ]),
                 leader_commit: 0,
             }),
         });
@@ -1004,11 +1004,11 @@ mod tests {
                 leader_id: n2.clone(),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![LogEntry {
+                entries: Box::new([LogEntry {
                     term: 2,
                     index: 1,
                     command: RaftCommand::Noop,
-                }],
+                }]),
                 leader_commit: 0,
             }),
         });

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -153,7 +153,6 @@ impl MultiRaft {
         // `apply_add_peer` is idempotent and self-skipping, so healthy
         // replicas no-op while divergent ones heal. Dead members are skipped
         // replacement is `reconcile_peers`'s job, rejoin is `add_node`'s.
-        let mut membership_asserted = false;
 
         if let Some(members) = self
             .topology
@@ -164,7 +163,7 @@ impl MultiRaft {
                     continue;
                 }
                 if raft.propose(RaftCommand::AddPeer(member.clone())).is_ok() {
-                    membership_asserted = true;
+                    self.dirty.insert(shard_group_id);
                 } else {
                     tracing::warn!(
                         "Takeover membership assert AddPeer({:?}) on {:?} rejected",
@@ -178,7 +177,7 @@ impl MultiRaft {
         let peer_reconciled = raft.reconcile_peers(&self.topology, &live_set);
         let segment_reconciled = raft.reconcile_segments(&live_set);
 
-        if membership_asserted || peer_reconciled || segment_reconciled {
+        if peer_reconciled || segment_reconciled {
             self.dirty.insert(shard_group_id);
         };
     }
@@ -280,7 +279,7 @@ impl MultiRaft {
 
         let timer_seqs = TimerSeqs {
             election: self.seq_counter.generate(),
-            heartbeat: self.seq_counter.generate(),
+            rpc: self.seq_counter.generate(),
             merge_check: self.seq_counter.generate(),
         };
 

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -135,8 +135,11 @@ impl MultiRaft {
         &self.node_id
     }
 
-    /// Invoked on `LeaderChange → self` to close the gap where the previous leader died
-    /// before proposing the removals (or their pairings).
+    /// Invoked on `LeaderChange → self` for takeover reconciliation:
+    /// 1. assert the group's current ring membership into the log, healing
+    ///    replicas whose genesis peer set was seeded from a partial ring;
+    /// 2. close the gap where the previous leader died before proposing the
+    ///    removals (or their pairings) for peers SWIM no longer considers live.
     pub(crate) fn reconcile_on_leadership_change(&mut self, shard_group_id: ShardGroupId) {
         let Some(raft) = self.groups.get_mut(&shard_group_id) else {
             return;
@@ -147,10 +150,47 @@ impl MultiRaft {
 
         let live_set: HashSet<NodeId> = self.topology.live_nodes().into_iter().collect();
 
+        // Each replica seeds its genesis peer set from its *local* ring
+        // snapshot at group-creation time, so the sets can diverge when a node
+        // created the group from a partially-joined ring (#133: a follower
+        // frozen with peers = {leader} can, after that leader dies, neither
+        // win an election — its RequestVotes go only to the corpse — nor grant
+        // one, because its own doomed candidacy self-votes first every round;
+        // the group livelocks leaderless). The peer set only mutates through
+        // the log, so the log must carry the membership at least once: on
+        // every takeover, assert the group's current ring membership as
+        // AddPeer entries. `apply_add_peer` is idempotent and self-skipping,
+        // making this a no-op on healthy replicas while healing divergent
+        // ones. Dead desired-members are deliberately skipped — replacing
+        // them is `reconcile_peers`'s job below, and a rejoining node is
+        // re-added by the join path (`add_node`).
+        let mut membership_asserted = false;
+        let desired = self
+            .topology
+            .shard_groups_for_node(&self.node_id)
+            .into_iter()
+            .find(|g| g.id == shard_group_id);
+        if let Some(group) = desired {
+            for member in group.members {
+                if member == self.node_id || !live_set.contains(&member) {
+                    continue;
+                }
+                match raft.propose(RaftCommand::AddPeer(member.clone())) {
+                    Ok(_) => membership_asserted = true,
+                    Err(e) => tracing::warn!(
+                        "Takeover membership assert AddPeer({:?}) on {:?} rejected: {:?}",
+                        member,
+                        shard_group_id,
+                        e
+                    ),
+                }
+            }
+        }
+
         let peer_reconciled = raft.reconcile_peers(&self.topology, &live_set);
         let segment_reconciled = raft.reconcile_segments(&live_set);
 
-        if peer_reconciled || segment_reconciled {
+        if membership_asserted || peer_reconciled || segment_reconciled {
             self.dirty.insert(shard_group_id);
         };
     }
@@ -317,7 +357,7 @@ impl MultiRaft {
     fn handle_timeout(&mut self, cb: RaftTimeoutCallback) {
         let shard_id = match &cb {
             RaftTimeoutCallback::Ignored => return,
-            RaftTimeoutCallback::ElectionTimeout { shard_group_id }
+            RaftTimeoutCallback::ElectionTimeout { shard_group_id, .. }
             | RaftTimeoutCallback::RpcTimeout { shard_group_id }
             | RaftTimeoutCallback::MergeCheckTimeout { shard_group_id, .. } => *shard_group_id,
         };
@@ -768,6 +808,7 @@ mod tests {
         store.handle_consensus(RaftProtocolMessage::Timeout(
             RaftTimeoutCallback::ElectionTimeout {
                 shard_group_id: ShardGroupId(42),
+                epoch: u64::MAX,
             },
         ));
         store.flush();
@@ -801,11 +842,13 @@ mod tests {
             store.handle_consensus(RaftProtocolMessage::Timeout(
                 RaftTimeoutCallback::ElectionTimeout {
                     shard_group_id: ShardGroupId(1),
+                    epoch: u64::MAX,
                 },
             ));
             store.handle_consensus(RaftProtocolMessage::Timeout(
                 RaftTimeoutCallback::ElectionTimeout {
                     shard_group_id: ShardGroupId(2),
+                    epoch: u64::MAX,
                 },
             ));
             store.flush();
@@ -832,6 +875,7 @@ mod tests {
         store.handle_consensus(RaftProtocolMessage::Timeout(
             RaftTimeoutCallback::ElectionTimeout {
                 shard_group_id: TEST_GROUP_ID,
+                epoch: u64::MAX,
             },
         ));
     }
@@ -1095,6 +1139,7 @@ mod tests {
         store.handle_consensus(RaftProtocolMessage::Timeout(
             RaftTimeoutCallback::ElectionTimeout {
                 shard_group_id: ShardGroupId(1),
+                epoch: u64::MAX,
             },
         ));
         store.flush();

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -163,15 +163,15 @@ impl MultiRaft {
                 if member == self.node_id || !live_set.contains(&member) {
                     continue;
                 }
-                match raft.propose(RaftCommand::AddPeer(member.clone())) {
-                    Ok(_) => membership_asserted = true,
-                    Err(e) => tracing::warn!(
-                        "Takeover membership assert AddPeer({:?}) on {:?} rejected: {:?}",
+                if raft.propose(RaftCommand::AddPeer(member.clone())).is_err() {
+                    tracing::warn!(
+                        "Takeover membership assert AddPeer({:?}) on {:?} rejected",
                         member,
                         shard_group_id,
-                        e
-                    ),
-                }
+                    );
+                    continue;
+                };
+                membership_asserted = true;
             }
         }
 

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -150,20 +150,14 @@ impl MultiRaft {
 
         let live_set: HashSet<NodeId> = self.topology.live_nodes().into_iter().collect();
 
-        // Each replica seeds its genesis peer set from its *local* ring
-        // snapshot at group-creation time, so the sets can diverge when a node
-        // created the group from a partially-joined ring (#133: a follower
-        // frozen with peers = {leader} can, after that leader dies, neither
-        // win an election — its RequestVotes go only to the corpse — nor grant
-        // one, because its own doomed candidacy self-votes first every round;
-        // the group livelocks leaderless). The peer set only mutates through
-        // the log, so the log must carry the membership at least once: on
-        // every takeover, assert the group's current ring membership as
-        // AddPeer entries. `apply_add_peer` is idempotent and self-skipping,
-        // making this a no-op on healthy replicas while healing divergent
-        // ones. Dead desired-members are deliberately skipped — replacing
-        // them is `reconcile_peers`'s job below, and a rejoining node is
-        // re-added by the join path (`add_node`).
+        // Genesis peer sets are seeded from each replica's *local* ring
+        // snapshot at creation and can diverge on a partially-joined ring
+        // (#133: a follower frozen with peers = {leader} livelocks the group
+        // once that leader dies). Peer sets mutate only through the log, so on
+        // takeover assert the group's ring membership as AddPeer entries:
+        // `apply_add_peer` is idempotent and self-skipping, so healthy
+        // replicas no-op while divergent ones heal. Dead members are skipped —
+        // replacement is `reconcile_peers`'s job, rejoin is `add_node`'s.
         let mut membership_asserted = false;
         let desired = self
             .topology

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -1,8 +1,3 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-
-use tokio::sync::oneshot;
-
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::{
     ClientProposalError, CoordinatorSealRequest, DeferredReply, InboundRaftRpc, LogMutation,
@@ -10,15 +5,16 @@ use crate::control_plane::consensus::messages::{
 };
 use crate::control_plane::consensus::raft::command::RaftCommand;
 use crate::control_plane::consensus::raft::state::{Raft, TimerSeqs};
-use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now_ms};
-use crate::control_plane::metadata::command::RollSegment;
-
-use crate::control_plane::metadata::{TopicId, TopicMeta, TopicStats};
-
 use crate::control_plane::consensus::raft::storage::RaftStorage;
+use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now_ms};
 use crate::control_plane::membership::{ShardGroup, ShardGroupId, TopologyReader};
+use crate::control_plane::metadata::command::RollSegment;
+use crate::control_plane::metadata::{TopicId, TopicMeta, TopicStats};
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::SegmentAssignmentAck;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use tokio::sync::oneshot;
 
 // dirty is owned here because it's a persistence concern — flush() drains it.
 pub(crate) struct MultiRaft {
@@ -152,20 +148,18 @@ impl MultiRaft {
 
         // Genesis peer sets are seeded from each replica's *local* ring
         // snapshot at creation and can diverge on a partially-joined ring
-        // (#133: a follower frozen with peers = {leader} livelocks the group
-        // once that leader dies). Peer sets mutate only through the log, so on
-        // takeover assert the group's ring membership as AddPeer entries:
+        // (#133: livelocks the group once that leader dies).
+        // Peer sets mutate only through the log, so on takeover assert the group's ring membership as AddPeer entries:
         // `apply_add_peer` is idempotent and self-skipping, so healthy
-        // replicas no-op while divergent ones heal. Dead members are skipped —
+        // replicas no-op while divergent ones heal. Dead members are skipped
         // replacement is `reconcile_peers`'s job, rejoin is `add_node`'s.
         let mut membership_asserted = false;
-        let desired = self
+
+        if let Some(members) = self
             .topology
-            .shard_groups_for_node(&self.node_id)
-            .into_iter()
-            .find(|g| g.id == shard_group_id);
-        if let Some(group) = desired {
-            for member in group.members {
+            .resolve_nodes_in_group(&self.node_id, shard_group_id)
+        {
+            for member in members {
                 if member == self.node_id || !live_set.contains(&member) {
                     continue;
                 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -163,15 +163,15 @@ impl MultiRaft {
                 if member == self.node_id || !live_set.contains(&member) {
                     continue;
                 }
-                if raft.propose(RaftCommand::AddPeer(member.clone())).is_err() {
+                if raft.propose(RaftCommand::AddPeer(member.clone())).is_ok() {
+                    membership_asserted = true;
+                } else {
                     tracing::warn!(
                         "Takeover membership assert AddPeer({:?}) on {:?} rejected",
                         member,
                         shard_group_id,
                     );
-                    continue;
-                };
-                membership_asserted = true;
+                }
             }
         }
 

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -162,14 +162,15 @@ impl MultiRaft {
                 if member == self.node_id || !live_set.contains(&member) {
                     continue;
                 }
-                if raft.propose(RaftCommand::AddPeer(member.clone())).is_ok() {
-                    self.dirty.insert(shard_group_id);
-                } else {
+
+                if let Err(e) = raft.propose(RaftCommand::AddPeer(member.clone())) {
                     tracing::warn!(
-                        "Takeover membership assert AddPeer({:?}) on {:?} rejected",
+                        "Takeover membership assert AddPeer({:?}) on {:?} rejected: {e:?}",
                         member,
                         shard_group_id,
-                    );
+                    )
+                } else {
+                    self.dirty.insert(shard_group_id);
                 }
             }
         }
@@ -479,7 +480,7 @@ impl MultiRaft {
     /// fresh means the join sees the latest cluster shape — including any
     /// topology drift between the SWIM event and this handler running.
     fn add_node(&mut self, node_id: NodeId) {
-        let affected_groups: Vec<ShardGroup> = self.topology.shard_groups_for_node(&node_id);
+        let affected_groups = self.topology.shard_groups_for_node(&node_id);
         if affected_groups.is_empty() {
             return;
         }
@@ -508,7 +509,7 @@ impl MultiRaft {
         }
     }
 
-    fn ensure_new_groups(&mut self, groups: Vec<ShardGroup>) {
+    fn ensure_new_groups(&mut self, groups: Box<[ShardGroup]>) {
         for group in groups {
             if !self.groups.contains_key(&group.id) && group.members.contains(&self.node_id) {
                 self.add_group(group);

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -94,6 +94,12 @@ pub struct Raft {
     state_machine: MetadataStateMachine,
     election_jitter: ElectionJitter,
     timer_seqs: TimerSeqs,
+    /// Election-timer generation. Bumped whenever the election timer is
+    /// (re)armed or cancelled; a fired `ElectionTimeout` carrying an older
+    /// epoch raced its own cancellation in flight and must be ignored
+    /// (#133: a stale fire one tick after a vote grant bumped the term and
+    /// deposed the freshly elected leader).
+    election_epoch: u64,
     /// Segments whose data-leader has acked its
     /// `SegmentAssignment`, mapped to the acking node. The heartbeat sweep skips
     /// re-driving a segment whose confirmed node still matches `replica_set[0]`
@@ -135,6 +141,7 @@ impl Raft {
             peer_states: HashMap::new(),
             election_jitter: ElectionJitter::new(election_jitter_seed),
             timer_seqs,
+            election_epoch: 0,
             confirmed_assignment: HashMap::new(),
         };
         raft.reset_election_timer();
@@ -408,8 +415,18 @@ impl Raft {
     pub fn handle_timeout(&mut self, event: RaftTimeoutCallback) {
         match event {
             RaftTimeoutCallback::Ignored => {}
-            RaftTimeoutCallback::ElectionTimeout { .. } => {
-                self.start_election();
+            RaftTimeoutCallback::ElectionTimeout { epoch, .. } => {
+                if epoch == self.election_epoch || epoch == u64::MAX {
+                    self.start_election();
+                } else {
+                    tracing::debug!(
+                        node = %self.node_id,
+                        group = self.shard_group_id.0,
+                        stale_epoch = epoch,
+                        epoch = self.election_epoch,
+                        "election: dropped stale election timeout"
+                    );
+                }
             }
             RaftTimeoutCallback::RpcTimeout { .. } => {
                 self.send_heartbeats();
@@ -455,6 +472,12 @@ impl Raft {
 
         self.role = Role::Candidate { votes_received: 1 }; // vote for self
         self.reset_election_timer();
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            term = self.current_term,
+            "election: became candidate, broadcasting RequestVote"
+        );
 
         let req = RequestVote {
             term: self.current_term,
@@ -477,9 +500,22 @@ impl Raft {
             self.step_down(req.term);
         }
 
-        let vote_granted = req.term == self.current_term
-            && self.vote_available_for(&req.candidate_id)
-            && self.log_is_up_to_date(req.last_log_index, req.last_log_term);
+        let term_ok = req.term == self.current_term;
+        let vote_ok = self.vote_available_for(&req.candidate_id);
+        let log_ok = self.log_is_up_to_date(req.last_log_index, req.last_log_term);
+        let vote_granted = term_ok && vote_ok && log_ok;
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            from = %req.candidate_id,
+            req_term = req.term,
+            term = self.current_term,
+            granted = vote_granted,
+            term_ok,
+            vote_ok,
+            log_ok,
+            "election: RequestVote received"
+        );
 
         if vote_granted {
             self.voted_for = Some(req.candidate_id);
@@ -502,6 +538,15 @@ impl Raft {
     }
 
     fn handle_request_vote_response(&mut self, resp: RequestVoteResponse) {
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            from = %resp.node_id,
+            resp_term = resp.term,
+            term = self.current_term,
+            granted = resp.vote_granted,
+            "election: RequestVoteResponse received"
+        );
         if resp.term > self.current_term {
             self.step_down(resp.term);
             return;
@@ -548,6 +593,12 @@ impl Raft {
     fn become_leader(&mut self) {
         self.role = Role::Leader;
         self.current_leader = Some(self.node_id.clone());
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            term = self.current_term,
+            "election: became leader"
+        );
 
         self.events.push(
             LeaderChange {
@@ -596,12 +647,35 @@ impl Raft {
         self.current_term = new_term;
         self.voted_for = None;
         self.push_hard_state();
+        let was_leader = self.role == Role::Leader;
         self.role = Role::Follower;
         self.current_leader = None;
         self.peer_states.clear();
         self.confirmed_assignment.clear();
-        self.cancel_all_timers();
-        self.reset_election_timer();
+        // Raft resets a node's election timer only when it grants a vote or
+        // recognizes AppendEntries from the current leader (§5.2; etcd
+        // implements the same). Resetting here — on *any* higher-term
+        // message, including a RequestVote we are about to reject — lets a
+        // candidate that can never win (e.g. its log fell behind before the
+        // old leader died) push back the one electable survivor's deadline
+        // every round: a livelock observed in #133 as both survivors
+        // reporting no leader for 40s+. Followers and candidates therefore
+        // keep their already-armed deadline; the explicit resets on the
+        // grant path (`handle_request_vote`) and on leader contact
+        // (`recognize_leader`) provide the paper's resets. Only an
+        // ex-leader — which runs no election timer — arms a fresh one so it
+        // cannot be stranded with no timer at all.
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            new_term,
+            was_leader,
+            "election: stepping down"
+        );
+        self.cancel_leader_timers();
+        if was_leader {
+            self.reset_election_timer();
+        }
     }
 
     // -------------------------------------------------------------------
@@ -719,6 +793,13 @@ impl Raft {
         }
         self.current_leader = Some(req.leader_id.clone());
         self.reset_election_timer();
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            term = self.current_term,
+            leader = %req.leader_id,
+            "election: leader recognized"
+        );
     }
 
     fn check_log_consistency(&self, prev_log_index: u64, prev_log_term: u64) -> bool {
@@ -1013,15 +1094,23 @@ impl Raft {
     }
 
     fn reset_election_timer(&mut self) {
+        self.election_epoch = self.election_epoch.wrapping_add(1);
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.timer_seqs.election,
             }));
         let jitter = self.election_jitter.next();
+        tracing::debug!(
+            node = %self.node_id,
+            group = self.shard_group_id.0,
+            epoch = self.election_epoch,
+            jitter_ticks = jitter,
+            "election: timer armed"
+        );
         self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
                 seq: self.timer_seqs.election,
-                timer: RaftTimer::election(jitter, self.shard_group_id),
+                timer: RaftTimer::election(jitter, self.shard_group_id, self.election_epoch),
             }));
     }
 
@@ -1054,7 +1143,22 @@ impl Raft {
         self.schedule_merge_check_timer();
     }
 
+    /// Cancels the leader-side timers (heartbeat, merge-check) without
+    /// touching the election timer — used by `step_down` so a follower or
+    /// candidate keeps its currently armed election deadline (#133).
+    fn cancel_leader_timers(&mut self) {
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
+                seq: self.timer_seqs.heartbeat,
+            }));
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
+                seq: self.timer_seqs.merge_check,
+            }));
+    }
+
     pub(crate) fn cancel_all_timers(&mut self) {
+        self.election_epoch = self.election_epoch.wrapping_add(1);
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.timer_seqs.election,
@@ -1263,6 +1367,7 @@ mod tests {
 
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         assert_eq!(raft.role, Role::Leader);
@@ -1275,6 +1380,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         assert_eq!(raft.current_term, 1);
 
@@ -1282,6 +1388,7 @@ mod tests {
         raft.step_down(1);
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         assert_eq!(raft.current_term, 2);
     }
@@ -1296,6 +1403,7 @@ mod tests {
 
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         assert!(matches!(raft.role, Role::Candidate { votes_received: 1 }));
@@ -1369,6 +1477,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -1388,6 +1497,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -1444,6 +1554,7 @@ mod tests {
         // Become leader
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1585,6 +1696,7 @@ mod tests {
         // Become leader
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1686,6 +1798,7 @@ mod tests {
         // Become leader
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1728,6 +1841,7 @@ mod tests {
         // Become leader at term 1
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1767,6 +1881,7 @@ mod tests {
         // Become leader at term 1
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1784,6 +1899,7 @@ mod tests {
         // Stale election timeout arrives — should be ignored
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         assert_eq!(
@@ -1812,6 +1928,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         assert!(matches!(raft.role, Role::Candidate { .. }));
@@ -1839,6 +1956,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -1883,6 +2001,7 @@ mod tests {
         // Become leader
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -1997,6 +2116,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         assert!(raft.is_leader());
     }
@@ -2022,6 +2142,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         assert!(raft.is_leader());
@@ -2039,6 +2160,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -2054,6 +2176,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         assert!(raft.is_leader());
@@ -2078,6 +2201,7 @@ mod tests {
 
         n1.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         let vote_reqs = packets(&mut n1);
         for pkt in &vote_reqs {
@@ -2118,6 +2242,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -2147,6 +2272,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
 
@@ -2173,6 +2299,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         let events = leader_events(&mut raft);
@@ -2187,6 +2314,7 @@ mod tests {
         // Become leader
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -2223,6 +2351,7 @@ mod tests {
         // First election: term 1
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         let events = leader_events(&mut raft);
         assert_eq!(events[0].term, 1);
@@ -2231,6 +2360,7 @@ mod tests {
         raft.step_down(1);
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         let reelection_events = leader_events(&mut raft);
@@ -2263,6 +2393,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.simulate_flush();
@@ -2278,6 +2409,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.simulate_flush();
@@ -2293,6 +2425,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.simulate_flush();
@@ -2311,6 +2444,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.simulate_flush();
@@ -2359,6 +2493,7 @@ mod tests {
         // node-1 wins election at term 2
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         raft.handle_rpc(
@@ -2422,6 +2557,7 @@ mod tests {
         );
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
 
         let events = raft.take_events();
@@ -2476,6 +2612,7 @@ mod tests {
         let mut raft = three_node_raft(id);
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         let peer = raft
@@ -2504,6 +2641,7 @@ mod tests {
         let mut raft = single_node_raft();
         raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
             shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
         });
         drain(&mut raft);
         assert_eq!(raft.role, Role::Leader);

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -472,7 +472,7 @@ impl Raft {
 
         self.role = Role::Candidate { votes_received: 1 }; // vote for self
         self.reset_election_timer();
-        tracing::debug!(
+        tracing::trace!(
             node = %self.node_id,
             group = self.shard_group_id.0,
             term = self.current_term,
@@ -1100,7 +1100,7 @@ impl Raft {
                 seq: self.timer_seqs.election,
             }));
         let jitter = self.election_jitter.next();
-        tracing::debug!(
+        tracing::trace!(
             node = %self.node_id,
             group = self.shard_group_id.0,
             epoch = self.election_epoch,

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -413,12 +413,20 @@ impl Raft {
         match event {
             RaftTimeoutCallback::Ignored => {}
             RaftTimeoutCallback::ElectionTimeout { epoch, .. } => {
+                // u64::MAX bypasses the staleness check for direct
+                // invocations in tests; real timers carry the epoch they
+                // were armed with.
                 if epoch == self.election_epoch || epoch == u64::MAX {
                     self.start_election();
                     return;
                 }
-
-                tracing::debug!("election: dropped stale election timeout");
+                tracing::debug!(
+                    node = %self.node_id,
+                    group = self.shard_group_id.0,
+                    stale_epoch = epoch,
+                    epoch = self.election_epoch,
+                    "election: dropped stale election timeout"
+                );
             }
             RaftTimeoutCallback::RpcTimeout { .. } => {
                 self.send_heartbeats();
@@ -636,19 +644,40 @@ impl Raft {
     }
 
     fn step_down(&mut self, new_term: u64) {
+        debug_assert!(
+            new_term >= self.current_term,
+            "step_down must never regress the term"
+        );
+        let was_leader = self.role == Role::Leader;
+
         tracing::debug!(
             node = %self.node_id,
             group = self.shard_group_id.0,
             new_term,
-            was_leader = self.role == Role::Leader,
+            was_leader,
             "election: stepping down"
         );
 
-        self.current_term = new_term;
-        self.voted_for = None;
-        self.push_hard_state();
+        // Clearing the vote is only safe when the term actually advances;
+        // at an equal term this is a pure demotion that must preserve
+        // `voted_for`, or the node could vote twice in one term — the same
+        // rule `recognize_leader`'s demotion branch follows. All production
+        // callers pass strictly newer terms (guarded `>` at every call
+        // site); tests use equal-term step_down to depose a leader in place.
+        if new_term > self.current_term {
+            self.current_term = new_term;
+            self.voted_for = None;
+            self.push_hard_state();
+        }
+
         self.cancel_leader_timers();
-        if self.role == Role::Leader {
+        if was_leader {
+            // The election timer resets only on a vote grant or
+            // on AppendEntries from the current leader — never on a mere
+            // higher-term message, or a doomed candidate can push back a healthy
+            // follower's deadline every round (the #133 livelock). Followers and
+            // candidates keep their armed deadline; only an ex-leader, which
+            // runs no election timer, arms a fresh one.
             self.reset_election_timer();
         }
         self.role = Role::Follower;

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -107,7 +107,7 @@ pub struct Raft {
 
 pub(crate) struct TimerSeqs {
     pub election: u64,
-    pub heartbeat: u64,
+    pub rpc: u64,
     pub merge_check: u64,
 }
 
@@ -147,7 +147,7 @@ impl Raft {
     }
 
     pub(crate) fn heartbeat_seq(&self) -> u64 {
-        self.timer_seqs.heartbeat
+        self.timer_seqs.rpc
     }
 
     pub(crate) fn topic_names(&self) -> Vec<String> {
@@ -636,38 +636,25 @@ impl Raft {
     }
 
     fn step_down(&mut self, new_term: u64) {
-        self.current_term = new_term;
-        self.voted_for = None;
-        self.push_hard_state();
-        let was_leader = self.role == Role::Leader;
-        self.role = Role::Follower;
-        self.current_leader = None;
-        self.peer_states.clear();
-        self.confirmed_assignment.clear();
-        // Raft resets a node's election timer only when it grants a vote or
-        // recognizes AppendEntries from the current leader (§5.2; etcd
-        // implements the same). Resetting here — on *any* higher-term
-        // message, including a RequestVote we are about to reject — lets a
-        // candidate that can never win (e.g. its log fell behind before the
-        // old leader died) push back the one electable survivor's deadline
-        // every round: a livelock observed in #133 as both survivors
-        // reporting no leader for 40s+. Followers and candidates therefore
-        // keep their already-armed deadline; the explicit resets on the
-        // grant path (`handle_request_vote`) and on leader contact
-        // (`recognize_leader`) provide the paper's resets. Only an
-        // ex-leader — which runs no election timer — arms a fresh one so it
-        // cannot be stranded with no timer at all.
         tracing::debug!(
             node = %self.node_id,
             group = self.shard_group_id.0,
             new_term,
-            was_leader,
+            was_leader = self.role == Role::Leader,
             "election: stepping down"
         );
+
+        self.current_term = new_term;
+        self.voted_for = None;
+        self.push_hard_state();
         self.cancel_leader_timers();
-        if was_leader {
+        if self.role == Role::Leader {
             self.reset_election_timer();
         }
+        self.role = Role::Follower;
+        self.current_leader = None;
+        self.peer_states.clear();
+        self.confirmed_assignment.clear();
     }
 
     // -------------------------------------------------------------------
@@ -1109,7 +1096,7 @@ impl Raft {
     fn schedule_rpc_timer(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::SetSchedule {
-                seq: self.timer_seqs.heartbeat,
+                seq: self.timer_seqs.rpc,
                 timer: RaftTimer::rpc(self.shard_group_id),
             }));
     }
@@ -1141,7 +1128,7 @@ impl Raft {
     fn cancel_leader_timers(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: self.timer_seqs.heartbeat,
+                seq: self.timer_seqs.rpc,
             }));
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
@@ -1157,7 +1144,7 @@ impl Raft {
             }));
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
-                seq: self.timer_seqs.heartbeat,
+                seq: self.timer_seqs.rpc,
             }));
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
@@ -1319,7 +1306,7 @@ mod tests {
     fn test_timer_seqs() -> TimerSeqs {
         TimerSeqs {
             election: 0,
-            heartbeat: 1,
+            rpc: 1,
             merge_check: 2,
         }
     }

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -97,8 +97,6 @@ pub struct Raft {
     /// Election-timer generation. Bumped whenever the election timer is
     /// (re)armed or cancelled; a fired `ElectionTimeout` carrying an older
     /// epoch raced its own cancellation in flight and must be ignored
-    /// (#133: a stale fire one tick after a vote grant bumped the term and
-    /// deposed the freshly elected leader).
     election_epoch: u64,
     /// Segments whose data-leader has acked its
     /// `SegmentAssignment`, mapped to the acking node. The heartbeat sweep skips
@@ -418,15 +416,10 @@ impl Raft {
             RaftTimeoutCallback::ElectionTimeout { epoch, .. } => {
                 if epoch == self.election_epoch || epoch == u64::MAX {
                     self.start_election();
-                } else {
-                    tracing::debug!(
-                        node = %self.node_id,
-                        group = self.shard_group_id.0,
-                        stale_epoch = epoch,
-                        epoch = self.election_epoch,
-                        "election: dropped stale election timeout"
-                    );
+                    return;
                 }
+
+                tracing::debug!("election: dropped stale election timeout");
             }
             RaftTimeoutCallback::RpcTimeout { .. } => {
                 self.send_heartbeats();

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -75,8 +75,6 @@ pub struct Raft {
     // Identity
     pub node_id: NodeId,
     pub shard_group_id: ShardGroupId,
-    peers: HashSet<NodeId>,
-
     current_term: u64,
     voted_for: Option<NodeId>,
     log: Vec<LogEntry>,
@@ -89,6 +87,8 @@ pub struct Raft {
     /// Tracks who the current leader is — set when this node becomes leader
     /// or when a valid `AppendEntries` is received from a leader.
     current_leader: Option<NodeId>,
+
+    peers: HashSet<NodeId>,
     // LEADER-ONLY volatile state
     peer_states: HashMap<NodeId, PeerState>,
     state_machine: MetadataStateMachine,
@@ -178,7 +178,6 @@ impl Raft {
 
     pub(crate) fn reconcile_peers(
         &mut self,
-
         topology_reader: &TopologyReader,
         live: &HashSet<NodeId>,
     ) -> bool {

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -150,11 +150,11 @@ impl Raft {
         self.timer_seqs.rpc
     }
 
-    pub(crate) fn topic_names(&self) -> Vec<String> {
+    pub(crate) fn topic_names(&self) -> Box<[String]> {
         self.state_machine.topic_names()
     }
 
-    pub(crate) fn topic_stats(&self) -> Vec<TopicStats> {
+    pub(crate) fn topic_stats(&self) -> Box<[TopicStats]> {
         self.state_machine.topic_stats()
     }
 
@@ -165,14 +165,14 @@ impl Raft {
     pub(crate) fn active_segments_for_node(
         &self,
         node_id: &NodeId,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         self.state_machine.active_segments_for_node(node_id)
     }
 
     /// Every active segment's assignment tuple `(key, replica_set, start_offset)`.
     /// The leader's confirmation-gated assignment sweep (`MultiRaft::build_redrive_cmds`)
     /// turns these into `SegmentAssignment` re-drives for unconfirmed segments.
-    pub(crate) fn active_segment_assignments(&self) -> Vec<(SegmentKey, ReplicaSet, u64)> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
         self.state_machine.active_segment_assignments()
     }
 
@@ -287,7 +287,7 @@ impl Raft {
     pub(crate) fn active_segments_with_dead_members(
         &self,
         live: &HashSet<NodeId>,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         self.state_machine.active_segments_with_dead_members(live)
     }
 
@@ -339,12 +339,12 @@ impl Raft {
         self.log.get((index - 1) as usize)
     }
 
-    fn log_entries_from(&self, start_index: u64) -> Vec<LogEntry> {
+    fn log_entries_from(&self, start_index: u64) -> Box<[LogEntry]> {
         let last = self.log_last_index();
         if start_index == 0 || start_index > last {
-            return vec![];
+            return Box::new([]);
         }
-        self.log[(start_index - 1) as usize..].to_vec()
+        self.log[(start_index - 1) as usize..].into()
     }
 
     fn log_append(&mut self, entry: LogEntry) {
@@ -818,7 +818,7 @@ impl Raft {
         local_term != 0 && local_term == prev_log_term
     }
 
-    fn replicate_entries(&mut self, entries: Vec<LogEntry>) {
+    fn replicate_entries(&mut self, entries: Box<[LogEntry]>) {
         for entry in entries {
             let existing_term = self.log_term_at(entry.index);
             if existing_term != 0 && existing_term != entry.term {
@@ -1624,11 +1624,11 @@ mod tests {
             leader_id: NodeId::new("node-1"),
             prev_log_index: 0,
             prev_log_term: 0,
-            entries: vec![LogEntry {
+            entries: Box::new([LogEntry {
                 term: 1,
                 index: 1,
                 command: RaftCommand::Noop,
-            }],
+            }]),
             leader_commit: 0,
         };
         raft.handle_rpc(node("node-1"), ae);
@@ -1654,7 +1654,7 @@ mod tests {
             leader_id: NodeId::new("node-1"),
             prev_log_index: 0,
             prev_log_term: 0,
-            entries: vec![],
+            entries: Default::default(),
             leader_commit: 0,
         };
         raft.handle_rpc(node("node-1"), ae);
@@ -1679,11 +1679,11 @@ mod tests {
             leader_id: NodeId::new("node-1"),
             prev_log_index: 1,
             prev_log_term: 1,
-            entries: vec![LogEntry {
+            entries: Box::new([LogEntry {
                 term: 1,
                 index: 2,
                 command: RaftCommand::Noop,
-            }],
+            }]),
             leader_commit: 0,
         };
         raft.handle_rpc(node("node-1"), ae);
@@ -1756,7 +1756,7 @@ mod tests {
                 leader_id: node("node-1"),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![],
+                entries: Default::default(),
                 leader_commit: 0,
             }),
         );
@@ -1782,11 +1782,11 @@ mod tests {
             leader_id: NodeId::new("node-1"),
             prev_log_index: 0,
             prev_log_term: 0,
-            entries: vec![LogEntry {
+            entries: Box::new([LogEntry {
                 term: 1,
                 index: 1,
                 command: RaftCommand::Noop,
-            }],
+            }]),
             leader_commit: 1,
         };
         raft.handle_rpc(node("node-1"), ae);
@@ -1869,7 +1869,7 @@ mod tests {
             leader_id: NodeId::new("node-3"),
             prev_log_index: 0,
             prev_log_term: 0,
-            entries: vec![],
+            entries: Default::default(),
             leader_commit: 0,
         };
         raft.handle_rpc(node("node-3"), ae);
@@ -1994,7 +1994,7 @@ mod tests {
                 leader_id: node("node-1"),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![],
+                entries: Default::default(),
                 leader_commit: 0,
             },
         );
@@ -2050,7 +2050,7 @@ mod tests {
                 leader_id: node("node-1"),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![],
+                entries: Default::default(),
                 leader_commit: 0,
             },
         );
@@ -2065,7 +2065,7 @@ mod tests {
                 leader_id: node("node-2"),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![],
+                entries: Default::default(),
                 leader_commit: 0,
             },
         );
@@ -2485,11 +2485,11 @@ mod tests {
                 leader_id: node("node-2"),
                 prev_log_index: 0,
                 prev_log_term: 0,
-                entries: vec![LogEntry {
+                entries: Box::new([LogEntry {
                     term: 1,
                     index: 1,
                     command: RaftCommand::Noop,
-                }],
+                }]),
                 leader_commit: 0,
             }),
         );

--- a/src/control_plane/consensus/raft/storage.rs
+++ b/src/control_plane/consensus/raft/storage.rs
@@ -18,6 +18,6 @@ impl RaftPersistentState {
 
 pub(crate) trait RaftStorage: Send + Sync {
     fn load_state(&self, group_id: u64) -> RaftPersistentState;
-    fn persist_mutations(&self, mutations: Vec<(ShardGroupId, LogMutation)>);
+    fn persist_mutations(&self, mutations: Box<[(ShardGroupId, LogMutation)]>);
     fn delete_group(&self, group_id: ShardGroupId);
 }

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -50,7 +50,7 @@ impl RaftTransportActor {
                         }
                     }
                     if !to_send.is_empty() {
-                        dispatcher.send(to_send.into_boxed_slice(), &swim_tx).await;
+                        dispatcher.send(to_send, &swim_tx).await;
                     }
                 }
                 Some(result) = dial_rx.recv() => {

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -38,13 +38,7 @@ impl RaftTransportActor {
                     dispatcher.accept(stream, &raft_tx).await;
                 }
                 Some(batch) = from_actor.recv() => {
-                    // Aggregate the batch into ONE dispatcher.send() call: the
-                    // actor emits one Send command *per target* (#133), so
-                    // dispatching them in arrival order would let a dial to a
-                    // crashed peer (3s connect timeout, no RST) stall commands
-                    // to reachable peers queued behind it — e.g. the two halves
-                    // of a RequestVote broadcast. Disconnects are applied first
-                    // so same-batch sends already skip removed peers, then
+                    // Disconnects are applied first so same-batch sends already skip removed peers, then
                     // `send()` flushes connected peers before dialing anyone.
                     let mut to_send = Vec::new();
                     for cmd in batch {
@@ -56,7 +50,7 @@ impl RaftTransportActor {
                         }
                     }
                     if !to_send.is_empty() {
-                        dispatcher.send(to_send, &swim_tx).await;
+                        dispatcher.send(to_send.into_boxed_slice(), &swim_tx).await;
                     }
                 }
                 Some(result) = dial_rx.recv() => {

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -27,7 +27,8 @@ impl RaftTransportActor {
         mut from_actor: mpsc::Receiver<Box<[RaftTransportCommand]>>,
         swim_tx: SwimSender,
     ) {
-        let mut write_dispatcher = RaftRpcDispatcher::new(node_id);
+        let (dial_tx, mut dial_rx) = mpsc::channel(256);
+        let mut write_dispatcher = RaftRpcDispatcher::new(node_id, dial_tx);
         let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(300));
         cleanup_interval.tick().await; // consume immediate first tick
 
@@ -37,16 +38,29 @@ impl RaftTransportActor {
                     write_dispatcher.accept(stream, &raft_tx).await;
                 }
                 Some(batch) = from_actor.recv() => {
+                    // Aggregate the batch into ONE dispatcher.send() call: the
+                    // actor emits one Send command *per target* (#133), so
+                    // dispatching them in arrival order would let a dial to a
+                    // crashed peer (3s connect timeout, no RST) stall commands
+                    // to reachable peers queued behind it — e.g. the two halves
+                    // of a RequestVote broadcast. Disconnects are applied first
+                    // so same-batch sends already skip removed peers, then
+                    // `send()` flushes connected peers before dialing anyone.
+                    let mut to_send = Vec::new();
                     for cmd in batch {
                         match cmd {
-                            RaftTransportCommand::Send(packets) => {
-                                write_dispatcher.send(packets, &raft_tx, &swim_tx).await;
-                            }
+                            RaftTransportCommand::Send(packets) => to_send.extend(packets),
                             RaftTransportCommand::DisconnectPeer(peer_id) => {
                                 write_dispatcher.disconnect(peer_id);
                             }
                         }
                     }
+                    if !to_send.is_empty() {
+                        write_dispatcher.send(to_send, &raft_tx, &swim_tx).await;
+                    }
+                }
+                Some(result) = dial_rx.recv() => {
+                    write_dispatcher.on_dial_result(result, &raft_tx).await;
                 }
                 _ = cleanup_interval.tick() => {
                     write_dispatcher.cleanup_dead_peers();
@@ -171,7 +185,8 @@ mod tests {
             let (raft_tx, _raft_rx) =
                 crate::control_plane::consensus::actor::MultiRaftActor::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
-            let mut state = RaftRpcDispatcher::new(NodeId::new("node-b"));
+            let (dial_tx, _dial_rx) = tokio::sync::mpsc::channel(8);
+            let mut state = RaftRpcDispatcher::new(NodeId::new("node-b"), dial_tx);
 
             let (stream, _) = listener.accept().await?;
             state.accept(stream, &raft_tx).await;
@@ -209,7 +224,8 @@ mod tests {
                 crate::control_plane::consensus::actor::MultiRaftActor::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
             let dummy_listener = TcpListener::bind("0.0.0.0:9001").await?;
-            let mut state = RaftRpcDispatcher::new(NodeId::new("node-b"));
+            let (dial_tx, _dial_rx) = tokio::sync::mpsc::channel(8);
+            let mut state = RaftRpcDispatcher::new(NodeId::new("node-b"), dial_tx);
 
             // First connection from node-a
             let (stream, _) = listener.accept().await?;

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -28,14 +28,14 @@ impl RaftTransportActor {
         swim_tx: SwimSender,
     ) {
         let (dial_tx, mut dial_rx) = mpsc::channel(256);
-        let mut write_dispatcher = RaftRpcDispatcher::new(node_id, dial_tx);
+        let mut dispatcher = RaftRpcDispatcher::new(node_id, dial_tx);
         let mut cleanup_interval = tokio::time::interval(std::time::Duration::from_secs(300));
         cleanup_interval.tick().await; // consume immediate first tick
 
         loop {
             tokio::select! {
                 Ok((stream, _)) = listener.accept() => {
-                    write_dispatcher.accept(stream, &raft_tx).await;
+                    dispatcher.accept(stream, &raft_tx).await;
                 }
                 Some(batch) = from_actor.recv() => {
                     // Aggregate the batch into ONE dispatcher.send() call: the
@@ -51,19 +51,19 @@ impl RaftTransportActor {
                         match cmd {
                             RaftTransportCommand::Send(packets) => to_send.extend(packets),
                             RaftTransportCommand::DisconnectPeer(peer_id) => {
-                                write_dispatcher.disconnect(peer_id);
+                                dispatcher.disconnect(peer_id);
                             }
                         }
                     }
                     if !to_send.is_empty() {
-                        write_dispatcher.send(to_send, &raft_tx, &swim_tx).await;
+                        dispatcher.send(to_send, &swim_tx).await;
                     }
                 }
                 Some(result) = dial_rx.recv() => {
-                    write_dispatcher.on_dial_result(result, &raft_tx).await;
+                    dispatcher.on_dial_result(result, &raft_tx).await;
                 }
                 _ = cleanup_interval.tick() => {
-                    write_dispatcher.cleanup_dead_peers();
+                    dispatcher.cleanup_dead_peers();
                 }
             }
         }

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -10,7 +10,7 @@ use crate::control_plane::consensus::messages::{OutboundRaftPacket, WireRaftMess
 
 use crate::control_plane::consensus::transport::RaftRpcListener;
 use crate::control_plane::membership::actor::SwimSender;
-use crate::control_plane::{BINCODE_CONFIG, NodeAddress, NodeId};
+use crate::control_plane::{BINCODE_CONFIG, NodeId};
 use crate::net::{OwnedWriteHalf, TcpStream};
 
 const CONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(2);
@@ -78,14 +78,9 @@ impl RaftRpcDispatcher {
         tokio::spawn(reader.run(raft_tx.clone()));
     }
 
-    pub(super) async fn send(
-        &mut self,
-        packets: Vec<OutboundRaftPacket>,
-        raft_tx: &MutlRaftSender,
-        swim_tx: &SwimSender,
-    ) {
+    pub(super) async fn send(&mut self, packets: Vec<OutboundRaftPacket>, swim_tx: &SwimSender) {
         for (target_id, msgs) in self.group_packets(packets) {
-            self.send_to_target(target_id, msgs, raft_tx, swim_tx).await;
+            self.send_to_target(target_id, msgs, swim_tx).await;
         }
     }
 
@@ -114,7 +109,6 @@ impl RaftRpcDispatcher {
         &mut self,
         target_id: NodeId,
         msgs: Vec<WireRaftMessage>,
-        _raft_tx: &MutlRaftSender,
         swim_tx: &SwimSender,
     ) {
         if let Some(&failed_at) = self.connect_backoffs.get(&target_id) {
@@ -158,33 +152,32 @@ impl RaftRpcDispatcher {
     pub(super) async fn on_dial_result(&mut self, result: DialOutcome, raft_tx: &MutlRaftSender) {
         let DialOutcome { target, outcome } = result;
         let buffered = self.pending_dials.remove(&target).unwrap_or_default();
-        match outcome {
-            Ok((reader, write_half)) => {
-                if self.dead_peers.contains(&target) {
-                    return;
-                }
-                // Mirror `accept`'s tie-break: the connection initiated by
-                // the lower NodeId wins, and we initiated this one. Losing the
-                // tie-break must not lose the buffered messages — deliver them
-                // over the surviving (accepted) connection instead; otherwise
-                // e.g. a buffered RequestVote silently costs a full election
-                // round (#133).
-                if self.writers.contains_key(&target) && self.node_id > target {
-                    if !buffered.is_empty() {
-                        let _ = self.write_messages_to(&target, &buffered).await;
-                    }
-                    return;
-                }
-                self.writers.insert(target.clone(), write_half);
-                tokio::spawn(reader.run(raft_tx.clone()));
-                if !buffered.is_empty() {
-                    let _ = self.write_messages_to(&target, &buffered).await;
-                }
+
+        let Ok((reader, write_half)) = outcome else {
+            self.connect_backoffs.insert(target, Instant::now());
+            return;
+        };
+
+        if self.dead_peers.contains(&target) {
+            return;
+        }
+        // Mirror `accept`'s tie-break: the connection initiated by
+        // the lower NodeId wins, and we initiated this one. Losing the
+        // tie-break must not lose the buffered messages — deliver them
+        // over the surviving (accepted) connection instead; otherwise
+        // e.g. a buffered RequestVote silently costs a full election
+        // round (#133).
+        if self.writers.contains_key(&target) && self.node_id > target {
+            if !buffered.is_empty() {
+                let _ = self.write_messages_to(&target, &buffered).await;
             }
-            Err(err) => {
-                tracing::warn!("{err}");
-                self.connect_backoffs.insert(target, Instant::now());
-            }
+            return;
+        }
+        self.writers.insert(target.clone(), write_half);
+        tokio::spawn(reader.run(raft_tx.clone()));
+
+        if !buffered.is_empty() {
+            let _ = self.write_messages_to(&target, &buffered).await;
         }
     }
 
@@ -234,37 +227,23 @@ impl RaftRpcDispatcher {
 }
 
 /// Resolve, connect (3s cap), and handshake — on a spawned task, so a hung
-/// connect can never block the transport select loop (#133). The loop
+/// connect can never block the transport select loop. The loop
 /// installs the writer and flushes buffered messages in `on_dial_result`.
 async fn dial(
     node_id: NodeId,
     target_id: NodeId,
     swim_tx: SwimSender,
 ) -> anyhow::Result<(RaftRpcListener, OwnedWriteHalf)> {
-    let addr: NodeAddress = match swim_tx.resolve_address(target_id.clone()).await {
-        Ok(Some(addr)) => addr,
-        Ok(None) => anyhow::bail!("[{}] Cannot resolve address for {:?}", node_id, target_id),
-        Err(e) => anyhow::bail!(
-            "[{}] Resolve address for {:?} failed: {e}",
-            node_id,
-            target_id
-        ),
+    let Some(addr) = swim_tx.resolve_address(target_id.clone()).await? else {
+        anyhow::bail!("[{}] Cannot resolve address for {:?}", node_id, target_id);
     };
-    tracing::debug!(node = %node_id, target = %target_id, "transport: dialing");
-    let Some(stream) = tokio::time::timeout(
+
+    let stream = tokio::time::timeout(
         std::time::Duration::from_secs(3),
         TcpStream::connect(addr.cluster_addr()),
     )
-    .await
-    .ok()
-    .and_then(|r| r.ok()) else {
-        anyhow::bail!(
-            "[{}] Failed to connect to {} ({:?})",
-            node_id,
-            addr.cluster_addr(),
-            target_id
-        );
-    };
+    .await??;
+
     let (read_half, mut write_half) = stream.into_split();
     let bytes = bincode::encode_to_vec(&node_id, BINCODE_CONFIG)
         .map_err(|e| anyhow::anyhow!("[{}] Handshake encode failed: {e}", node_id))?;

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -195,7 +195,6 @@ impl RaftRpcDispatcher {
 
     // --- Wire helpers ---
     // On error, writer is removed from the map so subsequent calls reconnect.
-
     /// Encode all messages into a single buffer, write to target's connection.
     async fn write_messages_to(
         &mut self,
@@ -229,6 +228,8 @@ impl RaftRpcDispatcher {
 /// Resolve, connect (3s cap), and handshake — on a spawned task, so a hung
 /// connect can never block the transport select loop. The loop
 /// installs the writer and flushes buffered messages in `on_dial_result`.
+// ! never inline this. Actor Model should onkly do work whose duration it controls.
+// ! Anything whose latency the outside actor controls must not be awaited in the handler.
 async fn dial(
     node_id: NodeId,
     target_id: NodeId,

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -78,7 +78,7 @@ impl RaftRpcDispatcher {
         tokio::spawn(reader.run(raft_tx.clone()));
     }
 
-    pub(super) async fn send(&mut self, packets: Vec<OutboundRaftPacket>, swim_tx: &SwimSender) {
+    pub(super) async fn send(&mut self, packets: Box<[OutboundRaftPacket]>, swim_tx: &SwimSender) {
         for (target_id, msgs) in self.group_packets(packets) {
             self.send_to_target(target_id, msgs, swim_tx).await;
         }
@@ -86,7 +86,7 @@ impl RaftRpcDispatcher {
 
     fn group_packets(
         &self,
-        packets: Vec<OutboundRaftPacket>,
+        packets: Box<[OutboundRaftPacket]>,
     ) -> BTreeMap<NodeId, Vec<WireRaftMessage>> {
         let mut by_target: BTreeMap<NodeId, Vec<WireRaftMessage>> = BTreeMap::new();
         for pkt in packets {

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -78,7 +78,7 @@ impl RaftRpcDispatcher {
         tokio::spawn(reader.run(raft_tx.clone()));
     }
 
-    pub(super) async fn send(&mut self, packets: Box<[OutboundRaftPacket]>, swim_tx: &SwimSender) {
+    pub(super) async fn send(&mut self, packets: Vec<OutboundRaftPacket>, swim_tx: &SwimSender) {
         for (target_id, msgs) in self.group_packets(packets) {
             self.send_to_target(target_id, msgs, swim_tx).await;
         }
@@ -86,7 +86,7 @@ impl RaftRpcDispatcher {
 
     fn group_packets(
         &self,
-        packets: Box<[OutboundRaftPacket]>,
+        packets: Vec<OutboundRaftPacket>,
     ) -> BTreeMap<NodeId, Vec<WireRaftMessage>> {
         let mut by_target: BTreeMap<NodeId, Vec<WireRaftMessage>> = BTreeMap::new();
         for pkt in packets {
@@ -153,7 +153,9 @@ impl RaftRpcDispatcher {
         let DialOutcome { target, outcome } = result;
         let buffered = self.pending_dials.remove(&target).unwrap_or_default();
 
-        let Ok((reader, write_half)) = outcome else {
+        let Ok((reader, write_half)) = outcome.inspect_err(|err| {
+            tracing::warn!(peer = %target, "dial failed: {err}");
+        }) else {
             self.connect_backoffs.insert(target, Instant::now());
             return;
         };

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -84,14 +84,7 @@ impl RaftRpcDispatcher {
         raft_tx: &MutlRaftSender,
         swim_tx: &SwimSender,
     ) {
-        let by_target = self.group_packets(packets);
-        // Dials run on background tasks (see `dial` / `on_dial_result`), so
-        // target order is no longer load-bearing (#133); flushing connected
-        // peers first simply gets wire bytes moving before dial bookkeeping.
-        let (connected, dialing): (Vec<_>, Vec<_>) = by_target
-            .into_iter()
-            .partition(|(target, _)| self.writers.contains_key(target));
-        for (target_id, msgs) in connected.into_iter().chain(dialing) {
+        for (target_id, msgs) in self.group_packets(packets) {
             self.send_to_target(target_id, msgs, raft_tx, swim_tx).await;
         }
     }

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::control_plane::consensus::actor::MutlRaftSender;
@@ -13,6 +14,9 @@ use crate::control_plane::{BINCODE_CONFIG, NodeAddress, NodeId};
 use crate::net::{OwnedWriteHalf, TcpStream};
 
 const CONNECT_BACKOFF: std::time::Duration = std::time::Duration::from_secs(2);
+/// Upper bound on messages buffered per peer while its dial is in flight;
+/// overflow is dropped (raft retries by timer).
+const PENDING_DIAL_BUFFER_CAP: usize = 256;
 
 /// Manages peer connections, address resolution, and dead-peer tracking.
 ///
@@ -33,15 +37,27 @@ pub(super) struct RaftRpcDispatcher {
     /// rapid reconnect storms to dead/unreachable peers that would block
     /// the transport's select loop and stall flush_events in MultiRaftActor.
     connect_backoffs: HashMap<NodeId, Instant>,
+    /// Messages buffered for peers whose connection is being established on a
+    /// background task; flushed (or dropped on failure) in `on_dial_result`.
+    pending_dials: HashMap<NodeId, Vec<WireRaftMessage>>,
+    dial_tx: mpsc::Sender<DialOutcome>,
+}
+
+/// Result of a background dial attempt, delivered back to the transport loop.
+pub(super) struct DialOutcome {
+    target: NodeId,
+    outcome: anyhow::Result<(RaftRpcListener, OwnedWriteHalf)>,
 }
 
 impl RaftRpcDispatcher {
-    pub(super) fn new(node_id: NodeId) -> Self {
+    pub(super) fn new(node_id: NodeId, dial_tx: mpsc::Sender<DialOutcome>) -> Self {
         Self {
             node_id,
             writers: HashMap::new(),
             dead_peers: HashSet::new(),
             connect_backoffs: HashMap::new(),
+            pending_dials: HashMap::new(),
+            dial_tx,
         }
     }
 
@@ -69,7 +85,13 @@ impl RaftRpcDispatcher {
         swim_tx: &SwimSender,
     ) {
         let by_target = self.group_packets(packets);
-        for (target_id, msgs) in by_target {
+        // Dials run on background tasks (see `dial` / `on_dial_result`), so
+        // target order is no longer load-bearing (#133); flushing connected
+        // peers first simply gets wire bytes moving before dial bookkeeping.
+        let (connected, dialing): (Vec<_>, Vec<_>) = by_target
+            .into_iter()
+            .partition(|(target, _)| self.writers.contains_key(target));
+        for (target_id, msgs) in connected.into_iter().chain(dialing) {
             self.send_to_target(target_id, msgs, raft_tx, swim_tx).await;
         }
     }
@@ -77,8 +99,8 @@ impl RaftRpcDispatcher {
     fn group_packets(
         &self,
         packets: Vec<OutboundRaftPacket>,
-    ) -> HashMap<NodeId, Vec<WireRaftMessage>> {
-        let mut by_target: HashMap<NodeId, Vec<WireRaftMessage>> = HashMap::new();
+    ) -> BTreeMap<NodeId, Vec<WireRaftMessage>> {
+        let mut by_target: BTreeMap<NodeId, Vec<WireRaftMessage>> = BTreeMap::new();
         for pkt in packets {
             if self.dead_peers.contains(&pkt.target) {
                 continue;
@@ -99,7 +121,7 @@ impl RaftRpcDispatcher {
         &mut self,
         target_id: NodeId,
         msgs: Vec<WireRaftMessage>,
-        raft_tx: &MutlRaftSender,
+        _raft_tx: &MutlRaftSender,
         swim_tx: &SwimSender,
     ) {
         if let Some(&failed_at) = self.connect_backoffs.get(&target_id) {
@@ -113,73 +135,69 @@ impl RaftRpcDispatcher {
         {
             return;
         }
+        // No usable writer: hand the messages to the in-flight dial (if any)
+        // or start one on a background task. Dials must never run inline — a
+        // hung connect (crashed peer; acceptor starved because *its* loop is
+        // mid-dial) blocks this select loop for the full connect timeout,
+        // stalling every queued batch and the accept arm with it (#133).
+        if let Some(buffered) = self.pending_dials.get_mut(&target_id) {
+            if buffered.len() + msgs.len() <= PENDING_DIAL_BUFFER_CAP {
+                buffered.extend(msgs);
+            }
+            return;
+        }
+        self.pending_dials.insert(target_id.clone(), msgs);
+        let dial_task = dial(self.node_id.clone(), target_id.clone(), swim_tx.clone());
+        let dial_tx = self.dial_tx.clone();
+        tokio::spawn(async move {
+            let outcome = dial_task.await;
+            let _ = dial_tx
+                .send(DialOutcome {
+                    target: target_id,
+                    outcome,
+                })
+                .await;
+        });
+    }
 
-        match self
-            .establish_session(target_id.clone(), msgs, swim_tx)
-            .await
-        {
-            Ok(rpc_listener) => {
-                tokio::spawn(rpc_listener.run(raft_tx.clone()));
+    /// Installs (or discards, per the NodeId tie-break) a completed dial and
+    /// flushes any messages buffered while it was in flight.
+    pub(super) async fn on_dial_result(&mut self, result: DialOutcome, raft_tx: &MutlRaftSender) {
+        let DialOutcome { target, outcome } = result;
+        let buffered = self.pending_dials.remove(&target).unwrap_or_default();
+        match outcome {
+            Ok((reader, write_half)) => {
+                if self.dead_peers.contains(&target) {
+                    return;
+                }
+                // Mirror `accept`'s tie-break: the connection initiated by
+                // the lower NodeId wins, and we initiated this one. Losing the
+                // tie-break must not lose the buffered messages — deliver them
+                // over the surviving (accepted) connection instead; otherwise
+                // e.g. a buffered RequestVote silently costs a full election
+                // round (#133).
+                if self.writers.contains_key(&target) && self.node_id > target {
+                    if !buffered.is_empty() {
+                        let _ = self.write_messages_to(&target, &buffered).await;
+                    }
+                    return;
+                }
+                self.writers.insert(target.clone(), write_half);
+                tokio::spawn(reader.run(raft_tx.clone()));
+                if !buffered.is_empty() {
+                    let _ = self.write_messages_to(&target, &buffered).await;
+                }
             }
             Err(err) => {
                 tracing::warn!("{err}");
-                self.connect_backoffs.insert(target_id, Instant::now());
+                self.connect_backoffs.insert(target, Instant::now());
             }
         }
-    }
-
-    async fn establish_session(
-        &mut self,
-        target_id: NodeId,
-        msgs: Vec<WireRaftMessage>,
-        swim_tx: &SwimSender,
-    ) -> anyhow::Result<RaftRpcListener> {
-        let Some(node_addr) = self.resolve_address(&target_id, swim_tx).await else {
-            anyhow::bail!(
-                "[{}] Cannot resolve address for {:?}",
-                self.node_id,
-                target_id
-            );
-        };
-        // Timeout required: in turmoil (and on dead hosts generally), TcpStream::connect
-        // never returns an error — it hangs forever, stalling the select loop.
-        let Some(stream) = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            TcpStream::connect(node_addr.cluster_addr()),
-        )
-        .await
-        .ok()
-        .and_then(|r| r.ok()) else {
-            anyhow::bail!(
-                "[{}] Failed to connect to {} ({:?})",
-                self.node_id,
-                node_addr.cluster_addr(),
-                target_id
-            );
-        };
-
-        let (read_half, write_half) = stream.into_split();
-        self.writers.insert(target_id.clone(), write_half);
-        if let Err(e) = self.handshake(&target_id).await {
-            anyhow::bail!(
-                "[{}] Handshake with {:?} failed: {e}",
-                self.node_id,
-                target_id
-            );
-        }
-        if let Err(e) = self.write_messages_to(&target_id, &msgs).await {
-            anyhow::bail!(
-                "[{}] Write {} msgs to {:?} failed: {e}",
-                self.node_id,
-                msgs.len(),
-                target_id
-            );
-        }
-        Ok(RaftRpcListener(read_half))
     }
 
     pub(super) fn disconnect(&mut self, peer_id: NodeId) {
         self.writers.remove(&peer_id);
+        self.pending_dials.remove(&peer_id);
         tracing::info!("[{}] Disconnected dead peer {:?}", self.node_id, peer_id);
         self.dead_peers.insert(peer_id);
     }
@@ -189,38 +207,8 @@ impl RaftRpcDispatcher {
         self.connect_backoffs.clear();
     }
 
-    async fn resolve_address(&self, node_id: &NodeId, swim_tx: &SwimSender) -> Option<NodeAddress> {
-        match swim_tx.resolve_address(node_id.clone()).await {
-            Ok(addr) => addr,
-            Err(e) => {
-                tracing::debug!("Resolve address for {:?} failed: {e}", node_id);
-                None
-            }
-        }
-    }
-
     // --- Wire helpers ---
     // On error, writer is removed from the map so subsequent calls reconnect.
-
-    /// Send handshake (our NodeId) to a writer already in the map.
-    async fn handshake(&mut self, target: &NodeId) -> std::io::Result<()> {
-        let writer = self.writers.get_mut(target).ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::NotConnected, "no writer for target")
-        })?;
-        let bytes = bincode::encode_to_vec(&self.node_id, BINCODE_CONFIG)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let len = bytes.len() as u32;
-        let result = async {
-            writer.write_all(&len.to_be_bytes()).await?;
-            writer.write_all(&bytes).await
-        }
-        .await;
-
-        if result.is_err() {
-            self.writers.remove(target);
-        }
-        result
-    }
 
     /// Encode all messages into a single buffer, write to target's connection.
     async fn write_messages_to(
@@ -250,4 +238,45 @@ impl RaftRpcDispatcher {
     pub fn contains(&self, node_id: &NodeId) -> bool {
         self.writers.contains_key(node_id)
     }
+}
+
+/// Resolve, connect (3s cap), and handshake — on a spawned task, so a hung
+/// connect can never block the transport select loop (#133). The loop
+/// installs the writer and flushes buffered messages in `on_dial_result`.
+async fn dial(
+    node_id: NodeId,
+    target_id: NodeId,
+    swim_tx: SwimSender,
+) -> anyhow::Result<(RaftRpcListener, OwnedWriteHalf)> {
+    let addr: NodeAddress = match swim_tx.resolve_address(target_id.clone()).await {
+        Ok(Some(addr)) => addr,
+        Ok(None) => anyhow::bail!("[{}] Cannot resolve address for {:?}", node_id, target_id),
+        Err(e) => anyhow::bail!(
+            "[{}] Resolve address for {:?} failed: {e}",
+            node_id,
+            target_id
+        ),
+    };
+    tracing::debug!(node = %node_id, target = %target_id, "transport: dialing");
+    let Some(stream) = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        TcpStream::connect(addr.cluster_addr()),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok()) else {
+        anyhow::bail!(
+            "[{}] Failed to connect to {} ({:?})",
+            node_id,
+            addr.cluster_addr(),
+            target_id
+        );
+    };
+    let (read_half, mut write_half) = stream.into_split();
+    let bytes = bincode::encode_to_vec(&node_id, BINCODE_CONFIG)
+        .map_err(|e| anyhow::anyhow!("[{}] Handshake encode failed: {e}", node_id))?;
+    let len = bytes.len() as u32;
+    write_half.write_all(&len.to_be_bytes()).await?;
+    write_half.write_all(&bytes).await?;
+    Ok((RaftRpcListener(read_half), write_half))
 }

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -164,9 +164,7 @@ impl RaftRpcDispatcher {
         // Mirror `accept`'s tie-break: the connection initiated by
         // the lower NodeId wins, and we initiated this one. Losing the
         // tie-break must not lose the buffered messages — deliver them
-        // over the surviving (accepted) connection instead; otherwise
-        // e.g. a buffered RequestVote silently costs a full election
-        // round (#133).
+        // over the surviving (accepted) connection instead;
         if self.writers.contains_key(&target) && self.node_id > target {
             if !buffered.is_empty() {
                 let _ = self.write_messages_to(&target, &buffered).await;

--- a/src/control_plane/membership/actor.rs
+++ b/src/control_plane/membership/actor.rs
@@ -131,9 +131,9 @@ impl SwimActor {
         }
         tokio::join!(
             self.transport_tx
-                .send_batch(std::mem::take(&mut self.packets)),
+                .send_batch(std::mem::take(&mut self.packets).into_boxed_slice()),
             self.scheduler_tx
-                .send_batch(std::mem::take(&mut self.timer_cmds)),
+                .send_batch(std::mem::take(&mut self.timer_cmds).into_boxed_slice()),
         );
     }
 }

--- a/src/control_plane/membership/topology.rs
+++ b/src/control_plane/membership/topology.rs
@@ -108,6 +108,21 @@ impl TopologyReader {
             .collect()
     }
 
+    pub(crate) fn resolve_nodes_in_group(
+        &self,
+        node_id: &NodeId,
+        shard_group_id: ShardGroupId,
+    ) -> Option<Box<[NodeId]>> {
+        if let Some(group) = self
+            .shard_groups_for_node(node_id)
+            .into_iter()
+            .find(|g| g.id == shard_group_id)
+        {
+            return Some(group.members.into_boxed_slice());
+        };
+        None
+    }
+
     pub(crate) fn ring_replacements_for(
         &self,
         group_id: ShardGroupId,

--- a/src/control_plane/membership/topology.rs
+++ b/src/control_plane/membership/topology.rs
@@ -99,7 +99,7 @@ impl TopologyReader {
         self.0.load().live_nodes()
     }
 
-    pub(crate) fn shard_groups_for_node(&self, node_id: &NodeId) -> Vec<ShardGroup> {
+    pub(crate) fn shard_groups_for_node(&self, node_id: &NodeId) -> Box<[ShardGroup]> {
         self.0
             .load()
             .shard_groups_for_node(node_id)
@@ -128,7 +128,7 @@ impl TopologyReader {
         group_id: ShardGroupId,
         excluded: &HashSet<NodeId>,
         count: usize,
-    ) -> Vec<NodeId> {
+    ) -> Box<[NodeId]> {
         let replacements = self
             .0
             .load()
@@ -357,9 +357,9 @@ impl Topology {
         group_id: ShardGroupId,
         excluded: &HashSet<NodeId>,
         count: usize,
-    ) -> Vec<NodeId> {
+    ) -> Box<[NodeId]> {
         if count == 0 || self.vnodes.is_empty() {
-            return Vec::new();
+            return Box::new([]);
         }
         let anchor = group_id.0 as u32;
         self.collect_distinct_owners_excluding(anchor, count, excluded)
@@ -1046,7 +1046,7 @@ mod tests {
 
         let current: HashSet<NodeId> = group.members.iter().cloned().collect();
         let picks = topology.ring_replacements_for(group.id, &current, 2);
-        assert_eq!(picks.as_slice(), expected_successors);
+        assert_eq!(&*picks, expected_successors);
     }
 
     // --- shard leader map tests ---

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -31,7 +31,7 @@ impl MetadataStateMachine {
             .and_then(|id| self.topics.get(id))
     }
 
-    pub(crate) fn topic_names(&self) -> Vec<String> {
+    pub(crate) fn topic_names(&self) -> Box<[String]> {
         self.topic_name_index.keys().cloned().collect()
     }
 
@@ -39,18 +39,18 @@ impl MetadataStateMachine {
         self.topics.len()
     }
 
-    pub(crate) fn topic_stats(&self) -> Vec<TopicStats> {
+    pub(crate) fn topic_stats(&self) -> Box<[TopicStats]> {
         self.topics.values().map(|t| t.stats()).collect()
     }
 
-    pub(crate) fn take_pending_proposals(&mut self) -> Vec<MetadataCommand> {
-        std::mem::take(&mut self.pending_proposals)
+    pub(crate) fn take_pending_proposals(&mut self) -> Box<[MetadataCommand]> {
+        std::mem::take(&mut self.pending_proposals).into_boxed_slice()
     }
 
     pub(crate) fn active_segments_for_node(
         &self,
         node_id: &NodeId,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         self.topics
             .values()
             .flat_map(|t| t.active_segments_for_node(node_id))
@@ -59,7 +59,7 @@ impl MetadataStateMachine {
 
     /// Every active segment across all topics with its replica set and start
     /// offset, for the leader's periodic assignment re-drive.
-    pub(crate) fn active_segment_assignments(&self) -> Vec<(SegmentKey, ReplicaSet, u64)> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
         self.topics
             .values()
             .flat_map(|t| t.active_segment_assignments())
@@ -71,7 +71,7 @@ impl MetadataStateMachine {
     pub(crate) fn active_segments_with_dead_members(
         &self,
         live: &HashSet<NodeId>,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         self.topics
             .values()
             .flat_map(|t| t.active_segments_with_dead_members(live))

--- a/src/control_plane/metadata/topic.rs
+++ b/src/control_plane/metadata/topic.rs
@@ -91,9 +91,9 @@ impl TopicMeta {
     pub(crate) fn active_segments_for_node(
         &self,
         node_id: &NodeId,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         if self.state != TopicState::Active {
-            return Vec::new();
+            return Box::new([]);
         }
         self.active_ranges
             .iter()
@@ -113,9 +113,9 @@ impl TopicMeta {
     /// the leader's periodic assignment re-drive. Returns `(key, replica_set,
     /// start_offset)` so a re-driven `SegmentAssignment` can recreate a segment
     /// that missed its one-shot delivery with the correct starting offset.
-    pub(crate) fn active_segment_assignments(&self) -> Vec<(SegmentKey, ReplicaSet, u64)> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
         if self.state != TopicState::Active {
-            return Vec::new();
+            return Box::new([]);
         }
         self.active_ranges
             .iter()
@@ -135,9 +135,9 @@ impl TopicMeta {
     pub(crate) fn active_segments_with_dead_members(
         &self,
         live: &std::collections::HashSet<NodeId>,
-    ) -> Vec<(SegmentKey, ReplicaSet)> {
+    ) -> Box<[(SegmentKey, ReplicaSet)]> {
         if self.state != TopicState::Active {
-            return Vec::new();
+            return Box::new([]);
         }
         self.active_ranges
             .iter()
@@ -412,7 +412,7 @@ pub mod props {
             if self.active_ranges.is_empty() {
                 return;
             }
-            let ranges: Vec<&RangeMeta> = self
+            let ranges: Box<[&RangeMeta]> = self
                 .active_ranges
                 .iter()
                 .map(|id| &self.ranges[id])

--- a/src/data_plane/messages/pending.rs
+++ b/src/data_plane/messages/pending.rs
@@ -65,7 +65,7 @@ impl DataPlaneOutputs {
         self.batch_scheduler
             .blocking_send_batch(self.batch_timer_cmds.drain(..).collect());
 
-        let repl_cmds: Vec<TimerCommand<ReplicationTimer>> = self
+        let repl_cmds: Box<[TimerCommand<ReplicationTimer>]> = self
             .repl_schedules
             .drain(..)
             .map(|(seq, timer)| TimerCommand::SetSchedule { seq, timer })
@@ -73,7 +73,7 @@ impl DataPlaneOutputs {
 
         self.repl_scheduler.blocking_send_batch(repl_cmds);
         self.transport_tx
-            .blocking_send_batch(std::mem::take(&mut self.transport_cmds));
+            .blocking_send_batch(std::mem::take(&mut self.transport_cmds).into_boxed_slice());
     }
 
     pub(crate) fn store_transport_cmd(&mut self, cmd: impl Into<DataTransportCommand>) {

--- a/src/data_plane/transport/command.rs
+++ b/src/data_plane/transport/command.rs
@@ -5,7 +5,7 @@ use crate::impl_from_variant;
 
 #[derive(Debug)]
 pub(crate) struct DataTransportSendToTargets {
-    pub targets: Vec<NodeId>,
+    pub targets: Box<[NodeId]>,
     pub message: DataPlaneInterNodeCommand,
 }
 
@@ -36,7 +36,7 @@ impl DataTransportCommand {
         message: impl Into<DataPlaneInterNodeCommand>,
     ) -> Self {
         Self::SendToTargets(DataTransportSendToTargets {
-            targets,
+            targets: targets.into_boxed_slice(),
             message: message.into(),
         })
     }

--- a/src/impls/metadata_storage.rs
+++ b/src/impls/metadata_storage.rs
@@ -197,8 +197,8 @@ impl RaftStorage for MetadataStorage {
         self.take_persistent_state_for(group_id)
     }
 
-    fn persist_mutations(&self, mutations: Vec<(ShardGroupId, LogMutation)>) {
-        let batch: Vec<DbOp> = mutations
+    fn persist_mutations(&self, mutations: Box<[(ShardGroupId, LogMutation)]>) {
+        let batch: Box<[DbOp]> = mutations
             .into_iter()
             .map(|(id, log)| DbOp::from_log(&id, log))
             .collect();
@@ -310,7 +310,7 @@ mod tests {
         let g1 = ShardGroupId(1);
         let g2 = ShardGroupId(2);
 
-        db.persist_mutations(vec![
+        db.persist_mutations(Box::new([
             (g1, LogMutation::Append(noop_entry(1, 1))),
             (
                 g1,
@@ -328,7 +328,7 @@ mod tests {
                     voted_for: Some(NodeId::new("n2")),
                 },
             ),
-        ]);
+        ]));
 
         let state1 = db.load_state(1);
         assert_eq!(state1.log.len(), 1, "group 1 must have exactly 1 entry");
@@ -357,7 +357,7 @@ mod tests {
         let (db, _path) = temp_db();
         let g = ShardGroupId(1);
 
-        db.persist_mutations(vec![
+        db.persist_mutations(Box::new([
             (g, LogMutation::Append(noop_entry(1, 5))),
             (g, LogMutation::Append(noop_entry(2, 5))),
             (g, LogMutation::Append(noop_entry(3, 5))),
@@ -368,14 +368,14 @@ mod tests {
                     voted_for: Some(NodeId::new("n1")),
                 },
             ),
-        ]);
+        ]));
 
         let before = db.load_state(1);
         assert_eq!(before.log.len(), 3);
         assert_eq!(before.term, 5);
         assert_eq!(before.voted_for, Some(NodeId::new("n1")));
 
-        db.persist_mutations(vec![(g, LogMutation::TruncateFrom(2))]);
+        db.persist_mutations(Box::new([(g, LogMutation::TruncateFrom(2))]));
 
         let after = db.load_state(1);
         assert_eq!(after.log.len(), 1, "only entry 1 should remain");

--- a/src/it/raft/election.rs
+++ b/src/it/raft/election.rs
@@ -121,7 +121,7 @@ async fn run_raft_node(
         .collect();
     let topology_reader = super::stub_topology_reader(&all_nodes);
     MultiRaftActor::spawn(
-        ticker_force.clone().into(),
+        ticker_force.clone(),
         raft_mailbox,
         node_id,
         election_jitter_seed,

--- a/src/it/raft/election.rs
+++ b/src/it/raft/election.rs
@@ -44,7 +44,9 @@ fn build_address_map(
 
 async fn drive_ticks(ticker: &SchedulerSender<RaftTimer>, count: usize) {
     for _ in 0..count {
-        let _ = ticker.send_batch(vec![TickerCommand::ForceTick]).await;
+        let _ = ticker
+            .send_batch(Box::new([TickerCommand::ForceTick]))
+            .await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::task::yield_now().await;

--- a/src/it/raft/leader_event.rs
+++ b/src/it/raft/leader_event.rs
@@ -134,7 +134,7 @@ fn leader_election_emits_leader_change_event() -> turmoil::Result {
                     std::iter::once(name).chain(peers.iter().copied()).collect();
                 let topology_reader = super::stub_topology_reader(&all_nodes);
                 MultiRaftActor::spawn(
-                    ticker_tx.clone().into(),
+                    ticker_tx.clone(),
                     raft_mailbox,
                     node_id,
                     election_jitter_seed,

--- a/src/it/raft/membership_change.rs
+++ b/src/it/raft/membership_change.rs
@@ -106,7 +106,7 @@ async fn start_raft_node(
     for _ in 0..200 {
         let _ = ticker_tx
             .clone()
-            .send_batch(vec![TickerCommand::ForceTick])
+            .send_batch(Box::new([TickerCommand::ForceTick]))
             .await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -118,7 +118,9 @@ async fn start_raft_node(
 
 async fn tick_n(ticker: &SchedulerSender<RaftTimer>, n: usize) {
     for _ in 0..n {
-        let _ = ticker.send_batch(vec![TickerCommand::ForceTick]).await;
+        let _ = ticker
+            .send_batch(Box::new([TickerCommand::ForceTick]))
+            .await;
         tokio::task::yield_now().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::task::yield_now().await;

--- a/src/it/sim/invariants.rs
+++ b/src/it/sim/invariants.rs
@@ -109,6 +109,53 @@ pub async fn assert_single_leader(
     Ok(())
 }
 
+/// Polls `GetShardLeader` on every node until **all** report the same leader,
+/// which must differ from `crashed` — or panics when `budget` elapses,
+/// printing the last set of views.
+///
+/// Unlike [`assert_single_leader`] with a zero grace, this absorbs *stale*
+/// views: right after a re-election one node can still hold the previous
+/// term's leader in `current_leader`, which is not split-brain. The admin API
+/// exposes no term, so a single snapshot cannot distinguish a stale view from
+/// same-term divergence — persistent disagreement past the deadline is the
+/// observable signal, and that is what this asserts (#133).
+pub async fn assert_leader_converges(
+    nodes: &[(&str, u16)],
+    shard_group_id: u64,
+    crashed: &str,
+    budget: Duration,
+) -> turmoil::Result {
+    let deadline = tokio::time::Instant::now() + budget;
+    let mut views: Vec<Option<String>> = Vec::new();
+    loop {
+        views.clear();
+        for &(host, port) in nodes {
+            views.push(
+                query_shard_leader(host, port, shard_group_id)
+                    .await
+                    .ok()
+                    .flatten(),
+            );
+        }
+        let known: Vec<&String> = views.iter().flatten().collect();
+        if known.len() == nodes.len()
+            && known.iter().all(|l| *l == known[0])
+            && known[0].as_str() != crashed
+        {
+            return Ok(());
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "shard {}: nodes did not converge on a single replacement leader within {:?} (views: {:?}, crashed: {:?})",
+            shard_group_id,
+            budget,
+            views,
+            crashed
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 /// After `CreateTopic` has been acked, retries `GetTopics` across alive nodes until
 /// a quorum (majority) report the topic or `max_attempts` is exhausted.
 ///

--- a/src/it/sim/invariants.rs
+++ b/src/it/sim/invariants.rs
@@ -240,7 +240,7 @@ pub(super) async fn query_shard_info(
     }
 }
 
-pub(super) async fn query_topics(host: &str, port: u16) -> turmoil::Result<Vec<TopicSummary>> {
+pub(super) async fn query_topics(host: &str, port: u16) -> turmoil::Result<Box<[TopicSummary]>> {
     let stream =
         tokio::time::timeout(Duration::from_secs(2), TcpStream::connect((host, port))).await??;
     let (read_half, write_half) = stream.into_split();
@@ -256,6 +256,6 @@ pub(super) async fn query_topics(host: &str, port: u16) -> turmoil::Result<Vec<T
         tokio::time::timeout(Duration::from_secs(3), reader.read_request()).await??;
     match response {
         ClientResponse::ControlPlane(ControlPlaneResponse::TopicList { topics }) => Ok(topics),
-        _ => Ok(vec![]),
+        _ => Ok(Box::new([])),
     }
 }

--- a/src/it/sim/properties.rs
+++ b/src/it/sim/properties.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::time::Duration;
 
 use turmoil::Builder;
@@ -5,22 +7,60 @@ use turmoil::Builder;
 use crate::StartUp;
 use crate::it::helpers::{check_alive_count, check_dead_or_not_exist, default_env};
 use crate::it::sim::invariants::{
-    assert_membership_converged, assert_single_leader, assert_topic_visible_on_quorum,
-    query_shard_info, query_shard_leader,
+    assert_leader_converges, assert_membership_converged, assert_single_leader,
+    assert_topic_visible_on_quorum, query_shard_info, query_shard_leader,
 };
 use crate::it::sim::scenario::{
     client_port, cluster_port, make_create_topic_req, node_name, try_propose,
 };
 
-fn three_node_sim(simulation_secs: u64) -> turmoil::Sim<'static> {
+/// One seed per run for both the turmoil rng and every node's `StartUp` rng
+/// (#133): a failing run prints it, and `EG_SIM_SEED=<seed>` replays the exact
+/// schedule, latencies, fault interleaving — and, because the seed is threaded
+/// into `spawn_node`, the same per-node election-jitter sequences. Previously
+/// every node in every run got `rng_seed = 0`, so the jitter sequences were
+/// identical across an entire stress sweep and only network latency varied.
+/// Timestamps tracing output with turmoil's simulated clock so replay logs
+/// read in sim seconds instead of (compressed) wall time. Lines emitted
+/// outside a sim context (e.g. the driver thread) print `--`.
+struct SimTime;
+
+impl tracing_subscriber::fmt::time::FormatTime for SimTime {
+    fn format_time(
+        &self,
+        w: &mut tracing_subscriber::fmt::format::Writer<'_>,
+    ) -> std::fmt::Result {
+        match turmoil::sim_elapsed() {
+            Some(t) => write!(w, "[sim {:>9.4}s]", t.as_secs_f64()),
+            None => write!(w, "[sim        --]"),
+        }
+    }
+}
+
+fn sim_seed() -> u64 {
+    let seed: u64 = std::env::var("EG_SIM_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos() as u64
+        });
+    println!("turmoil seed: {seed} (replay with EG_SIM_SEED={seed})");
+    seed
+}
+
+fn three_node_sim(simulation_secs: u64, seed: u64) -> turmoil::Sim<'static> {
     Builder::new()
         .tick_duration(Duration::from_millis(100))
         .simulation_duration(Duration::from_secs(simulation_secs))
         .tcp_capacity(4096)
+        .rng_seed(seed)
         .build()
 }
 
-fn spawn_node(sim: &mut turmoil::Sim<'static>, i: u8, total: u8) {
+fn spawn_node(sim: &mut turmoil::Sim<'static>, i: u8, total: u8, seed: u64) {
     let cp = client_port(i);
     let rp = cluster_port(i);
     sim.host(node_name(i), move || async move {
@@ -40,7 +80,7 @@ fn spawn_node(sim: &mut turmoil::Sim<'static>, i: u8, total: u8) {
         env.advertise_host = Some(me.to_string());
         env.join_seed_nodes = seeds;
         env.vnodes_per_node = 3;
-        StartUp::with_env(env, 0).run().await?;
+        StartUp::with_env(env, seed).run().await?;
         Ok(())
     });
 }
@@ -51,10 +91,12 @@ fn spawn_node(sim: &mut turmoil::Sim<'static>, i: u8, total: u8) {
 fn metadata_visible() -> turmoil::Result {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_timer(SimTime)
         .try_init();
-    let mut sim = three_node_sim(90);
+    let seed = sim_seed();
+    let mut sim = three_node_sim(90, seed);
     for i in 1..=3u8 {
-        spawn_node(&mut sim, i, 3);
+        spawn_node(&mut sim, i, 3, seed);
     }
 
     sim.client("checker", async {
@@ -86,83 +128,207 @@ fn metadata_visible() -> turmoil::Result {
     sim.run()
 }
 
-/// After `CreateTopic` is acked, a killed leader is replaced by a new one within 30s.
-/// The two surviving nodes must agree on the same leader (no split-brain).
+/// After the **current leader** of the topic's shard group is crashed, the
+/// surviving nodes elect a replacement and converge on it (no split-brain).
+///
+/// Rewritten for #133. The previous version had three structural problems:
+///
+/// 1. Vacuous in ~2/3 of runs: it crashed a fixed `node-1` at a fixed t=20s
+///    and accepted any leader `!starts_with("node-1")` — already true *before*
+///    the crash whenever node-2/3 won the initial election, so the checker
+///    completed without testing re-election at all.
+/// 2. Iteration-bounded polling: the helpers' inner connect/read timeouts
+///    (2s/3-5s) stretched the nominal "30s" loops far past their budget, so
+///    the sim hit its duration ceiling before any assert fired — producing
+///    bare `Ran for duration` failures with no diagnostic.
+/// 3. Time-gated crash: t=20s raced slow bootstraps, sometimes killing the
+///    node mid-initial-election — a different scenario than intended.
+///
+/// Structure now (every phase is bounded by a *sim-time deadline* and fails
+/// with its own labeled message; the 180s envelope is only a backstop):
+///
+/// - Phase 1 (≤30s): topology resolved and an initial leader agreed by ≥2
+///   nodes; its host index is published to the driver. A `CreateTopic` is
+///   also proposed to exercise the write path, but not asserted on (a lost
+///   ack makes the duplicate retry rejectable; `metadata_visible` covers
+///   creation semantics).
+/// - Driver: steps until the victim is published, allows 3s of steady state,
+///   crashes that host, then signals the checker.
+/// - Phase 2 (≤40s from the crash): a survivor reports a leader different
+///   from the crashed one. Budget: SWIM death detection (~6-7s) + election
+///   timeout (5-7s base+jitter) + a few pessimal split-vote rounds.
+/// - Phase 3 (≤10s): both survivors converge on the same replacement.
+///   `assert_leader_converges` absorbs *stale previous-term views*, which
+///   `assert_single_leader(.., Duration::ZERO)` would misread as split-brain.
 #[test]
 #[serial_test::serial]
 fn leader_elects_after_kill() -> turmoil::Result {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_timer(SimTime)
         .try_init();
-    let mut sim = three_node_sim(120);
+    let seed = sim_seed();
+    let mut sim = three_node_sim(180, seed);
     for i in 1..=3u8 {
-        spawn_node(&mut sim, i, 3);
+        spawn_node(&mut sim, i, 3, seed);
     }
 
-    sim.client("checker", async {
-        // Wait for leader election then create a topic (up to 30s).
+    // Checker → driver: host index (1..=3) of the discovered leader; 0 = unset.
+    let victim = Arc::new(AtomicU8::new(0));
+    // Driver → checker: set once the crash has been performed.
+    let crashed = Arc::new(AtomicBool::new(false));
+
+    let victim_tx = victim.clone();
+    let crashed_rx = crashed.clone();
+    sim.client("checker", async move {
+        let t0 = tokio::time::Instant::now();
+
+        // ── Phase 1: topology + an initial leader agreed by ≥2 nodes ──
         let req = make_create_topic_req("leader-kill-test");
+        let phase1_deadline = t0 + Duration::from_secs(30);
         let mut shard_group_id: Option<u64> = None;
-        for _ in 0..30u32 {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            for i in 1..=3u8 {
-                if let Some(crate::connections::protocol::ControlPlaneResponse::TopicCreated) =
-                    try_propose(&node_name(i), client_port(i), &req).await
-                {
-                    break;
+        let mut topic_acked = false;
+        let mut agreed_leader: Option<String> = None;
+        let mut last_round: Vec<Option<String>> = vec![None, None, None];
+        while tokio::time::Instant::now() < phase1_deadline {
+            if shard_group_id.is_none() {
+                shard_group_id =
+                    query_shard_info(&node_name(2), client_port(2), b"leader-kill-test")
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|info| info.shard_group_id);
+            }
+            if !topic_acked {
+                for i in 1..=3u8 {
+                    if let Some(crate::connections::protocol::ControlPlaneResponse::TopicCreated) =
+                        try_propose(&node_name(i), client_port(i), &req).await
+                    {
+                        topic_acked = true;
+                        break;
+                    }
                 }
             }
-            // Learn the shard group id once the topology is populated.
-            if let Ok(Some(info)) = query_shard_info("node-2", 8082, b"leader-kill-test").await {
-                shard_group_id = Some(info.shard_group_id);
+            if let Some(gid) = shard_group_id {
+                // Act only on a leader reported identically by at least two
+                // nodes, so one node's transient view can't pick the victim.
+                for (slot, i) in (1..=3u8).enumerate() {
+                    last_round[slot] = query_shard_leader(&node_name(i), client_port(i), gid)
+                        .await
+                        .ok()
+                        .flatten();
+                }
+                let mut views: Vec<String> = last_round.iter().flatten().cloned().collect();
+                views.sort();
+                agreed_leader = views
+                    .windows(2)
+                    .find(|w| w[0] == w[1])
+                    .map(|w| w[0].clone());
+            }
+            if agreed_leader.is_some() {
                 break;
             }
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
-        let shard_group_id = shard_group_id.expect("topology not populated within 30s");
-
-        // node-1 is crashed at t≈20s from the test thread.
-        // Sleep until we are safely past the crash, then assert re-election.
-        tokio::time::sleep(Duration::from_secs(10)).await; // ensures we are past t=20s
-
-        // Retry until at least one surviving node reports a leader that isn't node-1.
-        // Transient query errors (e.g. inner connect/read timeouts firing while the
-        // surviving nodes are mid-election) are treated as "no leader yet" — the
-        // whole point of this loop is to absorb such transients during convergence.
-        let mut elected = false;
-        for _ in 0..300u32 {
-            let l2 = query_shard_leader("node-2", 8082, shard_group_id)
-                .await
-                .ok()
-                .flatten();
-            let l3 = query_shard_leader("node-3", 8083, shard_group_id)
-                .await
-                .ok()
-                .flatten();
-            let any_new = [&l2, &l3]
-                .into_iter()
-                .flatten()
-                .any(|l| !l.starts_with("node-1"));
-            if any_new {
-                elected = true;
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert!(
-            elected,
-            "no new leader elected within 30s after killing node-1"
+        let shard_group_id =
+            shard_group_id.unwrap_or_else(|| panic!("phase1: topology not populated within 30s"));
+        let initial_leader = agreed_leader.unwrap_or_else(|| {
+            panic!(
+                "phase1: no quorum-agreed leader within 30s \
+                 (shard {shard_group_id}, topic_acked: {topic_acked}, \
+                 last views from node-1..3: {last_round:?})"
+            )
+        });
+        let victim_idx = (1..=3u8)
+            .find(|i| initial_leader.starts_with(node_name(*i).as_str()))
+            .unwrap_or_else(|| panic!("leader id {initial_leader:?} maps to no known host"));
+        tracing::info!(
+            elapsed = ?t0.elapsed(),
+            shard_group_id,
+            %initial_leader,
+            victim_idx,
+            topic_acked,
+            "phase1 done"
         );
+        victim_tx.store(victim_idx, Ordering::SeqCst);
 
-        let survivors: &[(&str, u16)] = &[("node-2", 8082), ("node-3", 8083)];
-        assert_single_leader(survivors, shard_group_id, Duration::ZERO).await?;
+        // Wait for the driver to perform the crash (it gates on the store above).
+        let crash_signal_deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        while !crashed_rx.load(Ordering::SeqCst) {
+            assert!(
+                tokio::time::Instant::now() < crash_signal_deadline,
+                "driver did not signal the crash within 15s"
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        let survivors: Vec<u8> = (1..=3u8).filter(|i| *i != victim_idx).collect();
+        let survivor_names: Vec<String> = survivors.iter().map(|i| node_name(*i)).collect();
+
+        // ── Phase 2: a survivor reports a replacement leader ──
+        let phase2_deadline = tokio::time::Instant::now() + Duration::from_secs(40);
+        let mut last_views: Vec<Option<String>> = vec![None; survivors.len()];
+        let mut replacement: Option<String> = None;
+        'phase2: while tokio::time::Instant::now() < phase2_deadline {
+            for (slot, (i, name)) in survivors.iter().zip(survivor_names.iter()).enumerate() {
+                let view = query_shard_leader(name, client_port(*i), shard_group_id)
+                    .await
+                    .ok()
+                    .flatten();
+                if let Some(l) = &view
+                    && l != &initial_leader
+                {
+                    replacement = Some(l.clone());
+                    break 'phase2;
+                }
+                last_views[slot] = view;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        let replacement = replacement.unwrap_or_else(|| {
+            panic!(
+                "phase2: no replacement leader within 40s after crashing {initial_leader:?} \
+                 (last views from {survivor_names:?}: {last_views:?})"
+            )
+        });
+        assert!(
+            survivor_names
+                .iter()
+                .any(|n| replacement.starts_with(n.as_str())),
+            "phase2: replacement leader {replacement:?} is not a survivor {survivor_names:?}"
+        );
+        tracing::info!(elapsed = ?t0.elapsed(), %replacement, "phase2 done");
+
+        // ── Phase 3: survivors converge on the replacement ──
+        let nodes: Vec<(&str, u16)> = survivors
+            .iter()
+            .zip(survivor_names.iter())
+            .map(|(i, n)| (n.as_str(), client_port(*i)))
+            .collect();
+        assert_leader_converges(&nodes, shard_group_id, &initial_leader, Duration::from_secs(10))
+            .await?;
+        // Converged views also satisfy the split-brain invariant by definition.
+        assert_single_leader(&nodes, shard_group_id, Duration::ZERO).await?;
         Ok(())
     });
 
-    // Crash node-1 at t≈20s.
-    while sim.elapsed() < Duration::from_secs(20) {
+    // ── Driver: phase-gate the crash on the checker's discovery ──
+    while victim.load(Ordering::SeqCst) == 0 {
+        assert!(
+            sim.elapsed() < Duration::from_secs(45),
+            "driver: checker published no leader within 45s of sim time"
+        );
         sim.step()?;
     }
-    sim.crash("node-1");
+    let victim_idx = victim.load(Ordering::SeqCst);
+    // A few seconds of steady state so the kill hits an established leader.
+    let crash_at = sim.elapsed() + Duration::from_secs(3);
+    while sim.elapsed() < crash_at {
+        sim.step()?;
+    }
+    tracing::info!(elapsed = ?sim.elapsed(), host = %node_name(victim_idx), "crashing leader");
+    sim.crash(node_name(victim_idx).as_str());
+    crashed.store(true, Ordering::SeqCst);
 
     sim.run()
 }
@@ -173,10 +339,12 @@ fn leader_elects_after_kill() -> turmoil::Result {
 fn membership_converges_after_rejoin() -> turmoil::Result {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_timer(SimTime)
         .try_init();
-    let mut sim = three_node_sim(120);
+    let seed = sim_seed();
+    let mut sim = three_node_sim(120, seed);
     for i in 1..=3u8 {
-        spawn_node(&mut sim, i, 3);
+        spawn_node(&mut sim, i, 3, seed);
     }
 
     sim.client("checker", async {

--- a/src/it/sim/properties.rs
+++ b/src/it/sim/properties.rs
@@ -26,10 +26,7 @@ use crate::it::sim::scenario::{
 struct SimTime;
 
 impl tracing_subscriber::fmt::time::FormatTime for SimTime {
-    fn format_time(
-        &self,
-        w: &mut tracing_subscriber::fmt::format::Writer<'_>,
-    ) -> std::fmt::Result {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
         match turmoil::sim_elapsed() {
             Some(t) => write!(w, "[sim {:>9.4}s]", t.as_secs_f64()),
             None => write!(w, "[sim        --]"),
@@ -225,7 +222,8 @@ fn leader_elects_after_kill() -> turmoil::Result {
                     .find(|w| w[0] == w[1])
                     .map(|w| w[0].clone());
             }
-            if agreed_leader.is_some() {
+
+            if topic_acked && agreed_leader.is_some() {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
@@ -239,6 +237,14 @@ fn leader_elects_after_kill() -> turmoil::Result {
                  last views from node-1..3: {last_round:?})"
             )
         });
+
+        assert!(
+            topic_acked,
+            "phase1: CreateTopic never acked within 30s \
+             (shard {shard_group_id}, leader {initial_leader}, \
+             last views from node-1..3: {last_round:?})"
+        );
+
         let victim_idx = (1..=3u8)
             .find(|i| initial_leader.starts_with(node_name(*i).as_str()))
             .unwrap_or_else(|| panic!("leader id {initial_leader:?} maps to no known host"));
@@ -305,8 +311,13 @@ fn leader_elects_after_kill() -> turmoil::Result {
             .zip(survivor_names.iter())
             .map(|(i, n)| (n.as_str(), client_port(*i)))
             .collect();
-        assert_leader_converges(&nodes, shard_group_id, &initial_leader, Duration::from_secs(10))
-            .await?;
+        assert_leader_converges(
+            &nodes,
+            shard_group_id,
+            &initial_leader,
+            Duration::from_secs(10),
+        )
+        .await?;
         // Converged views also satisfy the split-brain invariant by definition.
         assert_single_leader(&nodes, shard_group_id, Duration::ZERO).await?;
         Ok(())

--- a/src/schedulers/ticker_message.rs
+++ b/src/schedulers/ticker_message.rs
@@ -29,18 +29,20 @@ impl<T> SchedulerSender<T> {
         (tx.into(), rx)
     }
 
-    pub(crate) async fn send_batch(&self, cmds: Vec<TickerCommand<T>>) {
+    pub(crate) async fn send_batch(&self, cmds: Box<[TickerCommand<T>]>) {
         self.0.send_batch(cmds).await;
     }
 
-    pub(crate) fn blocking_send_batch(&self, cmds: Vec<TimerCommand<T>>) {
-        let ticker_cmds: Vec<TickerCommand<T>> = cmds.into_iter().map(Into::into).collect();
-        self.0.blocking_send_batch(ticker_cmds);
+    pub(crate) fn blocking_send_batch(&self, cmds: Box<[TimerCommand<T>]>) {
+        self.0
+            .blocking_send_batch(cmds.into_iter().map(Into::into).collect());
     }
 
     #[cfg(test)]
     pub(crate) async fn force_tick(&self) {
-        self.0.send_batch(vec![TickerCommand::ForceTick]).await;
+        self.0
+            .send_batch(Box::new([TickerCommand::ForceTick]))
+            .await;
     }
 }
 


### PR DESCRIPTION
closes #133


### Root cause 
Raft group genesis membership is per-replica — each node freezes its peer set from its local ring snapshot at creation, before the ring converges, and peer sets only mutate through the log. A follower born with peers = {leader} livelocks the group once that leader dies (campaigns only toward the corpse; its self-votes block the viable candidate every round). ~1.4–2% flake rate.

### Fix 
on takeover, the new leader asserts the group's ring membership into the log as AddPeer entries (idempotent, self-skipping apply). Also: test rewritten with phased asserts + seeded repro; election flight recorder (debug-level); transport hardening (non-blocking dials, tie-break buffer flush) and timer fixes (grant-only deadline reset, timeout epochs) found en route. Verification: 9 failures/500 → 0/500. Full RCA in the issue.