### PR TITLE
fix: make leader-selaed segment reable after seal

### DIFF
--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -308,7 +308,7 @@ impl<W: WalStorage> DataPlane<W> {
             C::ReplicaAck(cmd) => self.handle_replica_ack(cmd),
             C::CommitAdvance(cmd) => self.handle_commit_advance(cmd),
             C::SealResponse(cmd) => self.handle_seal_response(cmd),
-            C::SegmentSealed(cmd) => self.handle_segment_sealed(cmd.segment_key),
+            C::SegmentSealed(cmd) => self.retire_old_segment(cmd.segment_key),
 
             // Pass-through to MultiRaftActor — SealRequest is a control plane
             // message that shares the data transport wire format. The
@@ -437,9 +437,8 @@ impl<W: WalStorage> DataPlane<W> {
         let new_segment_key = cmd.old_segment_key.with_segment_id(cmd.new_segment_id);
 
         let shard_group_id = old_tracker.shard_group_id();
-        let old_start = old_tracker.start_entry_id();
-        let old_end = old_tracker.committed_entry_id();
-        let new_start_entry_id = old_end + 1;
+
+        let new_start_entry_id = old_tracker.successor_start_entry_id();
         let mut new_tracker = SegmentTracker::new_with_start_entry_id(
             new_segment_key.file_path(&self.config.data_dir, new_start_entry_id),
             SegmentRole::Leader,
@@ -456,9 +455,14 @@ impl<W: WalStorage> DataPlane<W> {
         // D5 crash recovery: duplicate WAL data is safe. Old entries route to the sealed
         // segment (bounded by metadata end_offset), new entries route to the new segment.
         // Metadata-first recovery (Raft log before WAL) provides the seal boundary.
+        let mut replayed_bytes = 0usize;
         for (data, record_count) in old_tracker.uncommitted_entries() {
+            replayed_bytes += data.len();
             new_tracker.stage_entry(new_segment_key, data, record_count);
         }
+        // Staged replays count toward pending bytes like a fresh produce, so the
+        // `buffer_byte_count == staged bytes` invariant holds after this command.
+        self.buffer_byte_count += replayed_bytes;
 
         self.replication
             .segment_handoff(cmd.old_segment_key, new_segment_key);
@@ -473,21 +477,16 @@ impl<W: WalStorage> DataPlane<W> {
                 ));
         }
 
+        self.retire_old_segment(cmd.old_segment_key);
+
         self.segments.insert_active(new_segment_key, new_tracker);
-        // The leader's old tracker stays in self.segments (no remove here —
-        // that happens via the follower-side SegmentSealed path). But the
-        // resolver index now points at the new active segment for the range;
-        // the old one moves to sealed so cold reads still find it.
-        self.segments
-            .move_active_to_sealed(cmd.old_segment_key, old_start, old_end);
         self.dirty_segments.push(new_segment_key);
         self.needs_flush = true;
     }
 
-    fn handle_segment_sealed(&mut self, segment_key: SegmentKey) {
-        // On followers this is where the seal is first observed; the store
-        // captures end_entry_id from the tracker's own committed boundary.
-        // a duplicate migrate would be harmless (the sealed entry is immutable by construction).
+    // Drop the sealed segment's live tracker and checkpoint its committed
+    // records so cold reads can still serve them.
+    fn retire_old_segment(&mut self, segment_key: SegmentKey) {
         if let Some(tracker) = self.segments.take_active_and_seal(segment_key) {
             self.out.store_checkpoint(tracker.checkpoint(segment_key));
         }
@@ -1598,6 +1597,67 @@ mod tests {
 
         let active = dp.segments.resolve(TopicId(1), RangeId(0), 1).unwrap();
         assert!(matches!(active, SegmentReadState::Active(k) if k == s1));
+    }
+
+    /// Seal before the first commit: the uncommitted record is replayed into the
+    /// successor at the same id, the old (empty) segment is dropped from the
+    /// resolver, and a fetch from offset 0 resolves to the active successor.
+    #[test]
+    fn seal_before_first_commit_keeps_offset_zero_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        let follower = NodeId::new("follower-1");
+
+        // Assign with a follower so the produce does NOT auto-commit: entry 0
+        // is published (write cursor 1) but uncommitted (read cursor 0).
+        dp.handle_command(assign_segment(test_key(), vec![test_node_id(), follower]));
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
+        process_and_flush(
+            &mut dp,
+            DataPlaneCommand::DataPlaneTimeoutCallback(
+                DataPlaneTimeoutCallback::BatchFlushDeadline,
+            ),
+        );
+        assert_eq!(
+            dp.segments
+                .get(&test_key())
+                .unwrap()
+                .cache()
+                .load_read_cursor(),
+            0,
+            "precondition: nothing committed before the seal",
+        );
+
+        // Replication-timeout failover seals the never-committed segment.
+        dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
+            SealResponse {
+                old_segment_key: test_key(),
+                new_segment_id: SegmentId(1),
+                new_replica_set: vec![test_node_id()],
+            }
+            .into(),
+        ));
+
+        let s1 = test_key().with_segment_id(SegmentId(1));
+
+        // Offset 0 resolves to the active successor (which reuses start 0), not
+        // an empty sealed segment — the old segment owned no committed offsets.
+        let resolved = dp.segments.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        assert!(
+            matches!(resolved, SegmentReadState::Active(k) if k == s1),
+            "offset 0 must resolve to the active successor, got {resolved:?}",
+        );
+        assert_eq!(dp.segments.get(&s1).unwrap().start_entry_id(), 0);
+
+        // The replayed record commits on flush (single replica) and is readable
+        // at offset 0 — proving no record was stranded by the seal.
+        dp.flush_batch();
+        assert_eq!(
+            dp.segments.get(&s1).unwrap().cache().load_read_cursor(),
+            1,
+            "replayed record must commit at offset 0 on the successor",
+        );
     }
 
     /// End-to-end cold read through `DataPlane`: a sealed segment's data lives on

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -177,6 +177,22 @@ impl SegmentTracker {
         self.committed_entry_id
     }
 
+    fn committed_count(&self) -> u64 {
+        self.cache.load_read_cursor()
+    }
+
+    /// Successor starts one past the last committed entry — or at `old_start`
+    /// when nothing committed, so replayed records keep their entry ids.
+    pub(crate) fn successor_start_entry_id(&self) -> u64 {
+        self.start_entry_id() + self.committed_count()
+    }
+
+    /// Last committed entry id, or `None` if nothing committed yet — the seal
+    /// boundary, so a segment sealed before its first commit owns no offsets.
+    pub(crate) fn last_committed_entry_id(&self) -> Option<u64> {
+        (self.committed_count() > 0).then_some(self.committed_entry_id)
+    }
+
     pub(crate) fn stage_entry(
         &mut self,
         segment_key: SegmentKey,

--- a/src/data_plane/states/segment_store.rs
+++ b/src/data_plane/states/segment_store.rs
@@ -122,43 +122,45 @@ impl SegmentStore {
             .insert(start, key.segment_id);
     }
 
-    /// Move an entry from `active_by_range` to `sealed_by_range` without
-    /// dropping its live tracker. Used by the leader path on seal
-    pub(crate) fn move_active_to_sealed(
-        &mut self,
-        key: SegmentKey,
-        start_entry_id: u64,
-        end_entry_id: u64,
-    ) {
-        if let Some(active) = self.active_by_range.get_mut(&(key.topic_id, key.range_id)) {
-            active.remove(&start_entry_id);
-            if active.is_empty() {
-                self.active_by_range.remove(&(key.topic_id, key.range_id));
-            }
+    pub(crate) fn unindex_active(&mut self, key: SegmentKey, start_entry_id: u64) {
+        let Some(active) = self.active_by_range.get_mut(&(key.topic_id, key.range_id)) else {
+            return;
+        };
+
+        // ! a segment sealed before its first commit shares its start offset with its successor,
+        // ! so a blind remove could evict that successor.
+        let segment_mapped_to_entry_id = active.get(&start_entry_id).copied();
+        if segment_mapped_to_entry_id != Some(key.segment_id) {
+            return;
         }
-        self.sealed_by_range
-            .entry((key.topic_id, key.range_id))
-            .or_default()
-            .insert(
-                start_entry_id,
-                SealedSegmentLocation {
-                    segment_id: key.segment_id,
-                    end_entry_id,
-                },
-            );
+        active.remove(&start_entry_id);
+        if active.is_empty() {
+            self.active_by_range.remove(&(key.topic_id, key.range_id));
+        }
     }
 
-    /// Take the active tracker out (removing it from `by_key`) AND move its
-    /// index entry to sealed in one step. Used by the follower path's
-    /// `SegmentSealed` handler where the tracker is genuinely done — no more
-    /// writes will happen here, so we hand it to the caller (who turns it
-    /// into a checkpoint) and re-index the offsets as sealed so cold reads
-    /// still find them.
+    /// Take the tracker out of `by_key` and re-index it: always dropped from the
+    /// active index, then added to the sealed index if it has committed offsets
+    /// (so cold reads still find it). Caller checkpoints the returned tracker.
     pub(crate) fn take_active_and_seal(&mut self, key: SegmentKey) -> Option<SegmentTracker> {
         let tracker = self.by_key.remove(&key)?;
-        let start = tracker.start_entry_id();
-        let end = tracker.committed_entry_id();
-        self.move_active_to_sealed(key, start, end);
+        let start_entry_id = tracker.start_entry_id();
+        self.unindex_active(key, start_entry_id);
+
+        // Committed offsets stay cold-readable via the sealed index; a segment
+        // that committed nothing owns none, so unindexing is enough.
+        if let Some(end) = tracker.last_committed_entry_id() {
+            self.sealed_by_range
+                .entry((key.topic_id, key.range_id))
+                .or_default()
+                .insert(
+                    start_entry_id,
+                    SealedSegmentLocation {
+                        segment_id: key.segment_id,
+                        end_entry_id: end,
+                    },
+                );
+        }
         Some(tracker)
     }
 
@@ -320,5 +322,46 @@ mod tests {
 
         // Offset past sealed end_entry_id → no segment found.
         assert!(store.resolve(TopicId(1), RangeId(0), 43).is_none());
+    }
+
+    /// A segment sealed before its first commit owns no offsets, so it must end
+    /// up in neither index — a read for its start offset falls through to the
+    /// successor rather than an empty sealed segment.
+    #[test]
+    fn seal_with_nothing_committed_claims_no_offsets() {
+        let mut store = SegmentStore::new();
+        let s0 = key(1, 0, 0);
+        store.insert_active(s0, tracker(0)); // start 0, nothing committed
+
+        let taken = store.take_active_and_seal(s0);
+        assert!(taken.is_some());
+
+        assert!(
+            store.resolve(TopicId(1), RangeId(0), 0).is_none(),
+            "a segment sealed with nothing committed must not claim offset 0",
+        );
+
+        // The successor reuses start 0 and now serves offset 0.
+        let s1 = key(1, 0, 1);
+        store.insert_active(s1, tracker(0));
+        let r = store.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        assert!(matches!(r, SegmentReadState::Active(g) if g == s1));
+    }
+
+    /// `unindex_active` is segment-id-checked: a segment sealed before its first commit shares its start offset with its successor,
+    /// so unindexing the old segment must not evict the successor already holding that slot.
+    #[test]
+    fn unindex_active_only_removes_the_named_segment() {
+        let mut store = SegmentStore::new();
+        let successor = key(1, 0, 1);
+        store.insert_active(successor, tracker(0)); // successor already at start 0
+
+        store.unindex_active(key(1, 0, 0), 0); // try to unindex the OLD segment id
+
+        let r = store.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        assert!(
+            matches!(r, SegmentReadState::Active(g) if g == successor),
+            "unindexing a different segment id must not evict the successor",
+        );
     }
 }

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -516,35 +516,52 @@ fn produce_then_fetch_hot() -> turmoil::Result {
             assert!(acked, "produce to leader {leader:?} not acked");
         }
 
-        // Fetch from offset 0 on the leader; poll until committed records land.
-        let fetch = ClientRequest::DataPlane(ClientDataPlaneRequest::Fetch(FetchRequest {
-            topic_name: TOPIC.into(),
-            range_id: 0,
-            entry_id: 0,
-            record_index: 0,
-            max_bytes: 1 << 20,
-            keyspace_bound: None,
-        }));
-        let mut result = None;
-        for _ in 0..40 {
+        // Fetch from offset 0, accumulating across next_entry_id. If the range
+        // rolled mid-produce (a replication timeout sealed the active segment),
+        // the records span the sealed segment + its successor, so one fetch
+        // isn't enough — follow next_entry_id across the boundary. A short or
+        // empty response just means "keep polling"; never reaching all three is
+        // a failure.
+        let mut entries = Vec::new();
+        let mut next_entry_id = 0u64;
+        let mut progress_signal = RangeProgressSignal::Active;
+        for _ in 0..80 {
+            let fetch = ClientRequest::DataPlane(ClientDataPlaneRequest::Fetch(FetchRequest {
+                topic_name: TOPIC.into(),
+                range_id: 0,
+                entry_id: next_entry_id,
+                record_index: 0,
+                max_bytes: 1 << 20,
+                keyspace_bound: None,
+            }));
             if let ClientResponse::DataPlane(DataPlaneResponse::Fetched {
-                entries,
-                next_entry_id,
-                progress_signal,
-            }) = send_request(leader.0, leader.1, fetch.clone()).await
-                && !entries.is_empty()
+                entries: batch,
+                next_entry_id: next,
+                progress_signal: signal,
+            }) = send_request(leader.0, leader.1, fetch).await
+                && !batch.is_empty()
             {
-                result = Some((entries, next_entry_id, progress_signal));
-                break;
+                progress_signal = signal;
+                next_entry_id = next;
+                entries.extend(batch);
+                if entries.len() >= 3 {
+                    break;
+                }
+                continue;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
-        let (entries, next_entry_id, progress_signal) =
-            result.expect("no records fetched within timeout");
 
-        assert_eq!(entries.len(), 3, "all three produced records should fetch");
+        assert_eq!(
+            entries.len(),
+            3,
+            "all three produced records should fetch, got {}",
+            entries.len()
+        );
         assert_eq!(entries[0].entry_id, 0);
         assert_eq!(entries[0].data, b"rec-0");
+        assert_eq!(entries[1].data, b"rec-1");
+        assert_eq!(entries[2].data, b"rec-2");
         assert_eq!(next_entry_id, 3);
         assert!(
             matches!(progress_signal, RangeProgressSignal::Active),


### PR DESCRIPTION
A replication-timeout seal moved the segment to the cold index but never checkpointed it on the leader, so fetching the sealed prefix returned nothing (flaky produce_then_fetch_hot). Share retire_old_segment across leader/follower seal, fix the seal boundary when nothing committed yet, and iterate the fetch across the seal boundary.