### PR TITLE
feat: 135

### DIFF
--- a/scripts/stress_test.sh
+++ b/scripts/stress_test.sh
@@ -31,10 +31,12 @@ TEST="${1:-produce_then_fetch_hot}"
 N="${2:-100}"
 PER_RUN_TIMEOUT="${3:-120}"   # seconds; a healthy run is well under this
 
+OUTDIR="$(mktemp -d "$PWD/eg-stress-XXXXXX")"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
 
-OUTDIR="$(mktemp -d "${TMPDIR:-/tmp}/eg-stress-XXXXXX")"
+
 SUMMARY="$OUTDIR/summary.txt"
 : > "$SUMMARY"
 

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -1,11 +1,11 @@
 use crate::connections::reader::ClientStreamReader;
 use crate::connections::writer::ClientRawWriter;
 use crate::connections::{protocol::*, run_client_writer};
+use crate::control_plane::consensus::raft::errors::ProposalError;
 use crate::control_plane::metadata::RangeMeta;
 use crate::control_plane::{
     NodeId, SwimNodeState,
     consensus::actor::MutlRaftSender,
-    consensus::messages::ClientProposalError,
     membership::{ShardGroupId, actor::SwimSender},
     metadata::{
         RangeId,
@@ -178,7 +178,7 @@ impl ClientController {
                 .await
             {
                 Ok(()) => ClientResponse::ControlPlane(ControlPlaneResponse::TopicCreated),
-                Err(ClientProposalError::NotLeader(_)) => {
+                Err(ProposalError::NotLeader(_)) => {
                     ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
                         "not the leader for this shard group — retry on another node".into(),
                     ))
@@ -205,7 +205,7 @@ impl ClientController {
                 .await
             {
                 Ok(()) => ClientResponse::ControlPlane(ControlPlaneResponse::TopicDeleted),
-                Err(ClientProposalError::NotLeader(_)) => {
+                Err(ProposalError::NotLeader(_)) => {
                     ClientResponse::ControlPlane(ControlPlaneResponse::InternalError(
                         "not the leader for this shard group — retry on another node".into(),
                     ))

--- a/src/control_plane/consensus/actor.rs
+++ b/src/control_plane/consensus/actor.rs
@@ -6,6 +6,7 @@ use crate::channels::BatchSender;
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::*;
 use crate::control_plane::consensus::multi_raft::MultiRaft;
+use crate::control_plane::consensus::raft::errors::ProposalError;
 use crate::control_plane::consensus::raft::storage::RaftStorage;
 use crate::control_plane::membership::actor::SwimSender;
 use crate::control_plane::membership::{ShardGroupId, SwimCommand, TopologyReader};
@@ -156,7 +157,7 @@ impl MutlRaftSender {
         &self,
         shard_group_id: ShardGroupId,
         command: MetadataCommand,
-    ) -> Result<(), ClientProposalError> {
+    ) -> Result<(), ProposalError> {
         let (reply, recv) = tokio::sync::oneshot::channel();
         let _ = self
             .send(MultiRaftActorCommand::ClientProposal {

--- a/src/control_plane/consensus/messages/actor.rs
+++ b/src/control_plane/consensus/messages/actor.rs
@@ -1,13 +1,14 @@
 use tokio::sync::oneshot;
 
 use crate::control_plane::NodeId;
+use crate::control_plane::consensus::raft::errors::ProposalError;
 use crate::control_plane::membership::{NodeDead, ShardGroupId};
 use crate::control_plane::metadata::{TopicMeta, TopicStats};
 use crate::data_plane::messages::command::SegmentAssignmentAck;
 
 use super::command::{
-    ClientProposalError, CoordinatorSealRequest, EnsureGroup, HandleNodeJoin, InboundRaftRpc,
-    MetadataProposal, RaftProtocolMessage, RemoveGroup,
+    CoordinatorSealRequest, EnsureGroup, HandleNodeJoin, InboundRaftRpc, MetadataProposal,
+    RaftProtocolMessage, RemoveGroup,
 };
 use super::timer::RaftTimeoutCallback;
 use crate::impl_from_variant_via;
@@ -28,7 +29,7 @@ pub enum MultiRaftActorCommand {
     /// Propose a command to a shard group's Raft log. Leader-only.
     ClientProposal {
         propose: MetadataProposal,
-        reply: oneshot::Sender<Result<(), ClientProposalError>>,
+        reply: oneshot::Sender<Result<(), ProposalError>>,
     },
     /// Query all topic names from all shard groups on this node.
     GetTopics {
@@ -80,8 +81,8 @@ pub(crate) enum DeferredReply {
     GetLeader(oneshot::Sender<Option<NodeId>>, Option<NodeId>),
     GetPeers(oneshot::Sender<Box<[NodeId]>>, Box<[NodeId]>),
     Propose(
-        oneshot::Sender<Result<(), ClientProposalError>>,
-        Result<(), ClientProposalError>,
+        oneshot::Sender<Result<(), ProposalError>>,
+        Result<(), ProposalError>,
     ),
     GetTopics(oneshot::Sender<Box<[String]>>, Box<[String]>),
     GetTopicStats(oneshot::Sender<Box<[TopicStats]>>, Box<[TopicStats]>),

--- a/src/control_plane/consensus/messages/command.rs
+++ b/src/control_plane/consensus/messages/command.rs
@@ -1,5 +1,3 @@
-use bincode::{Decode, Encode};
-
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::rpc::{OutboundRaftPacket, RaftRpc};
 use crate::control_plane::consensus::messages::timer::RaftTimeoutCallback;
@@ -7,13 +5,6 @@ use crate::control_plane::membership::{NodeDead, ShardGroup, ShardGroupId};
 use crate::control_plane::metadata::command::MetadataCommand;
 use crate::data_plane::messages::command::SealRequest;
 use crate::impl_from_variant;
-
-#[derive(Debug, PartialEq, Eq, Decode, Encode)]
-pub enum ClientProposalError {
-    NotLeader(Option<NodeId>),
-    ShardNotFound,
-    ShardGroupRemoved,
-}
 
 pub struct InboundRaftRpc {
     pub shard_group_id: ShardGroupId,

--- a/src/control_plane/consensus/messages/timer.rs
+++ b/src/control_plane/consensus/messages/timer.rs
@@ -4,6 +4,10 @@ use crate::schedulers::timer::TTimer;
 const ELECTION_TIMEOUT_BASE_TICKS: u32 = 50; // 5s base (+ jitter)
 const RAFT_RPC_INTERVAL_TICKS: u32 = 10; // 1s
 const MERGE_CHECK_INTERVAL_TICKS: u32 = 6_000; // 10 minutes
+/// 30s — frequent enough that a rebalance under a stable leader converges
+/// within a minute, slow enough that the O(RF) ring diff per group is noise.
+/// Also paces the consecutive-observation ring-stability gate for stale-peer removal
+const RING_CHECK_INTERVAL_TICKS: u32 = 300;
 
 #[derive(Debug, Clone)]
 pub struct RaftTimer {
@@ -18,6 +22,7 @@ pub enum RaftTimerKind {
     Election,
     Rpc,
     MergeCheck,
+    RingCheck,
 }
 
 #[derive(Debug, Default)]
@@ -34,6 +39,9 @@ pub enum RaftTimeoutCallback {
     MergeCheckTimeout {
         shard_group_id: ShardGroupId,
         now: u64,
+    },
+    RingCheckTimeout {
+        shard_group_id: ShardGroupId,
     },
 }
 
@@ -57,6 +65,9 @@ impl TTimer for RaftTimer {
             RaftTimerKind::MergeCheck => RaftTimeoutCallback::MergeCheckTimeout {
                 shard_group_id: self.shard_group_id,
                 now,
+            },
+            RaftTimerKind::RingCheck => RaftTimeoutCallback::RingCheckTimeout {
+                shard_group_id: self.shard_group_id,
             },
         }
     }
@@ -91,6 +102,15 @@ impl RaftTimer {
             shard_group_id,
             kind: RaftTimerKind::MergeCheck,
             ticks_remaining: MERGE_CHECK_INTERVAL_TICKS,
+            epoch: 0,
+        }
+    }
+
+    pub fn ring_check(shard_group_id: ShardGroupId) -> Self {
+        Self {
+            shard_group_id,
+            kind: RaftTimerKind::RingCheck,
+            ticks_remaining: RING_CHECK_INTERVAL_TICKS,
             epoch: 0,
         }
     }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -1,9 +1,10 @@
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::{
-    ClientProposalError, CoordinatorSealRequest, DeferredReply, InboundRaftRpc, LogMutation,
-    MetadataProposal, MultiRaftActorCommand, RaftEvent, RaftProtocolMessage, RaftTimeoutCallback,
+    CoordinatorSealRequest, DeferredReply, InboundRaftRpc, LogMutation, MetadataProposal,
+    MultiRaftActorCommand, RaftEvent, RaftProtocolMessage, RaftTimeoutCallback,
 };
 use crate::control_plane::consensus::raft::command::RaftCommand;
+use crate::control_plane::consensus::raft::errors::ProposalError;
 use crate::control_plane::consensus::raft::state::{Raft, TimerSeqs};
 use crate::control_plane::consensus::raft::storage::RaftStorage;
 use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now_ms};
@@ -27,8 +28,7 @@ pub(crate) struct MultiRaft {
     pending_events: Vec<RaftEvent>,
     deferred: Vec<DeferredReply>,
     /// Senders waiting for a specific (shard, log index) to be committed and applied.
-    pending_proposes:
-        BTreeMap<(ShardGroupId, u64), oneshot::Sender<Result<(), ClientProposalError>>>,
+    pending_proposes: BTreeMap<(ShardGroupId, u64), oneshot::Sender<Result<(), ProposalError>>>,
 
     pending_seals: PendingSealTracker,
 
@@ -131,11 +131,17 @@ impl MultiRaft {
         &self.node_id
     }
 
-    /// Invoked on `LeaderChange → self` for takeover reconciliation:
-    /// 1. assert the group's current ring membership into the log, healing
-    ///    replicas whose genesis peer set was seeded from a partial ring;
-    /// 2. close the gap where the previous leader died before proposing the
-    ///    removals (or their pairings) for peers SWIM no longer considers live.
+    /// This runs a reconciliation process to stabilize the group:
+    ///
+    /// 1. Sync Membership: Commits the current ring membership to the log. This fixes
+    ///    any replicas that were started with incomplete membership data.
+    /// 2. Clean Up Dead Peers: Removes peers that the SWIM protocol has marked as dead.
+    ///    This handles edge cases where the previous leader died before it could
+    ///    propose these removals.
+    /// 3. Track Live Ex-Owners: Records a ring observation to help safely evict peers
+    ///    that are still alive but no longer own data (#135). The periodic
+    ///    `handle_ringcheck_timeout` function manages the rest of the waiting period
+    ///    before the actual eviction happens.
     pub(crate) fn reconcile_on_leadership_change(&mut self, shard_group_id: ShardGroupId) {
         let target_members = self
             .topology
@@ -200,6 +206,14 @@ impl MultiRaft {
         }
         changed |= raft.reconcile_peers(&self.topology, &live_set);
         changed |= raft.reconcile_segments(&live_set);
+
+        // We record a ring observation every time this runs, whether it's a routine RingCheck or a leadership change.
+        // During a leadership change, actual evictions are paused until future RingChecks.
+        // This delay happens naturally because the system has to wait for a fresh stability window and for the new membership to be committed.
+        // Because of this, we get an "add-before-remove" behavior for free, without having to write special logic to trigger it.
+        changed |= raft
+            .reconcile_stale_live_peers(&self.topology, &live_set)
+            .is_ok();
         raft.log_ring_drift(&self.topology, &live_set);
         if changed {
             self.dirty.insert(shard_group_id);
@@ -275,14 +289,14 @@ impl MultiRaft {
         match cmd.into() {
             RaftProtocolMessage::InboundRaftRpc(cmd) => self.handle_rpc(cmd),
             RaftProtocolMessage::Timeout(cb) => self.handle_timeout(cb),
-            RaftProtocolMessage::EnsureGroup(cmd) => self.add_group(cmd.group),
+            RaftProtocolMessage::EnsureGroup(cmd) => self.add_group(&cmd.group),
             RaftProtocolMessage::RemoveGroup(cmd) => self.remove_group(cmd.group_id),
             RaftProtocolMessage::HandleNodeDeath(cmd) => self.handle_node_death(cmd.dead_node_id),
             RaftProtocolMessage::HandleNodeJoin(cmd) => self.add_node(cmd.new_node_id),
         }
     }
 
-    fn add_group(&mut self, group: ShardGroup) {
+    fn add_group(&mut self, group: &ShardGroup) {
         if self.groups.contains_key(&group.id) {
             return;
         }
@@ -297,7 +311,7 @@ impl MultiRaft {
             .cloned()
             .collect();
 
-        let election_jitter_seed = self.create_election_jitter_seed(&group);
+        let election_jitter_seed = self.create_election_jitter_seed(group);
 
         let persistent = self.storage.load_state(group.id.0);
 
@@ -350,7 +364,7 @@ impl MultiRaft {
             .collect();
         for key in pending_keys {
             if let Some(sender) = self.pending_proposes.remove(&key) {
-                let _ = sender.send(Err(ClientProposalError::ShardGroupRemoved));
+                let _ = sender.send(Err(ProposalError::ShardGroupRemoved));
             }
         }
 
@@ -518,7 +532,6 @@ impl MultiRaft {
             return;
         }
         self.add_peer_to_existing_groups(&node_id, &affected_groups);
-        self.ensure_new_groups(affected_groups);
 
         // A join is precisely the moment reassignment can mint a live
         // ex-owner (#135): the joiner displaces a still-alive member from a
@@ -532,6 +545,7 @@ impl MultiRaft {
 
     fn add_peer_to_existing_groups(&mut self, node_id: &NodeId, groups: &[ShardGroup]) {
         for group in groups {
+            self.add_group(group);
             let Some(raft) = self.groups.get_mut(&group.id) else {
                 continue;
             };
@@ -551,18 +565,10 @@ impl MultiRaft {
         }
     }
 
-    fn ensure_new_groups(&mut self, groups: Box<[ShardGroup]>) {
-        for group in groups {
-            if !self.groups.contains_key(&group.id) && group.members.contains(&self.node_id) {
-                self.add_group(group);
-            }
-        }
-    }
-
     fn propose(
         &mut self,
         cmd: MetadataProposal,
-        reply: oneshot::Sender<Result<(), ClientProposalError>>,
+        reply: oneshot::Sender<Result<(), ProposalError>>,
     ) {
         let gid = cmd.shard_group_id;
         match self.propose_internal(cmd) {
@@ -575,14 +581,14 @@ impl MultiRaft {
         }
     }
 
-    fn propose_internal(&mut self, cmd: MetadataProposal) -> Result<u64, ClientProposalError> {
+    fn propose_internal(&mut self, cmd: MetadataProposal) -> Result<u64, ProposalError> {
         match self.groups.get_mut(&cmd.shard_group_id) {
             Some(raft) => {
                 let result = raft.propose(cmd.command.into());
                 self.dirty.insert(cmd.shard_group_id);
                 result
             }
-            None => Err(ClientProposalError::ShardNotFound),
+            None => Err(ProposalError::ShardNotFound),
         }
     }
 
@@ -706,7 +712,7 @@ impl MultiRaft {
                     };
 
                     if let Some(sender) = self.pending_proposes.remove(&key) {
-                        let _ = sender.send(Err(ClientProposalError::NotLeader(None)));
+                        let _ = sender.send(Err(ProposalError::NotLeader(None)));
                     }
                 }
             }
@@ -808,8 +814,8 @@ mod tests {
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
 
-        store.add_group(shard(1, vec![me.clone(), node("n2")]));
-        store.add_group(shard(2, vec![me.clone(), node("n2")]));
+        store.add_group(&shard(1, vec![me.clone(), node("n2")]));
+        store.add_group(&shard(2, vec![me.clone(), node("n2")]));
 
         let events = store.flush();
         let seqs = timer_seqs(&events);
@@ -823,7 +829,7 @@ mod tests {
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
 
-        store.add_group(shard(42, vec![me.clone(), node("n2")]));
+        store.add_group(&shard(42, vec![me.clone(), node("n2")]));
 
         assert!(store.groups.contains_key(&ShardGroupId(42)));
     }
@@ -834,7 +840,7 @@ mod tests {
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
 
-        store.add_group(shard(42, vec![me.clone()]));
+        store.add_group(&shard(42, vec![me.clone()]));
         store.handle_consensus(RaftProtocolMessage::Timeout(
             RaftTimeoutCallback::ElectionTimeout {
                 shard_group_id: ShardGroupId(42),
@@ -854,7 +860,7 @@ mod tests {
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
 
-        store.add_group(shard(42, vec![node("n2"), node("n3")]));
+        store.add_group(&shard(42, vec![node("n2"), node("n3")]));
 
         assert!(!store.groups.contains_key(&ShardGroupId(42)));
     }
@@ -867,8 +873,8 @@ mod tests {
         {
             let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
-            store.add_group(shard(1, vec![me.clone()]));
-            store.add_group(shard(2, vec![me.clone()]));
+            store.add_group(&shard(1, vec![me.clone()]));
+            store.add_group(&shard(2, vec![me.clone()]));
             store.handle_consensus(RaftProtocolMessage::Timeout(
                 RaftTimeoutCallback::ElectionTimeout {
                     shard_group_id: ShardGroupId(1),
@@ -930,7 +936,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
         store.flush(); // persist election HardState
@@ -948,7 +954,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
         store.flush();
@@ -962,7 +968,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         assert_eq!(store.stabled_for(TEST_GROUP_ID), 0);
 
@@ -985,7 +991,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
         store.flush(); // consume dirty from add_group
 
         // No state changes — flush should be a no-op and return no events.
@@ -999,7 +1005,7 @@ mod tests {
         let me = node("n1");
         let n2 = node("n2");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone(), n2.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone(), n2.clone()]));
         store.flush(); // consume add_group dirty
 
         // n2 is acting as leader at term 1.  Send two entries to n1 (follower).
@@ -1073,7 +1079,7 @@ mod tests {
         {
             let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
-            store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+            store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
             store.flush();
             propose_noop(&mut store);
@@ -1083,7 +1089,7 @@ mod tests {
 
         let db = MetadataStorage::open(path);
         let mut store = new_store(me.clone(), Box::new(db));
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
         assert_eq!(
@@ -1105,14 +1111,14 @@ mod tests {
         {
             let db = MetadataStorage::open(path.clone());
             let mut store = new_store(me.clone(), Box::new(db));
-            store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+            store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
             elect_leader(&mut store);
             store.flush();
         }
 
         let db = MetadataStorage::open(path);
         let mut store = new_store(me.clone(), Box::new(db));
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
         let raft = store.groups.get(&TEST_GROUP_ID).unwrap();
         assert_eq!(raft.current_term(), 1);
         assert_eq!(raft.voted_for(), Some(node("n1")));
@@ -1126,7 +1132,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
         store.flush();
@@ -1161,8 +1167,8 @@ mod tests {
         let mut store = new_store(me.clone(), storage);
 
         // Single-node groups so election succeeds immediately
-        store.add_group(shard(1, vec![me.clone()]));
-        store.add_group(shard(2, vec![me.clone()]));
+        store.add_group(&shard(1, vec![me.clone()]));
+        store.add_group(&shard(2, vec![me.clone()]));
         store.flush();
 
         // Elect leader in group 1 only
@@ -1197,7 +1203,7 @@ mod tests {
         let (storage, _) = temp_storage();
         let me = node("n1");
         let mut store = new_store(me.clone(), storage);
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone()]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
 
         elect_leader(&mut store);
         store.flush();
@@ -1373,7 +1379,7 @@ mod tests {
         let all_nodes = vec![me.clone(), node("n2"), node("n3"), node("n4"), node("n5")];
         let mut store = new_store_with_topology(me.clone(), storage, &all_nodes);
 
-        store.add_group(shard(TEST_GROUP_ID.0, group_members.clone()));
+        store.add_group(&shard(TEST_GROUP_ID.0, group_members.clone()));
         elect_leader_with_peers(&mut store, &peers);
         store.flush();
 
@@ -1421,7 +1427,7 @@ mod tests {
         let all_nodes = vec![me.clone(), node("n2")];
         let mut store = new_store_with_topology(me.clone(), storage, &all_nodes);
 
-        store.add_group(shard(TEST_GROUP_ID.0, vec![me.clone(), node("n2")]));
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone(), node("n2")]));
         elect_leader_with_peers(&mut store, &peers);
         store.flush();
 
@@ -1478,7 +1484,7 @@ mod tests {
 
         // Old ring is 3 nodes at RF=3, so every group's membership is exactly
         // {n1, n2, n3}.
-        store.add_group(shard(gid.0, old_nodes.to_vec()));
+        store.add_group(&shard(gid.0, old_nodes.to_vec()));
         elect_leader_for(&mut store, gid, &[node("n2"), node("n3")]);
         store.flush();
 
@@ -1499,6 +1505,82 @@ mod tests {
             "stable-leader ring check must propose AddPeer for the newly \
              assigned member (log: {:?})",
             log.iter().map(|e| &e.command).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn ring_check_evicts_live_ex_owner_after_stability_window() {
+        use crate::control_plane::consensus::messages::{AppendEntriesResponse, RaftRpc};
+        use crate::control_plane::consensus::raft::state::RING_STABLE_OBSERVATIONS;
+
+        // Ring has [n1, n2, n3, n9]; pick a group the ring assigns to
+        // {n1, n2, n3} — n9 is alive (on the ring) but NOT an owner of this
+        // group. Seed the Raft group with n9 as a voter anyway: the #135
+        // ratchet, as left behind by an earlier reassignment.
+        let (storage, _) = temp_storage();
+        let n1 = node("n1");
+        let all_nodes = [node("n1"), node("n2"), node("n3"), node("n9")];
+        let mut store = new_store_with_topology(n1.clone(), storage, &all_nodes);
+
+        let gid = store
+            .topology
+            .shard_groups_for_node(&n1)
+            .iter()
+            .find(|g| !g.members.contains(&node("n9")))
+            .map(|g| g.id)
+            .expect("some group of n1 must exclude n9");
+
+        store.add_group(&shard(gid.0, all_nodes.to_vec()));
+        elect_leader_for(&mut store, gid, &[node("n2"), node("n3"), node("n9")]);
+        store.flush();
+
+        // Ring members confirm replication up to the leader's last entry so
+        // the caught-up gate holds; the stale n9 never acks.
+        {
+            let raft = store.groups.get_mut(&gid).unwrap();
+            let term = raft.current_term();
+            let last = raft.log_last_index();
+            for peer in [node("n2"), node("n3")] {
+                raft.handle_rpc(
+                    peer.clone(),
+                    RaftRpc::AppendEntriesResponse(AppendEntriesResponse {
+                        term,
+                        node_id: peer,
+                        success: true,
+                        last_log_index: last,
+                    }),
+                );
+            }
+            store.dirty.insert(gid);
+        }
+        store.flush();
+
+        // Tick past the stability window, plus extra passes that must park
+        // behind the in-flight removal: exactly one eviction, ever.
+        for _ in 0..RING_STABLE_OBSERVATIONS + 2 {
+            store.handle_consensus(RaftProtocolMessage::Timeout(
+                RaftTimeoutCallback::RingCheckTimeout {
+                    shard_group_id: gid,
+                },
+            ));
+            store.flush();
+        }
+
+        let log = store.storage.load_state(gid.0).log;
+        let removals = log
+            .iter()
+            .filter(|e| e.command == RaftCommand::RemovePeer(node("n9")))
+            .count();
+        assert_eq!(
+            removals,
+            1,
+            "exactly one gated eviction of the live ex-owner (log: {:?})",
+            log.iter().map(|e| &e.command).collect::<Vec<_>>()
+        );
+        assert!(
+            !log.iter()
+                .any(|e| e.command == RaftCommand::AddPeer(node("n9"))),
+            "the eviction must not be paired with an AddPeer"
         );
     }
 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -137,51 +137,73 @@ impl MultiRaft {
     /// 2. close the gap where the previous leader died before proposing the
     ///    removals (or their pairings) for peers SWIM no longer considers live.
     pub(crate) fn reconcile_on_leadership_change(&mut self, shard_group_id: ShardGroupId) {
+        let target_members = self
+            .topology
+            .resolve_nodes_in_group(&self.node_id, shard_group_id);
+
+        self.reconcile_shard(shard_group_id, target_members);
+    }
+
+    fn handle_ringcheck_timeout(&mut self, shard_group_id: ShardGroupId) {
+        let Some(raft) = self.groups.get(&shard_group_id) else {
+            return;
+        };
+
+        // Tick-path filter: only chase ring deltas. Asserting already-present
+        // members is the takeover path's genesis-divergence heal (#133/#134);
+        // repeating it every interval would spam the log with no-op AddPeers.
+        // hash_peer() saves recurring log spam, covered by takeover
+        let target_members = self
+            .topology
+            .group_ring_members(shard_group_id)
+            .map(|members| {
+                members
+                    .iter()
+                    .filter(|m| !raft.has_peer(m))
+                    .cloned()
+                    .collect::<Box<[NodeId]>>()
+            });
+
+        self.reconcile_shard(shard_group_id, target_members);
+    }
+
+    fn reconcile_shard(
+        &mut self,
+        shard_group_id: ShardGroupId,
+        target_members: Option<Box<[NodeId]>>,
+    ) {
         let Some(raft) = self.groups.get_mut(&shard_group_id) else {
             return;
         };
         if !raft.is_leader() {
             return;
         }
-
         let live_set: HashSet<NodeId> = self.topology.live_nodes().into_iter().collect();
+        let mut changed = false;
 
-        // Genesis peer sets are seeded from each replica's *local* ring
-        // snapshot at creation and can diverge on a partially-joined ring
-        // (#133: livelocks the group once that leader dies).
-        // Peer sets mutate only through the log, so on takeover assert the group's ring membership as AddPeer entries:
-        // `apply_add_peer` is idempotent and self-skipping, so healthy
-        // replicas no-op while divergent ones heal. Dead members are skipped
-        // replacement is `reconcile_peers`'s job, rejoin is `add_node`'s.
-
-        if let Some(members) = self
-            .topology
-            .resolve_nodes_in_group(&self.node_id, shard_group_id)
-        {
-            for member in members {
-                if member == self.node_id || !live_set.contains(&member) {
+        if let Some(members) = target_members {
+            for member in members.iter() {
+                if *member == self.node_id || !live_set.contains(member) {
                     continue;
                 }
 
-                if let Err(e) = raft.propose(RaftCommand::AddPeer(member.clone())) {
-                    tracing::warn!(
-                        "Takeover membership assert AddPeer({:?}) on {:?} rejected: {e:?}",
+                match raft.propose(RaftCommand::AddPeer(member.clone())) {
+                    Ok(_) => changed = true,
+                    Err(e) => tracing::warn!(
+                        "AddPeer({:?}) on {:?} rejected: {:?}",
                         member,
                         shard_group_id,
-                    )
-                } else {
-                    self.dirty.insert(shard_group_id);
+                        e
+                    ),
                 }
             }
         }
-
-        let peer_reconciled = raft.reconcile_peers(&self.topology, &live_set);
-        let segment_reconciled = raft.reconcile_segments(&live_set);
+        changed |= raft.reconcile_peers(&self.topology, &live_set);
+        changed |= raft.reconcile_segments(&live_set);
         raft.log_ring_drift(&self.topology, &live_set);
-
-        if peer_reconciled || segment_reconciled {
+        if changed {
             self.dirty.insert(shard_group_id);
-        };
+        }
     }
 
     pub(crate) fn process(&mut self, cmd: MultiRaftActorCommand) {
@@ -283,6 +305,7 @@ impl MultiRaft {
             election: self.seq_counter.generate(),
             rpc: self.seq_counter.generate(),
             merge_check: self.seq_counter.generate(),
+            ring_check: self.seq_counter.generate(),
         };
 
         let raft = Raft::new(
@@ -348,8 +371,16 @@ impl MultiRaft {
             RaftTimeoutCallback::Ignored => return,
             RaftTimeoutCallback::ElectionTimeout { shard_group_id, .. }
             | RaftTimeoutCallback::RpcTimeout { shard_group_id }
-            | RaftTimeoutCallback::MergeCheckTimeout { shard_group_id, .. } => *shard_group_id,
+            | RaftTimeoutCallback::MergeCheckTimeout { shard_group_id, .. }
+            | RaftTimeoutCallback::RingCheckTimeout { shard_group_id } => *shard_group_id,
         };
+
+        // The ring diff needs `self.topology`, which the Raft state machine
+        // deliberately doesn't hold — run it here, then forward the callback
+        // so the leader-gated re-arm stays inside `Raft` like MergeCheck's.
+        if matches!(cb, RaftTimeoutCallback::RingCheckTimeout { .. }) {
+            self.handle_ringcheck_timeout(shard_id);
+        }
 
         if let Some(raft) = self.groups.get_mut(&shard_id) {
             raft.handle_timeout(cb);
@@ -1233,6 +1264,29 @@ mod tests {
         MultiRaft::new(node_id, 0, storage, reader)
     }
 
+    /// `new_store_with_topology`, but the publisher half is kept so the test
+    /// can simulate a rebalance by publishing a fresh snapshot — exactly what
+    /// `SwimActor` does on a membership change.
+    fn new_store_with_topology_publisher(
+        node_id: NodeId,
+        storage: Box<dyn RaftStorage>,
+        all_nodes: &[NodeId],
+    ) -> (
+        MultiRaft,
+        std::sync::Arc<arc_swap::ArcSwap<crate::control_plane::membership::Topology>>,
+    ) {
+        use crate::control_plane::membership::{Topology, TopologyConfig, topology_channel};
+        let topology = Topology::new(
+            all_nodes.iter().cloned(),
+            TopologyConfig {
+                vnodes_per_pnode: 64,
+                replication_factor: 3,
+            },
+        );
+        let (pub_handle, reader) = topology_channel(topology);
+        (MultiRaft::new(node_id, 0, storage, reader), pub_handle)
+    }
+
     /// Drive `TEST_GROUP_ID` to elect this node as leader by simulating
     /// vote-granted RequestVoteResponses from a majority of `peers`. Mirrors
     /// the pattern used in `raft/state.rs` tests: ElectionTimeout transitions
@@ -1260,6 +1314,36 @@ mod tests {
             );
         }
         store.dirty.insert(TEST_GROUP_ID);
+    }
+
+    /// `elect_leader_with_peers`, but for an arbitrary group id. Ring-derived
+    /// ids (rather than the synthetic `TEST_GROUP_ID`) are needed whenever a
+    /// test must line a Raft group up with a real topology snapshot.
+    fn elect_leader_for(store: &mut MultiRaft, gid: ShardGroupId, peers: &[NodeId]) {
+        use crate::control_plane::consensus::messages::{RaftRpc, RequestVoteResponse};
+
+        store.handle_consensus(RaftProtocolMessage::Timeout(
+            RaftTimeoutCallback::ElectionTimeout {
+                shard_group_id: gid,
+                epoch: u64::MAX,
+            },
+        ));
+
+        let cluster_size = peers.len() + 1;
+        let needed = cluster_size / 2;
+        let raft = store.groups.get_mut(&gid).unwrap();
+        let term = raft.current_term();
+        for peer in peers.iter().take(needed) {
+            raft.handle_rpc(
+                peer.clone(),
+                RaftRpc::RequestVoteResponse(RequestVoteResponse {
+                    term,
+                    node_id: peer.clone(),
+                    vote_granted: true,
+                }),
+            );
+        }
+        store.dirty.insert(gid);
     }
 
     /// All proposals committed so far on `TEST_GROUP_ID`, in log order.
@@ -1349,6 +1433,72 @@ mod tests {
             proposals,
             vec![RaftCommand::RemovePeer(node("n2"))],
             "exhausted pool must yield only the removal, no paired addition"
+        );
+    }
+
+    #[test]
+    fn ring_check_adds_new_ring_member_under_stable_leader() {
+        use crate::control_plane::membership::{Topology, TopologyConfig};
+
+        // The #135 trigger gap: reconciliation used to run only on takeover
+        // or SWIM join/death *as seen by this handler chain*. Here the leader
+        // stays healthy across a rebalance (n4 joins the ring), so no
+        // takeover ever re-runs the ring diff — the periodic RingCheck alone
+        // must converge the add direction.
+        let (storage, _) = temp_storage();
+        let n1 = node("n1");
+        let old_nodes = [node("n1"), node("n2"), node("n3")];
+        let config = TopologyConfig {
+            vnodes_per_pnode: 64,
+            replication_factor: 3,
+        };
+
+        // Deterministic group pick (murmur3 ring): a group n1 owns in the old
+        // ring whose new-ring assignment includes the joiner n4. With 192
+        // candidate groups and n4 owning a quarter of all vnode positions,
+        // such a group always exists.
+        let old_topology = Topology::new(old_nodes.iter().cloned(), config.clone());
+        let new_topology = Topology::new(
+            old_nodes.iter().cloned().chain([node("n4")]),
+            config.clone(),
+        );
+        let gid = old_topology
+            .shard_groups_for_node(&n1)
+            .into_iter()
+            .map(|g| g.id)
+            .find(|id| {
+                new_topology
+                    .group(*id)
+                    .is_some_and(|g| g.members.contains(&node("n4")))
+            })
+            .expect("some group of n1 must gain n4 after the join");
+
+        let (mut store, publisher) =
+            new_store_with_topology_publisher(n1.clone(), storage, &old_nodes);
+
+        // Old ring is 3 nodes at RF=3, so every group's membership is exactly
+        // {n1, n2, n3}.
+        store.add_group(shard(gid.0, old_nodes.to_vec()));
+        elect_leader_for(&mut store, gid, &[node("n2"), node("n3")]);
+        store.flush();
+
+        // The rebalance lands; the leader is healthy, so no takeover fires.
+        publisher.store(std::sync::Arc::new(new_topology));
+
+        store.handle_consensus(RaftProtocolMessage::Timeout(
+            RaftTimeoutCallback::RingCheckTimeout {
+                shard_group_id: gid,
+            },
+        ));
+        store.flush();
+
+        let log = store.storage.load_state(gid.0).log;
+        assert!(
+            log.iter()
+                .any(|e| e.command == RaftCommand::AddPeer(node("n4"))),
+            "stable-leader ring check must propose AddPeer for the newly \
+             assigned member (log: {:?})",
+            log.iter().map(|e| &e.command).collect::<Vec<_>>()
         );
     }
 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -177,6 +177,7 @@ impl MultiRaft {
 
         let peer_reconciled = raft.reconcile_peers(&self.topology, &live_set);
         let segment_reconciled = raft.reconcile_segments(&live_set);
+        raft.log_ring_drift(&self.topology, &live_set);
 
         if peer_reconciled || segment_reconciled {
             self.dirty.insert(shard_group_id);
@@ -413,6 +414,7 @@ impl MultiRaft {
             if raft.handle_node_death(&dead_node_id, &live_set, &self.topology) {
                 self.dirty.insert(*group_id);
             }
+            raft.log_ring_drift(&self.topology, &live_set);
         }
     }
 
@@ -486,6 +488,15 @@ impl MultiRaft {
         }
         self.add_peer_to_existing_groups(&node_id, &affected_groups);
         self.ensure_new_groups(affected_groups);
+
+        // A join is precisely the moment reassignment can mint a live
+        // ex-owner (#135): the joiner displaces a still-alive member from a
+        // group's ring assignment. Detection only — scan is O(groups × RF)
+        // and joins are rare.
+        let live_set: HashSet<NodeId> = self.topology.live_nodes().into_iter().collect();
+        for raft in self.groups.values() {
+            raft.log_ring_drift(&self.topology, &live_set);
+        }
     }
 
     fn add_peer_to_existing_groups(&mut self, node_id: &NodeId, groups: &[ShardGroup]) {

--- a/src/control_plane/consensus/raft/errors.rs
+++ b/src/control_plane/consensus/raft/errors.rs
@@ -1,0 +1,25 @@
+use bincode::{Decode, Encode};
+
+use crate::control_plane::NodeId;
+
+#[derive(Debug, PartialEq, Eq, Decode, Encode, thiserror::Error)]
+pub enum ProposalError {
+    #[error("Non-leader cannot make proposal: {0:?}")]
+    NotLeader(Option<NodeId>),
+    #[error("Shard not found for proposal")]
+    ShardNotFound,
+    #[error("Shard group removed")]
+    ShardGroupRemoved,
+}
+
+#[derive(Debug)]
+pub(crate) enum EvictionError {
+    NotLeader,
+    GroupNotFound,
+    LeaderNotInRing,
+    WaitingForStability,
+    NoStalePeers,
+    ConfigChangeInFlight,
+    FollowersLagging,
+    ProposalRejected, // Only allocate a string if it actually errors
+}

--- a/src/control_plane/consensus/raft/mod.rs
+++ b/src/control_plane/consensus/raft/mod.rs
@@ -1,6 +1,7 @@
 use crate::control_plane::NodeId;
 
 pub(crate) mod command;
+pub(crate) mod errors;
 pub(crate) mod log;
 pub(crate) mod state;
 pub(crate) mod storage;

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -208,6 +208,50 @@ impl Raft {
         changed
     }
 
+    /// Live voters that the ring no longer assigns to this group.
+    /// Dead voters are deliberately excluded — they are `reconcile_peers`'
+    /// jurisdiction, mirroring the live-set guard on the add side.
+    pub(crate) fn stale_live_voters(
+        &self,
+        ring_members: &[NodeId],
+        live: &HashSet<NodeId>,
+    ) -> Vec<NodeId> {
+        let mut stale: Vec<NodeId> = self
+            .peers
+            .iter()
+            .filter(|p| live.contains(*p) && !ring_members.contains(p))
+            .cloned()
+            .collect();
+        stale.sort();
+        stale
+    }
+
+    /// Leader-side drift telemetry - detection only, no proposals.
+    /// Warns when the voter set has ratcheted past the ring's assignment
+    /// for this group: live ex-owners present, or more voters than the ring
+    /// names. Catching the ratchet in the wild precedes curing it.
+    pub(crate) fn log_ring_drift(&self, topology_reader: &TopologyReader, live: &HashSet<NodeId>) {
+        if self.role != Role::Leader {
+            return;
+        }
+        let Some(ring_members) = topology_reader.group_ring_members(self.shard_group_id) else {
+            return;
+        };
+        let stale_live = self.stale_live_voters(&ring_members, live);
+        let voter_count = self.peers.len() + 1; // +1 for self
+        if !stale_live.is_empty() || voter_count > ring_members.len() {
+            tracing::warn!(
+                node = %self.node_id,
+                group = self.shard_group_id.0,
+                voters = voter_count,
+                ring_members = ring_members.len(),
+                stale_live = ?stale_live,
+                "ring drift (#135): voter set exceeds the ring's assignment — \
+                 quorum is inflated until the stale members are removed",
+            );
+        }
+    }
+
     /// scan active segments in this group for any whose replica set still names a
     /// node SWIM considers dead, and propose a `RollSegment` to swap in
     /// healthy replacements. Closes the gap where deaths landed during the
@@ -2726,6 +2770,36 @@ mod tests {
             proposals,
             vec![RaftCommand::RemovePeer(node("node-2"))],
             "exhausted pool must yield only the removal, no paired addition"
+        );
+    }
+
+    #[test]
+    fn stale_live_voters_flags_live_ex_owners_only() {
+        // Voters are {node-1 (self), node-2, node-3}; the ring now assigns the
+        // group to {node-1, node-3, node-4}. node-2 is the #135 ratchet case
+        // only while it is alive — once dead it becomes `reconcile_peers`'
+        // jurisdiction and must not be reported here.
+        let raft = three_node_raft("node-1");
+        let ring = [node("node-1"), node("node-3"), node("node-4")];
+
+        let all_live = live_set(&["node-1", "node-2", "node-3", "node-4"]);
+        assert_eq!(
+            raft.stale_live_voters(&ring, &all_live),
+            vec![node("node-2")],
+            "a live voter outside the ring assignment is a stale live voter"
+        );
+
+        let node_2_dead = live_set(&["node-1", "node-3", "node-4"]);
+        assert!(
+            raft.stale_live_voters(&ring, &node_2_dead).is_empty(),
+            "dead ex-owners belong to reconcile_peers, not drift detection"
+        );
+
+        let ring_matches_voters = [node("node-1"), node("node-2"), node("node-3")];
+        assert!(
+            raft.stale_live_voters(&ring_matches_voters, &all_live)
+                .is_empty(),
+            "no drift when voters equal the ring assignment"
         );
     }
 

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -1,8 +1,5 @@
 #![allow(dead_code)]
 
-use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::*;
 use crate::control_plane::consensus::raft::command::RaftCommand;
@@ -20,6 +17,8 @@ use crate::data_plane::transport::command::DataTransportCommand;
 use crate::schedulers::ticker_message::TimerCommand;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 const ELECTION_JITTER_RANGE: u32 = 20;
 
@@ -109,6 +108,7 @@ pub(crate) struct TimerSeqs {
     pub election: u64,
     pub rpc: u64,
     pub merge_check: u64,
+    pub ring_check: u64,
 }
 
 impl Raft {
@@ -478,6 +478,9 @@ impl Raft {
             RaftTimeoutCallback::MergeCheckTimeout { now, .. } => {
                 self.evaluate_merges(now);
             }
+            RaftTimeoutCallback::RingCheckTimeout { .. } => {
+                self.reschedule_ring_check();
+            }
         }
         #[cfg(any(test, debug_assertions))]
         self.assert_invariants();
@@ -653,10 +656,11 @@ impl Raft {
             .into(),
         );
 
-        // Cancel election timer, start heartbeat + merge check timers.
+        // Cancel election timer, start heartbeat + merge/ring check timers.
         self.cancel_all_timers();
         self.schedule_rpc_timer();
         self.schedule_merge_check_timer();
+        self.schedule_ring_check_timer();
 
         // next_index is set *before* the noop is appended, so it points
         // at the noop's index — causing the first AppendEntries to carry it.
@@ -1182,6 +1186,26 @@ impl Raft {
             }));
     }
 
+    fn schedule_ring_check_timer(&mut self) {
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::SetSchedule {
+                seq: self.timer_seqs.ring_check,
+                timer: RaftTimer::ring_check(self.shard_group_id),
+            }));
+    }
+
+    /// Re-arm the periodic ring check (#135 trigger gap). The ring diff
+    /// itself runs in `MultiRaft::reconcile_ring` — it needs the topology
+    /// reader, which lives a layer up — so this Raft-side handler owns only
+    /// the timer lifecycle, leader-gated like `evaluate_merges`: a deposed
+    /// leader lets the timer die (it is re-armed on the next become_leader).
+    pub(crate) fn reschedule_ring_check(&mut self) {
+        if self.role != Role::Leader {
+            return;
+        }
+        self.schedule_ring_check_timer();
+    }
+
     pub(crate) fn evaluate_merges(&mut self, now: u64) {
         if self.role != Role::Leader {
             return;
@@ -1195,9 +1219,10 @@ impl Raft {
         self.schedule_merge_check_timer();
     }
 
-    /// Cancels the leader-side timers (heartbeat, merge-check) without
-    /// touching the election timer — used by `step_down` so a follower or
-    /// candidate keeps its currently armed election deadline (#133).
+    /// Cancels the leader-side timers (heartbeat, merge-check, ring-check)
+    /// without touching the election timer — used by `step_down` so a
+    /// follower or candidate keeps its currently armed election deadline
+    /// (#133).
     fn cancel_leader_timers(&mut self) {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
@@ -1206,6 +1231,10 @@ impl Raft {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.timer_seqs.merge_check,
+            }));
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
+                seq: self.timer_seqs.ring_check,
             }));
     }
 
@@ -1222,6 +1251,10 @@ impl Raft {
         self.events
             .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
                 seq: self.timer_seqs.merge_check,
+            }));
+        self.events
+            .push(RaftEvent::Timer(TimerCommand::CancelSchedule {
+                seq: self.timer_seqs.ring_check,
             }));
     }
 }
@@ -1381,6 +1414,7 @@ mod tests {
             election: 0,
             rpc: 1,
             merge_check: 2,
+            ring_check: 3,
         }
     }
 
@@ -2622,6 +2656,85 @@ mod tests {
         assert!(
             merge_check_set,
             "merge_check timer must be scheduled on become_leader"
+        );
+    }
+
+    #[test]
+    fn ring_check_timer_scheduled_on_leadership() {
+        let seqs = test_timer_seqs();
+        let ring_seq = seqs.ring_check;
+        let mut raft = Raft::new(
+            node("node-1"),
+            HashSet::new(),
+            RaftPersistentState::default(),
+            0,
+            TEST_SHARD,
+            seqs,
+        );
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
+        });
+
+        let events = raft.take_events();
+        let ring_check_set = events.iter().any(|e| match e {
+            RaftEvent::Timer(TimerCommand::SetSchedule { seq, timer }) => {
+                *seq == ring_seq && timer.shard_group_id == TEST_SHARD
+            }
+            _ => false,
+        });
+        assert!(
+            ring_check_set,
+            "ring_check timer must be scheduled on become_leader"
+        );
+    }
+
+    #[test]
+    fn ring_check_rearm_is_leader_gated() {
+        let seqs = test_timer_seqs();
+        let ring_seq = seqs.ring_check;
+        let mut raft = Raft::new(
+            node("node-1"),
+            HashSet::new(),
+            RaftPersistentState::default(),
+            0,
+            TEST_SHARD,
+            seqs,
+        );
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
+        });
+        drain(&mut raft);
+
+        // Leader: the fired check re-arms itself.
+        raft.handle_timeout(RaftTimeoutCallback::RingCheckTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        let rearmed = raft.take_events().iter().any(|e| {
+            matches!(
+                e,
+                RaftEvent::Timer(TimerCommand::SetSchedule { seq, .. }) if *seq == ring_seq
+            )
+        });
+        assert!(rearmed, "leader must re-arm the ring check on fire");
+
+        // Deposed: the timer dies until the next become_leader.
+        let term = raft.current_term();
+        raft.step_down(term);
+        drain(&mut raft);
+        raft.handle_timeout(RaftTimeoutCallback::RingCheckTimeout {
+            shard_group_id: TEST_SHARD,
+        });
+        let rearmed_after_depose = raft.take_events().iter().any(|e| {
+            matches!(
+                e,
+                RaftEvent::Timer(TimerCommand::SetSchedule { seq, .. }) if *seq == ring_seq
+            )
+        });
+        assert!(
+            !rearmed_after_depose,
+            "a non-leader must let the ring check die"
         );
     }
 

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -3,6 +3,7 @@
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::*;
 use crate::control_plane::consensus::raft::command::RaftCommand;
+use crate::control_plane::consensus::raft::errors::{EvictionError, ProposalError};
 use crate::control_plane::consensus::raft::log::LogEntry;
 use crate::control_plane::consensus::raft::storage::RaftPersistentState;
 use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now_ms};
@@ -17,10 +18,20 @@ use crate::data_plane::transport::command::DataTransportCommand;
 use crate::schedulers::ticker_message::TimerCommand;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 const ELECTION_JITTER_RANGE: u32 = 20;
+
+/// #135: The number of consecutive, identical ring observations needed
+/// before we can safely evict a live ex-owner.
+///
+/// Observations happen during routine RingChecks (~every 30s) and during
+/// leadership changes. Requiring 3 observations guarantees about a minute
+/// of ring stability. This buffer ensures we don't accidentally evict a
+/// legitimate owner just because our local snapshot was briefly incorrect
+/// during a rebalance.
+pub(crate) const RING_STABLE_OBSERVATIONS: u32 = 3;
 
 struct ElectionJitter {
     seed: u64,
@@ -102,6 +113,15 @@ pub struct Raft {
     /// re-driving a segment whose confirmed node still matches `replica_set[0]`
     confirmed_assignment: HashMap<SegmentKey, NodeId>,
     pending_proposals: Vec<MetadataCommand>,
+
+    /// Tracks the ring membership seen during the last check, along with a count
+    /// of how many times we've seen this exact membership in a row (#135).
+    ///
+    /// This state is "leader-volatile," meaning it gets wiped clean whenever a
+    /// new leader takes over. This guarantees that a new leader must observe a
+    /// stable ring over time to "re-earn confidence" before it is allowed to
+    /// evict anyone.
+    ring_observation_streak: Option<(BTreeSet<NodeId>, u32)>,
 }
 
 pub(crate) struct TimerSeqs {
@@ -141,6 +161,7 @@ impl Raft {
             timer_seqs,
             election_epoch: 0,
             confirmed_assignment: HashMap::new(),
+            ring_observation_streak: None,
         };
         raft.reset_election_timer();
         raft
@@ -250,6 +271,130 @@ impl Raft {
                  quorum is inflated until the stale members are removed",
             );
         }
+    }
+
+    /// Returns `true` if there is a pending membership change (`AddPeer` or
+    /// `RemovePeer`) that has been appended to the log but not yet committed.
+    ///
+    /// We only allow one configuration change in flight at a time per group.
+    /// Because of this rule, stale-peer removals must wait in line. This
+    /// naturally enforces our "add-before-remove" ordering: if an `AddPeer`
+    /// is proposed during a check, any `RemovePeer` proposed later in that
+    /// same check is delayed until the add successfully commits.
+    fn has_uncommitted_membership_change(&self) -> bool {
+        (self.commit_index + 1..=self.log_last_index()).any(|i| {
+            matches!(
+                self.log_get(i).map(|e| &e.command),
+                Some(RaftCommand::AddPeer(_) | RaftCommand::RemovePeer(_))
+            )
+        })
+    }
+
+    /// Safely evicts up to one *live* ex-owner per pass (Issue #135).
+    ///
+    /// This function only targets nodes that are alive, currently
+    /// acting as voters, but no longer belong to the ring. Dead peers are
+    /// handled separately by `reconcile_peers`. These two functions can run
+    /// in any order without conflict.
+    ///
+    /// To prevent accidental data loss or instability, all of the following
+    /// safety gates must pass before an eviction occurs:
+    /// 1. The current node is the leader, and the group still exists in the ring.
+    /// 2. The ring membership has been stable for `RING_STABLE_OBSERVATIONS` checks.
+    /// 3. The leader is still a member of the ring (if the leader is the ex-owner, it should transfer leadership, not evict itself).
+    /// 4. There are no uncommitted configuration changes in flight.
+    /// 5. All current ring members are alive, are voters, and have caught up on the log. This ensures we don't drop below our replication factor or strand committed data.
+    /// 6. We only remove one peer per pass, picking the lowest `NodeId` for consistency.
+    ///
+    /// Note on `AddPeer`: Unlike replacing a dead node, this removal is not
+    /// paired with an `AddPeer`. Because gate #5 ensures all current members
+    /// are active voters, this eviction just safely shrinks the group back
+    /// to its standard replication factor.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(crate) fn reconcile_stale_live_peers(
+        &mut self,
+        topology_reader: &TopologyReader,
+        live: &HashSet<NodeId>,
+    ) -> Result<(), EvictionError> {
+        if self.role != Role::Leader {
+            return Err(EvictionError::NotLeader);
+        }
+
+        let Some(ring_members) = topology_reader.group_ring_members(self.shard_group_id) else {
+            self.ring_observation_streak = None;
+            return Err(EvictionError::GroupNotFound);
+        };
+        let ring: BTreeSet<NodeId> = ring_members.iter().cloned().collect();
+
+        // Gate 2: Check leader validity BEFORE doing any work/allocations
+        if !ring.contains(&self.node_id) {
+            return Err(EvictionError::LeaderNotInRing);
+        }
+
+        // Gate 3: consecutive identical observations.
+        let observations = self.record_ring_observation(&ring);
+        if observations < RING_STABLE_OBSERVATIONS {
+            return Err(EvictionError::WaitingForStability);
+        }
+
+        let victim = self
+            .peers
+            .iter()
+            .filter(|p| live.contains(*p) && !ring.contains(*p))
+            .min()
+            .cloned();
+
+        let Some(victim) = victim else {
+            return Err(EvictionError::NoStalePeers);
+        };
+
+        // Gate 4: Raft only allows one membership change at a time.
+        if self.has_uncommitted_membership_change() {
+            return Err(EvictionError::ConfigChangeInFlight);
+        }
+
+        // Gate 5. Before the leader removes an ex-owner, it must verify that every legitimate member currently in the ring is online,
+        // fully integrated, and has a complete copy of all committed data.
+        for member in &ring {
+            if *member == self.node_id {
+                continue;
+            }
+            if !live.contains(member) || !self.peers.contains(member) {
+                return Err(EvictionError::ConfigChangeInFlight);
+            }
+
+            // It checks if a specific node has a complete, up-to-date copy of all permanently saved data.
+            let in_sync = self
+                .peer_states
+                .get(member)
+                .is_some_and(|ps| ps.match_index >= self.commit_index);
+            if !in_sync {
+                return Err(EvictionError::FollowersLagging);
+            }
+        }
+
+        // Gate 6. Propose the removal of the single victim.
+
+        match self.propose(RaftCommand::RemovePeer(victim.clone())) {
+            Ok(_) => {
+                tracing::info!("evicting live ex-owner after ring stability window",);
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(?victim, error = ?e, "Stale-peer RemovePeer rejected");
+                Err(EvictionError::ProposalRejected)
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn record_ring_observation(&mut self, ring: &BTreeSet<NodeId>) -> u32 {
+        let observations = match self.ring_observation_streak.take() {
+            Some((prev, n)) if prev == *ring => n.saturating_add(1),
+            _ => 1,
+        };
+        self.ring_observation_streak = Some((ring.clone(), observations));
+        observations
     }
 
     /// scan active segments in this group for any whose replica set still names a
@@ -668,6 +813,8 @@ impl Raft {
 
         // Peer state tracker needs to be re-initialized on every leadership transition
         self.peer_states.clear();
+        // #135: ring confidence is leader-volatile — re-earn it.
+        self.ring_observation_streak = None;
         for peer_id in self.peers.iter() {
             self.peer_states.insert(
                 peer_id.clone(),
@@ -719,6 +866,8 @@ impl Raft {
         }
 
         self.cancel_leader_timers();
+        // #135: a deposed leader's ring observations die with its term.
+        self.ring_observation_streak = None;
         if was_leader {
             // The election timer resets only on a vote grant or
             // on AppendEntries from the current leader — never on a mere
@@ -1084,9 +1233,9 @@ impl Raft {
     // -> Majority ack -> committed
     // -> Applied to MetadataStateMachine → topic blue exists
     /// Returns the log index at which the command was appended on success.
-    pub fn propose(&mut self, command: RaftCommand) -> Result<u64, ClientProposalError> {
+    pub fn propose(&mut self, command: RaftCommand) -> Result<u64, ProposalError> {
         if self.role != Role::Leader {
-            return Err(ClientProposalError::NotLeader(self.current_leader.clone()));
+            return Err(ProposalError::NotLeader(self.current_leader.clone()));
         }
 
         self.add_new_entry(command);
@@ -1353,7 +1502,7 @@ mod tests {
     use super::*;
 
     impl Raft {
-        pub(crate) fn propose_noop(&mut self) -> Result<u64, ClientProposalError> {
+        pub(crate) fn propose_noop(&mut self) -> Result<u64, ProposalError> {
             self.propose(RaftCommand::Noop)
         }
 
@@ -1819,7 +1968,7 @@ mod tests {
         let mut raft = three_node_raft("node-1");
         assert_eq!(
             raft.propose_noop(),
-            Err::<u64, _>(ClientProposalError::NotLeader(None))
+            Err::<u64, _>(ProposalError::NotLeader(None))
         );
     }
 
@@ -1842,7 +1991,7 @@ mod tests {
 
         assert_eq!(
             raft.propose_noop(),
-            Err::<u64, _>(ClientProposalError::NotLeader(Some(node("node-1"))))
+            Err::<u64, _>(ProposalError::NotLeader(Some(node("node-1"))))
         );
     }
 
@@ -2913,6 +3062,262 @@ mod tests {
             raft.stale_live_voters(&ring_matches_voters, &all_live)
                 .is_empty(),
             "no drift when voters equal the ring assignment"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // #135 stale-live-peer eviction: gate-by-gate coverage.
+    //
+    // The 3-node ring at RF=3 assigns every group all three nodes, so any
+    // real group id taken from the reader has members {node-1..3} — which
+    // lets these tests line a Raft's shard_group_id up with an actual ring
+    // group (the synthetic TEST_SHARD never resolves on the ring).
+    // -------------------------------------------------------------------
+
+    /// Leader over a real ring group plus the named extra "stale" voters.
+    /// Ring peers have granted the election; nothing is acked yet, so
+    /// commit_index is 0 until the test drives `ack_to_last`.
+    fn ring_raft_with_stale(stale_names: &[&str]) -> (Raft, TopologyReader, Vec<NodeId>) {
+        let reader = topology_reader_with(&["node-1", "node-2", "node-3"]);
+        let group = reader
+            .shard_groups_for_node(&node("node-1"))
+            .first()
+            .expect("node-1 must own at least one group")
+            .clone();
+
+        let mut peers: HashSet<NodeId> = group
+            .members
+            .iter()
+            .filter(|m| **m != node("node-1"))
+            .cloned()
+            .collect();
+        for stale in stale_names {
+            peers.insert(node(stale));
+        }
+
+        let mut raft = Raft::new(
+            node("node-1"),
+            peers,
+            RaftPersistentState::default(),
+            0,
+            group.id,
+            test_timer_seqs(),
+        );
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: group.id,
+            epoch: u64::MAX,
+        });
+        let term = raft.current_term();
+        for peer in group.members.iter().filter(|m| **m != node("node-1")) {
+            raft.handle_rpc(
+                peer.clone(),
+                RaftRpc::RequestVoteResponse(RequestVoteResponse {
+                    term,
+                    node_id: peer.clone(),
+                    vote_granted: true,
+                }),
+            );
+        }
+        drain(&mut raft);
+        assert_eq!(raft.role, Role::Leader, "must be leader after election");
+
+        let members = group.members.clone();
+        (raft, reader, members)
+    }
+
+    /// Simulate `peer` confirming replication up to the leader's last index.
+    fn ack_to_last(raft: &mut Raft, peer: &NodeId) {
+        let term = raft.current_term();
+        let last = raft.log_last_index();
+        raft.handle_rpc(
+            peer.clone(),
+            RaftRpc::AppendEntriesResponse(AppendEntriesResponse {
+                term,
+                node_id: peer.clone(),
+                success: true,
+                last_log_index: last,
+            }),
+        );
+        drain(raft);
+    }
+
+    fn ring_peers(members: &[NodeId]) -> Vec<NodeId> {
+        members
+            .iter()
+            .filter(|m| **m != node("node-1"))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn stale_live_peer_evicted_after_ring_stability_window() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9"]);
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        let live = live_set(&["node-1", "node-2", "node-3", "node-9"]);
+
+        // The window itself parks the eviction…
+        for _ in 0..RING_STABLE_OBSERVATIONS - 1 {
+            assert!(
+                raft.reconcile_stale_live_peers(&topology, &live).is_err(),
+                "no eviction before the stability window completes"
+            );
+        }
+        // …and the pass that completes it evicts exactly the stale member.
+        assert!(raft.reconcile_stale_live_peers(&topology, &live).is_ok());
+
+        assert_eq!(
+            proposals_after_become_leader(&raft),
+            vec![RaftCommand::RemovePeer(node("node-9"))],
+            "pure shrink back to RF: a removal with no paired addition"
+        );
+    }
+
+    #[test]
+    fn eviction_parks_behind_in_flight_config_change_then_proceeds() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9"]);
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        let live = live_set(&["node-1", "node-2", "node-3", "node-9"]);
+
+        for _ in 0..RING_STABLE_OBSERVATIONS - 1 {
+            assert!(raft.reconcile_stale_live_peers(&topology, &live).is_err());
+        }
+
+        // A membership entry is in flight: the window is complete, but the
+        // one-config-change-at-a-time gate must park the eviction.
+        raft.propose(RaftCommand::AddPeer(node("node-7"))).unwrap();
+        assert!(
+            raft.reconcile_stale_live_peers(&topology, &live).is_err(),
+            "uncommitted AddPeer must park the eviction"
+        );
+
+        // Once the add commits (ring peers ack, entry applies), the next
+        // pass may evict — add-before-remove falls out of the gate.
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        assert!(raft.reconcile_stale_live_peers(&topology, &live).is_ok());
+
+        assert_eq!(
+            proposals_after_become_leader(&raft),
+            vec![
+                RaftCommand::AddPeer(node("node-7")),
+                RaftCommand::RemovePeer(node("node-9")),
+            ],
+        );
+    }
+
+    #[test]
+    fn one_eviction_per_pass_smallest_node_first() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9", "node-8"]);
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        let live = live_set(&["node-1", "node-2", "node-3", "node-8", "node-9"]);
+
+        for _ in 0..RING_STABLE_OBSERVATIONS - 1 {
+            assert!(raft.reconcile_stale_live_peers(&topology, &live).is_err());
+        }
+        assert!(raft.reconcile_stale_live_peers(&topology, &live).is_ok());
+
+        // The second stale member must wait: the first removal is in flight.
+        assert!(
+            raft.reconcile_stale_live_peers(&topology, &live).is_err(),
+            "second eviction must park behind the uncommitted first"
+        );
+
+        assert_eq!(
+            proposals_after_become_leader(&raft),
+            vec![RaftCommand::RemovePeer(node("node-8"))],
+            "one eviction per pass, smallest NodeId first"
+        );
+    }
+
+    #[test]
+    fn eviction_parks_while_a_ring_member_lags() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9"]);
+        let peers = ring_peers(&members);
+        let (acked, lagging) = (&peers[0], &peers[1]);
+
+        // Commit advances via the stale member's ack, leaving one ring
+        // member behind the committed prefix.
+        ack_to_last(&mut raft, acked);
+        ack_to_last(&mut raft, &node("node-9"));
+        raft.simulate_flush_and_apply();
+        let live = live_set(&["node-1", "node-2", "node-3", "node-9"]);
+
+        for _ in 0..RING_STABLE_OBSERVATIONS + 2 {
+            assert!(
+                raft.reconcile_stale_live_peers(&topology, &live).is_err(),
+                "a lagging ring member must park the eviction"
+            );
+        }
+
+        // The laggard catches up; the very next pass may evict.
+        ack_to_last(&mut raft, lagging);
+        assert!(raft.reconcile_stale_live_peers(&topology, &live).is_ok());
+        assert_eq!(
+            proposals_after_become_leader(&raft),
+            vec![RaftCommand::RemovePeer(node("node-9"))],
+        );
+    }
+
+    #[test]
+    fn ring_instability_restarts_the_observation_window() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9"]);
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        let live = live_set(&["node-1", "node-2", "node-3", "node-9"]);
+
+        for _ in 0..RING_STABLE_OBSERVATIONS - 1 {
+            assert!(raft.reconcile_stale_live_peers(&topology, &live).is_err());
+        }
+
+        // A divergent snapshot lands mid-window (rebalance in progress):
+        // whatever this group looks like on the shrunken ring — different
+        // membership or vanished outright — confidence must restart.
+        let shrunken = topology_reader_with(&["node-1", "node-2"]);
+        assert!(raft.reconcile_stale_live_peers(&shrunken, &live).is_err());
+
+        // Back on the stable ring, the full window is owed again.
+        for _ in 0..RING_STABLE_OBSERVATIONS - 1 {
+            assert!(
+                raft.reconcile_stale_live_peers(&topology, &live).is_err(),
+                "instability must restart the window, not resume it"
+            );
+        }
+        assert!(raft.reconcile_stale_live_peers(&topology, &live).is_ok());
+        assert_eq!(
+            proposals_after_become_leader(&raft),
+            vec![RaftCommand::RemovePeer(node("node-9"))],
+        );
+    }
+
+    #[test]
+    fn dead_stale_member_is_left_to_reconcile_peers() {
+        let (mut raft, topology, members) = ring_raft_with_stale(&["node-9"]);
+        for peer in ring_peers(&members) {
+            ack_to_last(&mut raft, &peer);
+        }
+        raft.simulate_flush_and_apply();
+        // node-9 is an ex-owner AND dead: not this path's jurisdiction.
+        let live = live_set(&["node-1", "node-2", "node-3"]);
+
+        for _ in 0..RING_STABLE_OBSERVATIONS + 2 {
+            assert!(raft.reconcile_stale_live_peers(&topology, &live).is_err());
+        }
+        assert!(
+            proposals_after_become_leader(&raft).is_empty(),
+            "dead voters belong to reconcile_peers' replace pairing"
         );
     }
 

--- a/src/control_plane/membership/topology.rs
+++ b/src/control_plane/membership/topology.rs
@@ -123,6 +123,17 @@ impl TopologyReader {
         None
     }
 
+    /// Ring membership of `group_id` in the current snapshot, regardless of
+    /// whether the local node is among the members. `resolve_nodes_in_group`
+    /// resolves through a member node and therefore returns `None` when the
+    /// caller is itself no longer assigned to the group
+    pub(crate) fn group_ring_members(&self, group_id: ShardGroupId) -> Option<Box<[NodeId]>> {
+        self.0
+            .load()
+            .group(group_id)
+            .map(|g| g.members.clone().into_boxed_slice())
+    }
+
     pub(crate) fn ring_replacements_for(
         &self,
         group_id: ShardGroupId,
@@ -326,6 +337,13 @@ impl Topology {
             .get(node_id)
             .map(|ids| ids.iter().filter_map(|id| self.groups.get(id)).collect())
             .unwrap_or_default()
+    }
+
+    /// Snapshot lookup of a shard group by id. Backs
+    /// `TopologyReader::group_ring_members`; see the reader method for why
+    /// this must not go through a member node.
+    pub(crate) fn group(&self, group_id: ShardGroupId) -> Option<&ShardGroup> {
+        self.groups.get(&group_id)
     }
 
     /// Returns the shard group responsible for `key`.

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -505,7 +505,7 @@ impl<W: WalStorage> DataPlane<W> {
     }
 
     pub(crate) fn enqueue_seal_for_aged_segments(&mut self, max_age: std::time::Duration) {
-        let aged: Vec<SegmentKey> = self
+        let aged: Box<[SegmentKey]> = self
             .segments
             .iter()
             .filter(|(_, t)| t.role() == SegmentRole::Leader && t.age_limit_reached(max_age))


### PR DESCRIPTION
Closes #135.

## Problem

All membership reconciliation ran on `LeaderChange → self` or SWIM join/death events. 
A rebalance under a stable, long-lived leader was therefore reconciled in *neither* direction until the next takeover: new ring members were never added, and live ex-owners were never removed — the voter set only ratcheted
upward past RF.

## Changes (one commit each)

**1. Drift detection (warn-only).** `log_ring_drift` reports live ex-owners and over-sized voter sets at every reconciliation trigger — observability first, no behavior change.

**2. Periodic leader-side ring check.** 

A 30s `RingCheck` timer, armed on `become_leader`, leader-gated on re-arm exactly like `MergeCheck` (a deposed leader lets it die). 

The fired callback is intercepted in `MultiRaft` — the ring diff needs the topology reader, which `Raft` deliberately doesn't hold — then forwarded so the timer lifecycle stays inside `Raft`. Takeover and tick now share one `reconcile_shard` tail (dead-peer replacement + segment backfill + drift telemetry); the add phase differs by caller:

- takeover asserts *all* live ring members unconditionally (genesis-divergence
  heal, #133/#134 — the leader's local peer set can't witness follower state);
- the tick pre-filters `has_peer`, chasing only ring deltas so the
  steady-state log stays free of redundant `AddPeer` entries.

**3. Gated removal of live ex-owners.** 
`reconcile_stale_live_peers`: at most one eviction per pass, all gates required —

- jurisdiction: live ∧ ∉ ring voters only; dead peers remain `reconcile_peers`' job, keeping the two writers commutative;
- ring stability streak: identical membership across 3 consecutive passes  (~1 min at the 30s tick), leader-volatile, reset on any leadership  transition or unresolvable snapshot — a transiently-wrong snapshot mid-rebalance cannot evict a legitimate owner;
- the leader itself must still be a ring member (an ex-owner leader needs leadership transfer, not peer eviction);
- no membership entry in flight: one config change at a time, which also orders add-before-remove naturally;
- every ring member live, already a voter, and caught up (`match_index ≥ commit_index`) — the post-removal quorum holds the full committed prefix and availability never dips below RF;
- deterministic victim: smallest NodeId first.

Deliberately *not* paired with an `AddPeer`: the caught-up gate guarantees all
ring members are present, so the removal is a pure shrink back to RF — the
inverse of `propose_replace_peer`'s pairing for deaths.

## Tests

Gate-by-gate state-level suite (mirroring `reconcile_peers_*`), plus MultiRaft
end-to-ends: a rebalance under a healthy leader converges the add direction
via RingCheck ticks alone, and the ticks drive exactly one unpaired eviction
of a live ex-owner.