### PR TITLE
feat(dp): wire D5 crash recovery into startup — orchestrator, WAL lifecycle, crash-sim

### DIFF
--- a/src/data_plane/actor.rs
+++ b/src/data_plane/actor.rs
@@ -1,6 +1,7 @@
 use super::checkpoint::CheckpointJob;
 use super::cold_read::ColdReadPool;
 use super::messages::pending::DataPlaneOutputs;
+use super::recovery::inventory::RecoveryOutput;
 use super::sparse_index::SparseIndex;
 use super::state::DataPlane;
 use super::timer::SegmentAgeTimer;
@@ -34,6 +35,7 @@ impl DataPlaneActor {
         data_transport_tx: BatchSender<DataTransportCommand>,
         coordinator_tx: MutlRaftSender,
         sparse_index: Arc<dyn SparseIndex>,
+        recovery: RecoveryOutput,
     ) -> DataPlaneSender {
         let (timer_tx, mut timer_rx) = mpsc::channel::<DataPlaneCommand>(64);
 
@@ -68,7 +70,14 @@ impl DataPlaneActor {
         thread::Builder::new()
             .name("data-plane-worker".into())
             .spawn(move || {
-                let wal = match WalWriter::new(config.data_dir.clone()) {
+                // Recovery ran in bootstrap (before this node joined the cluster);
+                // it left the WAL dir empty and handed us the verified inventory.
+                // Open the fresh WAL in the dir it cleared.
+                let RecoveryOutput {
+                    inventory,
+                    data_dir,
+                } = recovery;
+                let wal = match WalWriter::new(data_dir) {
                     Ok(w) => w,
                     Err(e) => {
                         tracing::error!("Failed to initialize WAL: {e}");
@@ -82,7 +91,7 @@ impl DataPlaneActor {
                     data_transport_tx,
                     coordinator_tx,
                 );
-                let mut state = DataPlane::new(node_id, config, wal, cold_read_tx, out);
+                let mut state = DataPlane::new(node_id, config, wal, cold_read_tx, out, inventory);
 
                 while let Ok(msg) = mailbox.recv() {
                     state.process(msg);

--- a/src/data_plane/recovery/inventory.rs
+++ b/src/data_plane/recovery/inventory.rs
@@ -13,6 +13,12 @@ impl LocalInventory {
     pub(crate) fn from_recovered(recovered: &RecoveredSegments) -> Self {
         Self(recovered.cursors().collect())
     }
+
+    /// Highest verified entry id held for `key`, or `None` if the segment holds
+    /// no verified data locally.
+    pub(crate) fn get(&self, key: &SegmentKey) -> Option<u64> {
+        self.0.get(key).copied()
+    }
 }
 
 // [`RecoveryOutput`] bundles [`LocalInventory`] with the data dir and is what `DataPlane::new`

--- a/src/data_plane/recovery/inventory.rs
+++ b/src/data_plane/recovery/inventory.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::segment_scan::RecoveredSegments;
+use crate::data_plane::SegmentKey;
+
+/// Built only by [`LocalInventory::from_recovered`];
+/// maps each locally-held segment to the highest entry id a CRC-complete batch put on disk
+#[derive(Debug)]
+pub(crate) struct LocalInventory(HashMap<SegmentKey, u64>);
+
+impl LocalInventory {
+    pub(crate) fn from_recovered(recovered: &RecoveredSegments) -> Self {
+        Self(recovered.cursors().collect())
+    }
+}
+
+// [`RecoveryOutput`] bundles [`LocalInventory`] with the data dir and is what `DataPlane::new`
+// will require: recovery-before-serving stops being a convention and becomes a type, since the serving side cannot be built without one.
+#[derive(Debug)]
+pub(crate) struct RecoveryOutput {
+    pub(crate) inventory: LocalInventory,
+    pub(crate) data_dir: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+
+    fn seg(topic: u64, segment: u64) -> SegmentKey {
+        SegmentKey::new(TopicId(topic), RangeId(0), SegmentId(segment))
+    }
+
+    #[test]
+    fn inventory_is_exactly_the_post_replay_cursors() {
+        let a = seg(1, 0);
+        let b = seg(2, 0);
+        let mut recovered = RecoveredSegments::default();
+        recovered.advance(a, 5); // from-nothing segment, base/cursor 5
+        recovered.advance(b, 0);
+        recovered.advance(b, 1); // cursor 1
+
+        let inv = LocalInventory::from_recovered(&recovered);
+        let cursors: HashMap<SegmentKey, u64> = recovered.cursors().collect();
+        assert_eq!(inv.0, cursors);
+        assert_eq!(inv.0.get(&a), Some(&5));
+        assert_eq!(inv.0.get(&b), Some(&1));
+    }
+
+    #[test]
+    fn empty_recovery_yields_an_empty_inventory() {
+        // The empty-disk path commit 14 constructs through.
+        let inv = LocalInventory::from_recovered(&RecoveredSegments::default());
+        assert!(inv.0.is_empty());
+    }
+
+    #[test]
+    fn recovery_output_bundles_inventory_and_data_dir() {
+        let inv = LocalInventory::from_recovered(&RecoveredSegments::default());
+        let output = RecoveryOutput {
+            inventory: inv,
+            data_dir: PathBuf::from("/var/lib/eastguard/data"),
+        };
+        assert!(output.inventory.0.is_empty());
+        assert_eq!(output.data_dir, PathBuf::from("/var/lib/eastguard/data"));
+    }
+}

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -8,6 +8,7 @@
 //! into node startup.
 
 pub(crate) mod index_rebuild;
+pub(crate) mod inventory;
 pub(crate) mod replay;
 pub(crate) mod segment_scan;
 pub(crate) mod wal_scan;

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -13,11 +13,12 @@ pub(crate) mod replay;
 pub(crate) mod segment_scan;
 pub(crate) mod wal_scan;
 use self::inventory::{LocalInventory, RecoveryOutput};
-use self::replay::ReplayWriter;
+use self::replay::{ReplayOutput, ReplayWriter};
 use self::segment_scan::RecoveredSegments;
 use self::wal_scan::{ScanError, WalScanner};
 use crate::data_plane::sparse_index::SparseIndex;
 use crate::data_plane::states::segment::record::RoutingHeader;
+use std::io;
 use std::path::PathBuf;
 
 /// Fatal recovery failure. WAL *corruption* is deliberately not a variant: it is
@@ -30,66 +31,103 @@ pub(crate) enum RecoveryError {
 }
 
 /// Runs crash recovery and returns the verified local inventory.
+/// It is a small type-state pipeline so the order is enforced by the compiler, not by convention:
 ///
-/// This is the non-destructive half: safe on any disk, since it only reads the WAL and appends the records
-/// the segment files are missing. Pipeline:
-///
-/// 1. scan the segment files into a cursor map — what is already durable,
-/// 2. replay the WAL's un-checkpointed suffix into them, skipping duplicates,
-/// 3. re-index just that appended suffix (full rebuild stays the fallback),
-/// 4. freeze the post-replay cursors into a [`LocalInventory`].
-///
-/// WAL corruption is not fatal: a [`ScanError::Corrupt`] stops replay at the
-/// last verified batch, and recovery proceeds with what was already durable —
-/// it never aborts.
+// ! The safety-critical edge is that the WAL must not be deleted before the segment files are fsynced.
+// ! ```text
+// ! Replaying --replay_wal--> Durable --commit--> RecoveryOutput
+// ! ```
+// ! `commit` is the only thing that deletes the WAL - lives on [`Durable`], and the only way to reach `Durable` is `replay_wal`,
+// ! which fsyncs via `ReplayWriter::finish`. So "delete only after durable" is a compile-time fact, and each state has a narrow API: `Replaying` cannot
+// ! delete, `Durable` cannot replay.
 pub(crate) fn run(
     data_dir: PathBuf,
     index: &dyn SparseIndex,
 ) -> Result<RecoveryOutput, RecoveryError> {
-    let recovered = RecoveredSegments::scan_data_dir(&data_dir)?;
-    let mut writer = ReplayWriter::new(data_dir.clone(), recovered);
-    let mut scanner = WalScanner::open(&data_dir)?;
+    Ok(Replaying::start(data_dir)?.replay_wal()?.commit(index)?)
+}
 
-    loop {
-        match scanner.next_batch() {
-            Ok(Some(batch)) => {
-                for record in &batch.records {
-                    // ! Fail only if a record that already passed the WAL CRC has a payload shorter than the 36-byte header
-                    let (header, entry_data) = RoutingHeader::split_wal_payload(&record.payload)?;
+struct Replaying {
+    data_dir: PathBuf,
+    writer: ReplayWriter,
+    scanner: WalScanner,
+}
 
-                    // ! fails only on a real disk error
-                    writer.replay(&header, entry_data)?;
-                }
-            }
-            Ok(None) => break,
-            Err(ScanError::Corrupt { file, valid_bytes }) => {
-                tracing::warn!(
-                    file = %file.display(),
-                    valid_bytes,
-                    "WAL corruption: stopping replay, keeping what was verified before it",
-                );
-                // ! expected crash artifact (torn/CRC-bad) this is only "recover... only what you can" case
-                break;
-            }
-            // ! Genuine I/O failure, fatal
-            Err(ScanError::Io(e)) => return Err(e.into()),
-        }
+impl Replaying {
+    fn start(data_dir: PathBuf) -> io::Result<Self> {
+        let recovered = RecoveredSegments::scan_data_dir(&data_dir)?;
+        let writer = ReplayWriter::new(data_dir.clone(), recovered);
+        let scanner = WalScanner::open(&data_dir)?;
+        Ok(Self {
+            data_dir,
+            writer,
+            scanner,
+        })
     }
 
-    let output = writer.finish()?;
-    index.put_batch(output.suffix_index.into_vec())?;
-    let inventory = LocalInventory::from_recovered(&output.recovered);
+    /// Replays every WAL batch into the segment files (skipping duplicates) and
+    /// fsyncs them via [`ReplayWriter::finish`] — only after which is the WAL
+    /// deletable.
+    // ! WAL corruption is not fatal: it stops replay at the last verified batch
+    // ! and proceeds with what was already durable.
+    fn replay_wal(mut self) -> io::Result<Durable> {
+        loop {
+            match self.scanner.next_batch() {
+                Ok(Some(batch)) => {
+                    for record in &batch.records {
+                        // Fails only if a record that already passed the WAL CRC
+                        // has a payload shorter than the 36-byte routing header.
+                        let (header, entry_data) =
+                            RoutingHeader::split_wal_payload(&record.payload)?;
+                        // Fails only on a real disk error.
+                        self.writer.replay(&header, entry_data)?;
+                    }
+                }
+                Ok(None) => break,
+                Err(ScanError::Corrupt { file, valid_bytes }) => {
+                    // Expected crash artifact (torn / CRC-bad tail) — the only
+                    // "recover what you can" case.
+                    tracing::warn!(
+                        file = %file.display(),
+                        valid_bytes,
+                        "WAL corruption: stopping replay, keeping what was verified before it",
+                    );
+                    break;
+                }
+                // Genuine I/O failure — fatal.
+                Err(ScanError::Io(e)) => return Err(e),
+            }
+        }
 
-    // The WAL's contents are now durable in the segment files (finish fsynced
-    // them), so the WAL is superseded — delete it. The fresh WAL is created
-    // later by the serving side (DataPlane, commit 14), leaving the dir empty in
-    // between (an empty WAL just means nothing to replay).
-    scanner.delete_files()?;
+        let output = self.writer.finish()?;
+        Ok(Durable {
+            data_dir: self.data_dir,
+            scanner: self.scanner,
+            output,
+        })
+    }
+}
 
-    Ok(RecoveryOutput {
-        inventory,
-        data_dir,
-    })
+struct Durable {
+    data_dir: PathBuf,
+    scanner: WalScanner,
+    output: ReplayOutput,
+}
+
+impl Durable {
+    /// Re-indexes the replayed suffix, freezes the cursors into a
+    /// [`LocalInventory`], then DELETEs the now-superseded WAL. The fresh WAL is
+    /// the serving side's job (commit 14), leaving the dir empty in between — an
+    /// empty WAL just means nothing to replay.
+    fn commit(self, index: &dyn SparseIndex) -> io::Result<RecoveryOutput> {
+        index.put_batch(self.output.suffix_index.into_vec())?;
+        let inventory = LocalInventory::from_recovered(&self.output.recovered);
+        self.scanner.delete_files()?;
+        Ok(RecoveryOutput {
+            inventory,
+            data_dir: self.data_dir,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -141,7 +141,7 @@ mod tests {
     use super::*;
     use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
     use crate::data_plane::SegmentKey;
-    use crate::data_plane::wal::WalRecord;
+    use crate::data_plane::wal::{WalRecord, WalStorage, WalWriter};
 
     /// One bare-payload `(Data, BatchEnd)` batch — the segment-file framing the
     /// checkpoint worker writes (no routing header).
@@ -330,5 +330,102 @@ mod tests {
         assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), before);
         assert_eq!(output.inventory.get(&a), Some(1));
         assert!(fs::read_dir(data_dir.join("wal")).unwrap().next().is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Crash simulation: produce through the real WAL writer,
+    // "kill" the process at a chosen point, recover, and assert the recovered
+    // state equals exactly what was ACKed — no more, no less.
+    // ---------------------------------------------------------------
+
+    /// Produces entries through the real `WalWriter` — one fsynced batch per
+    /// inner slice, exactly like the live produce path — then drops it. Dropping
+    /// with no graceful shutdown or WAL cleanup *is* the crash: the fsynced files
+    /// stay on disk as they were the instant the process died.
+    fn produce_and_crash(data_dir: &Path, batches: &[&[(SegmentKey, u64, &str)]]) {
+        let mut wal = WalWriter::new(data_dir.to_path_buf()).unwrap();
+        for batch in batches {
+            for &(key, entry_id, payload) in *batch {
+                let wp = RoutingHeader::new(key, entry_id, 1).build_wal_payload(payload.as_bytes());
+                WalRecord::data(wp, 1).encode_to(wal.buf()).unwrap();
+            }
+            WalRecord::batch_end().encode_to(wal.buf()).unwrap();
+            wal.flush_batch().unwrap();
+        }
+    }
+
+    /// Appends a half-written record to the single WAL file — bytes that were in
+    /// flight when the crash struck and never reached their fsync.
+    fn append_torn_tail(data_dir: &Path, key: SegmentKey, entry_id: u64) {
+        let mut torn = wal_batch(&[wal_data(key, entry_id, 1, "torn")]);
+        torn.truncate(torn.len() - 4);
+        let path = data_dir.join("wal").join("wal-000001.log");
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        std::io::Write::write_all(&mut f, &torn).unwrap();
+    }
+
+    #[test]
+    fn crash_mid_batch_recovers_acked_and_drops_the_torn_tail() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+
+        // ACKed: entries 0 and 1 (two fsynced batches). Then a torn write of 2
+        // that the crash interrupted before its fsync.
+        produce_and_crash(&data_dir, &[&[(a, 0, "a0")], &[(a, 1, "a1")]]);
+        append_torn_tail(&data_dir, a, 2);
+
+        let (_db, db) = open_db();
+        let output = run(data_dir.clone(), &db).unwrap();
+
+        // Exactly the ACKed prefix survives; the never-fsynced entry 2 is gone.
+        assert_eq!(output.inventory.get(&a), Some(1));
+        assert_eq!(last_id(&data_dir, a, 0), Some(1));
+    }
+
+    #[test]
+    fn crash_after_checkpoint_recovers_the_uncheckpointed_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+
+        // The checkpoint worker had flushed entry 0 to the segment file...
+        write_segment(&data_dir, a, 0, &seg_batch("a0", 1));
+        // ...but the WAL (entries 0..=2, all ACKed) was not yet deleted at the crash.
+        produce_and_crash(&data_dir, &[&[(a, 0, "a0"), (a, 1, "a1"), (a, 2, "a2")]]);
+
+        let (_db, db) = open_db();
+        let output = run(data_dir.clone(), &db).unwrap();
+
+        // Entry 0 dedups against the checkpoint; 1 and 2 are replayed from the WAL.
+        assert_eq!(output.inventory.get(&a), Some(2));
+        assert_eq!(last_id(&data_dir, a, 0), Some(2));
+        assert!(fs::read_dir(data_dir.join("wal")).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn crash_mid_recovery_truncates_torn_segment_then_replays() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+
+        // The WAL holds ACKed entries 0 and 1.
+        produce_and_crash(&data_dir, &[&[(a, 0, "a0"), (a, 1, "a1")]]);
+        // A previous recovery had begun appending to the segment but crashed
+        // mid-write: entry 0 is complete, followed by a half-written fragment.
+        let mut seg = seg_batch("a0", 1);
+        seg.extend_from_slice(b"torn-half-written-entry");
+        write_segment(&data_dir, a, 0, &seg);
+
+        let (_db, db) = open_db();
+        let output = run(data_dir.clone(), &db).unwrap();
+
+        // The torn segment tail is truncated to the verified prefix, then entry 1
+        // is re-replayed from the WAL — converging to the full ACKed sequence.
+        assert_eq!(output.inventory.get(&a), Some(1));
+        assert_eq!(last_id(&data_dir, a, 0), Some(1));
     }
 }

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -12,3 +12,228 @@ pub(crate) mod inventory;
 pub(crate) mod replay;
 pub(crate) mod segment_scan;
 pub(crate) mod wal_scan;
+use self::inventory::{LocalInventory, RecoveryOutput};
+use self::replay::ReplayWriter;
+use self::segment_scan::RecoveredSegments;
+use self::wal_scan::{ScanError, WalScanner};
+use crate::data_plane::sparse_index::SparseIndex;
+use crate::data_plane::states::segment::record::RoutingHeader;
+use std::path::PathBuf;
+
+/// Fatal recovery failure. WAL *corruption* is deliberately not a variant: it is
+/// not fatal — `run` stops replay at the last verified batch and recovers what
+/// was already durable. Only genuine I/O failures abort recovery.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RecoveryError {
+    #[error("recovery I/O failure: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Runs crash recovery and returns the verified local inventory.
+///
+/// This is the non-destructive half: safe on any disk, since it only reads the WAL and appends the records
+/// the segment files are missing. Pipeline:
+///
+/// 1. scan the segment files into a cursor map — what is already durable,
+/// 2. replay the WAL's un-checkpointed suffix into them, skipping duplicates,
+/// 3. re-index just that appended suffix (full rebuild stays the fallback),
+/// 4. freeze the post-replay cursors into a [`LocalInventory`].
+///
+/// WAL corruption is not fatal: a [`ScanError::Corrupt`] stops replay at the
+/// last verified batch, and recovery proceeds with what was already durable —
+/// it never aborts.
+pub(crate) fn run(
+    data_dir: PathBuf,
+    index: &dyn SparseIndex,
+) -> Result<RecoveryOutput, RecoveryError> {
+    let recovered = RecoveredSegments::scan_data_dir(&data_dir)?;
+    let mut writer = ReplayWriter::new(data_dir.clone(), recovered);
+    let mut scanner = WalScanner::open(&data_dir)?;
+
+    loop {
+        match scanner.next_batch() {
+            Ok(Some(batch)) => {
+                for record in &batch.records {
+                    // ! Fail only if a record that already passed the WAL CRC has a payload shorter than the 36-byte header
+                    let (header, entry_data) = RoutingHeader::split_wal_payload(&record.payload)?;
+
+                    // ! fails only on a real disk error
+                    writer.replay(&header, entry_data)?;
+                }
+            }
+            Ok(None) => break,
+            Err(ScanError::Corrupt { file, valid_bytes }) => {
+                tracing::warn!(
+                    file = %file.display(),
+                    valid_bytes,
+                    "WAL corruption: stopping replay, keeping what was verified before it",
+                );
+                // ! expected crash artifact (torn/CRC-bad) this is only "recover... only what you can" case
+                break;
+            }
+            // ! Genuine I/O failure, fatal
+            Err(ScanError::Io(e)) => return Err(e.into()),
+        }
+    }
+
+    let output = writer.finish()?;
+    index.put_batch(output.suffix_index.into_vec())?;
+
+    Ok(RecoveryOutput {
+        inventory: LocalInventory::from_recovered(&output.recovered),
+        data_dir,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use bytes::Bytes;
+
+    use super::segment_scan::scan_segment_file;
+    use super::*;
+    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+    use crate::data_plane::SegmentKey;
+    use crate::data_plane::wal::WalRecord;
+
+    /// One bare-payload `(Data, BatchEnd)` batch — the segment-file framing the
+    /// checkpoint worker writes (no routing header).
+    fn seg_batch(payload: &str, record_count: u32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        WalRecord::data(Bytes::copy_from_slice(payload.as_bytes()), record_count)
+            .encode_to(&mut buf)
+            .unwrap();
+        WalRecord::batch_end().encode_to(&mut buf).unwrap();
+        buf
+    }
+
+    /// One WAL data record: a routing header followed by the bare payload,
+    /// exactly as the live produce path (`tracker.rs`) stages it.
+    fn wal_data(key: SegmentKey, entry_id: u64, record_count: u32, payload: &str) -> WalRecord {
+        let wal_payload =
+            RoutingHeader::new(key, entry_id, record_count).build_wal_payload(payload.as_bytes());
+        WalRecord::data(wal_payload, record_count)
+    }
+
+    /// Encodes `records` followed by a batch-end marker — one fsynced WAL batch.
+    fn wal_batch(records: &[WalRecord]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for record in records {
+            record.encode_to(&mut buf).unwrap();
+        }
+        WalRecord::batch_end().encode_to(&mut buf).unwrap();
+        buf
+    }
+
+    fn write_segment(data_dir: &Path, key: SegmentKey, start_offset: u64, bytes: &[u8]) {
+        let path = key.file_path(data_dir, start_offset);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn write_wal(data_dir: &Path, seq: u64, bytes: &[u8]) {
+        let wal_dir = data_dir.join("wal");
+        fs::create_dir_all(&wal_dir).unwrap();
+        fs::write(wal_dir.join(format!("wal-{seq:06}.log")), bytes).unwrap();
+    }
+
+    fn open_db() -> (tempfile::TempDir, rocksdb::DB) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = rocksdb::DB::open_default(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    fn last_id(data_dir: &Path, key: SegmentKey, start_offset: u64) -> Option<u64> {
+        scan_segment_file(&key.file_path(data_dir, start_offset))
+            .unwrap()
+            .last_entry_id
+    }
+
+    #[test]
+    fn runs_full_pipeline_and_builds_inventory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+        let b = SegmentKey::new(TopicId(1), RangeId(1), SegmentId(0));
+
+        // Checkpointed prefix already on disk: entry 0 of each segment.
+        write_segment(&data_dir, a, 0, &seg_batch("a0", 1));
+        write_segment(&data_dir, b, 0, &seg_batch("b0", 1));
+
+        // WAL re-presents the checkpointed entries (overlap → skipped) plus the
+        // un-checkpointed suffix, interleaved across the two segments.
+        write_wal(
+            &data_dir,
+            1,
+            &wal_batch(&[
+                wal_data(a, 0, 1, "a0"),
+                wal_data(b, 0, 1, "b0"),
+                wal_data(a, 1, 1, "a1"),
+                wal_data(b, 1, 1, "b1"),
+                wal_data(a, 2, 1, "a2"),
+            ]),
+        );
+
+        let (_db_dir, db) = open_db();
+        let output = run(data_dir.clone(), &db).unwrap();
+
+        // Inventory reflects the post-replay cursors.
+        assert_eq!(output.inventory.get(&a), Some(2)); // a0, a1, a2
+        assert_eq!(output.inventory.get(&b), Some(1)); // b0, b1
+        assert_eq!(output.data_dir, data_dir);
+
+        // The segment files actually gained the replayed suffix.
+        assert_eq!(last_id(&data_dir, a, 0), Some(2));
+        assert_eq!(last_id(&data_dir, b, 0), Some(1));
+    }
+
+    #[test]
+    fn re_running_recovery_converges() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+        write_segment(&data_dir, a, 0, &seg_batch("a0", 1));
+        write_wal(
+            &data_dir,
+            1,
+            &wal_batch(&[
+                wal_data(a, 0, 1, "a0"),
+                wal_data(a, 1, 1, "a1"),
+                wal_data(a, 2, 1, "a2"),
+            ]),
+        );
+
+        let (_db_dir, db) = open_db();
+        run(data_dir.clone(), &db).unwrap();
+        let after_first = fs::read(a.file_path(&data_dir, 0)).unwrap();
+
+        // Commit 12 leaves the WAL in place, so a second run replays the same
+        // records — every one now dedups, leaving the file byte-identical.
+        let output = run(data_dir.clone(), &db).unwrap();
+        assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), after_first);
+        assert_eq!(output.inventory.get(&a), Some(2));
+    }
+
+    #[test]
+    fn corruption_is_not_fatal_and_keeps_the_verified_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+
+        // Earlier file: a clean batch (entry 0) then a torn one (entry 1).
+        // Damage in a non-last file is corruption, not a tolerable torn tail.
+        let intact = wal_batch(&[wal_data(a, 0, 1, "a0")]);
+        let mut damaged = wal_batch(&[wal_data(a, 1, 1, "a1")]);
+        damaged.truncate(damaged.len() - 3);
+        write_wal(&data_dir, 1, &[intact, damaged].concat());
+        write_wal(&data_dir, 2, &wal_batch(&[wal_data(a, 2, 1, "a2")]));
+
+        let (_db_dir, db) = open_db();
+        // Recovery returns Ok, having recovered only the pre-corruption entry.
+        let output = run(data_dir.clone(), &db).unwrap();
+        assert_eq!(output.inventory.get(&a), Some(0));
+        assert_eq!(last_id(&data_dir, a, 0), Some(0));
+    }
+}

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -78,9 +78,16 @@ pub(crate) fn run(
 
     let output = writer.finish()?;
     index.put_batch(output.suffix_index.into_vec())?;
+    let inventory = LocalInventory::from_recovered(&output.recovered);
+
+    // The WAL's contents are now durable in the segment files (finish fsynced
+    // them), so the WAL is superseded — delete it. The fresh WAL is created
+    // later by the serving side (DataPlane, commit 14), leaving the dir empty in
+    // between (an empty WAL just means nothing to replay).
+    scanner.delete_files()?;
 
     Ok(RecoveryOutput {
-        inventory: LocalInventory::from_recovered(&output.recovered),
+        inventory,
         data_dir,
     })
 }
@@ -209,8 +216,9 @@ mod tests {
         run(data_dir.clone(), &db).unwrap();
         let after_first = fs::read(a.file_path(&data_dir, 0)).unwrap();
 
-        // Commit 12 leaves the WAL in place, so a second run replays the same
-        // records — every one now dedups, leaving the file byte-identical.
+        // Commit 13 deletes the WAL after the first run, so the second run finds
+        // an empty WAL dir and rebuilds the inventory from the segment files
+        // alone — still byte-identical, still cursor 2.
         let output = run(data_dir.clone(), &db).unwrap();
         assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), after_first);
         assert_eq!(output.inventory.get(&a), Some(2));
@@ -235,5 +243,54 @@ mod tests {
         let output = run(data_dir.clone(), &db).unwrap();
         assert_eq!(output.inventory.get(&a), Some(0));
         assert_eq!(last_id(&data_dir, a, 0), Some(0));
+    }
+
+    #[test]
+    fn recovery_clears_the_wal_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+        write_wal(&data_dir, 1, &wal_batch(&[wal_data(a, 0, 1, "a0")]));
+        write_wal(&data_dir, 2, &wal_batch(&[wal_data(a, 1, 1, "a1")]));
+
+        let (_db_dir, db) = open_db();
+        run(data_dir.clone(), &db).unwrap();
+
+        // Every discovered WAL file is deleted; the dir is left empty (the fresh
+        // WAL is the serving side's job, commit 14).
+        let remaining: Vec<_> = fs::read_dir(data_dir.join("wal"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        assert!(remaining.is_empty(), "WAL dir not empty: {remaining:?}");
+        // The data itself survived in the segment file.
+        assert_eq!(last_id(&data_dir, a, 0), Some(1));
+    }
+
+    #[test]
+    fn converges_after_a_partial_wal_deletion() {
+        // Simulates a crash mid-deletion: the segment already holds entries 0 and
+        // 1, one old WAL file was already deleted, and only the survivor remains.
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+        write_segment(
+            &data_dir,
+            a,
+            0,
+            &[seg_batch("a0", 1), seg_batch("a1", 1)].concat(),
+        );
+        // The survivor re-presents entry 1 — already on disk, so it dedups.
+        write_wal(&data_dir, 2, &wal_batch(&[wal_data(a, 1, 1, "a1")]));
+        let before = fs::read(a.file_path(&data_dir, 0)).unwrap();
+
+        let (_db_dir, db) = open_db();
+        let output = run(data_dir.clone(), &db).unwrap();
+
+        // Zero appends (the survivor dedups), the segment is byte-identical, and
+        // the already-deleted half's data was safe in the segment all along.
+        assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), before);
+        assert_eq!(output.inventory.get(&a), Some(1));
+        assert!(fs::read_dir(data_dir.join("wal")).unwrap().next().is_none());
     }
 }

--- a/src/data_plane/recovery/replay.rs
+++ b/src/data_plane/recovery/replay.rs
@@ -6,9 +6,10 @@
 //! aren't. It opens one appender per segment lazily — truncating any damaged
 //! tail to `valid_len` before the first write — and re-encodes each record in
 //! the checkpoint's `(Data, BatchEnd)` framing with the **bare** entry payload
-//! (the routing header is WAL-only). [`ReplayWriter::finish`] fsyncs every file
-//! before the cursors become the inventory: nothing is reported durable until
-//! it is on disk.
+//! (the routing header is WAL-only), tracking the byte offset of each appended
+//! record so it can hand back the index anchors for the suffix it wrote.
+//! [`ReplayWriter::finish`] fsyncs every file before the cursors become the
+//! inventory: nothing is reported durable until it is on disk.
 
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
@@ -19,6 +20,7 @@ use bytes::Bytes;
 
 use super::segment_scan::{Decision, RecoveredSegments};
 use crate::data_plane::SegmentKey;
+use crate::data_plane::sparse_index::{SparseEntry, is_index_anchor};
 use crate::data_plane::states::segment::record::RoutingHeader;
 use crate::data_plane::wal::WalRecord;
 
@@ -30,8 +32,40 @@ use crate::data_plane::wal::WalRecord;
 /// too, not just WAL-vs-file.
 pub(crate) struct ReplayWriter {
     data_dir: PathBuf,
+    writers: HashMap<SegmentKey, SegmentAppender>,
     recovered: RecoveredSegments,
-    writers: HashMap<SegmentKey, BufWriter<File>>,
+    index_entries: Vec<SparseEntry>,
+}
+
+/// What [`ReplayWriter::finish`] produces: the advanced cursors (which become
+/// the local inventory) and the index anchors for the suffix replay appended.
+/// The orchestrator feeds `suffix_index` through `SparseIndex::put_batch`, so
+/// only the replayed suffix is re-indexed — the checkpointed prefix the live
+/// index already covers is left untouched.
+pub(crate) struct ReplayOutput {
+    pub(crate) recovered: RecoveredSegments,
+    pub(crate) suffix_index: Box<[SparseEntry]>,
+}
+
+/// One open segment appender plus the absolute byte offset of its next write —
+/// the position an index anchor would point at.
+struct SegmentAppender {
+    writer: BufWriter<File>,
+    next_pos: u64,
+}
+
+impl SegmentAppender {
+    /// Writes one `(Data, BatchEnd)` batch with the bare `entry_data` payload and
+    /// returns the absolute byte offset where the `Data` record begins.
+    fn append_batch(&mut self, entry_data: &[u8], record_count: u32) -> io::Result<u64> {
+        let data_start = self.next_pos;
+        let data = WalRecord::data(Bytes::copy_from_slice(entry_data), record_count);
+        data.encode_to(&mut self.writer)?;
+        let end = WalRecord::batch_end();
+        end.encode_to(&mut self.writer)?;
+        self.next_pos += data.encoded_size() as u64 + end.encoded_size() as u64;
+        Ok(data_start)
+    }
 }
 
 impl ReplayWriter {
@@ -40,6 +74,7 @@ impl ReplayWriter {
             data_dir,
             recovered,
             writers: HashMap::new(),
+            index_entries: Vec::new(),
         }
     }
 
@@ -57,23 +92,33 @@ impl ReplayWriter {
             return Ok(Decision::Skip);
         }
         let key = header.segment_key();
-        let writer = self.writer_for(key, header.entry_id)?;
-        WalRecord::data(Bytes::copy_from_slice(entry_data), header.record_count)
-            .encode_to(writer)?;
-        WalRecord::batch_end().encode_to(writer)?;
+        let data_start = self
+            .writer_for(key, header.entry_id)?
+            .append_batch(entry_data, header.record_count)?;
+        if is_index_anchor(data_start, header.entry_id) {
+            self.index_entries.push(SparseEntry::new(
+                key,
+                header.entry_id,
+                data_start.to_be_bytes(),
+            ));
+        }
         self.recovered.advance(key, header.entry_id);
         Ok(Decision::Append)
     }
 
     /// Flushes and fsyncs every open segment file, then returns the advanced
-    /// cursors (which become the local inventory). Nothing replay appended is
-    /// durable until this returns `Ok`.
-    pub(crate) fn finish(mut self) -> io::Result<RecoveredSegments> {
-        for writer in self.writers.values_mut() {
-            writer.flush()?;
-            writer.get_ref().sync_all()?;
+    /// cursors (which become the local inventory) together with the index
+    /// anchors for the suffix it appended. Nothing replay appended is durable
+    /// until this returns `Ok`.
+    pub(crate) fn finish(mut self) -> io::Result<ReplayOutput> {
+        for appender in self.writers.values_mut() {
+            appender.writer.flush()?;
+            appender.writer.get_ref().sync_all()?;
         }
-        Ok(self.recovered)
+        Ok(ReplayOutput {
+            recovered: self.recovered,
+            suffix_index: self.index_entries.into_boxed_slice(),
+        })
     }
 
     /// The open appender for `key`, created on first use:
@@ -83,7 +128,7 @@ impl ReplayWriter {
         &mut self,
         key: SegmentKey,
         first_entry_id: u64,
-    ) -> io::Result<&mut BufWriter<File>> {
+    ) -> io::Result<&mut SegmentAppender> {
         if !self.writers.contains_key(&key) {
             let start_offset = self.recovered.start_offset(&key).unwrap_or(first_entry_id);
             let valid_len = self.recovered.valid_len(&key);
@@ -97,16 +142,24 @@ impl ReplayWriter {
                 .write(true)
                 .truncate(false)
                 .open(&path)?;
+
+            // * truncate torn-tail
             file.set_len(valid_len)?;
             let mut writer = BufWriter::new(file);
             writer.seek(SeekFrom::Start(valid_len))?;
-            self.writers.insert(key, writer);
+            self.writers.insert(
+                key,
+                SegmentAppender {
+                    writer,
+                    next_pos: valid_len,
+                },
+            );
         }
 
         Ok(self
             .writers
             .get_mut(&key)
-            .expect("writer inserted just above"))
+            .expect("appender inserted just above"))
     }
 }
 
@@ -287,5 +340,61 @@ mod tests {
         w.finish().unwrap();
 
         assert_eq!(fs::read(s.file_path(&data_dir, 0)).unwrap(), before);
+    }
+
+    fn open_db() -> (tempfile::TempDir, rocksdb::DB) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = rocksdb::DB::open_default(dir.path()).unwrap();
+        (dir, db)
+    }
+
+    /// The live index (checkpoint-written prefix) plus the anchors replay emits
+    /// for the suffix must resolve identically to a full rebuild of the final
+    /// file — replay re-indexes only what it appended, never the prefix.
+    #[test]
+    fn suffix_index_plus_live_prefix_equals_full_rebuild() {
+        use crate::data_plane::recovery::index_rebuild::rebuild_entries;
+        use crate::data_plane::sparse_index::{INDEX_INTERVAL_ENTRIES, SparseIndex};
+
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_path_buf();
+        let path = key().file_path(&data_dir, 0);
+
+        // A checkpointed prefix on disk: ids 0..n, so the first interval anchor
+        // past the base (id n) falls in the replayed suffix below.
+        let n = INDEX_INTERVAL_ENTRIES;
+        let prefix: Vec<u8> = (0..n)
+            .flat_map(|i| encode_batch(&format!("e{i}"), 1))
+            .collect();
+        write_segment(&path, &prefix);
+        // Checkpoint and rebuild share `is_index_anchor`, so rebuilding the
+        // prefix-only file == what the live index already holds for that prefix.
+        let prefix_index = rebuild_entries(&path, key()).unwrap();
+
+        // Replay re-presents the whole prefix (skipped) then appends ids n..=n+3.
+        let recovered = RecoveredSegments::scan_data_dir(&data_dir).unwrap();
+        let mut w = ReplayWriter::new(data_dir.clone(), recovered);
+        for i in 0..=n + 3 {
+            w.replay(&RoutingHeader::new(key(), i, 1), format!("e{i}").as_bytes())
+                .unwrap();
+        }
+        let out = w.finish().unwrap();
+        // The suffix crossed an interval boundary (id n), so it indexed an anchor.
+        assert!(!out.suffix_index.is_empty());
+
+        // live prefix + replayed suffix
+        let (_combined_dir, combined) = open_db();
+        combined.put_batch(prefix_index).unwrap();
+        combined.put_batch(out.suffix_index.into_vec()).unwrap();
+
+        // full rebuild of the final (prefix + suffix) file
+        let (_full_dir, full) = open_db();
+        full.put_batch(rebuild_entries(&path, key()).unwrap())
+            .unwrap();
+
+        // Identical resolution for every id across the prefix/suffix boundary.
+        for id in 0..=n + 4 {
+            assert_eq!(combined.seek_index(key(), id), full.seek_index(key(), id));
+        }
     }
 }

--- a/src/data_plane/recovery/segment_scan.rs
+++ b/src/data_plane/recovery/segment_scan.rs
@@ -108,6 +108,16 @@ impl RecoveredSegments {
         self.0.get(key).map(|scan| scan.start_offset)
     }
 
+    /// `(segment, highest verified entry id)` for every segment that has a
+    /// verified prefix. Segments with no complete batch (`last_entry_id` is
+    /// `None`) are omitted — they hold no durable data. This post-replay cursor
+    /// map is what the local inventory (`inventory.rs`) is built from.
+    pub(crate) fn cursors(&self) -> impl Iterator<Item = (SegmentKey, u64)> + '_ {
+        self.0
+            .iter()
+            .filter_map(|(key, scan)| scan.last_entry_id.map(|id| (*key, id)))
+    }
+
     /// Records that `entry_id` was just appended to `key`'s segment file,
     /// advancing its cursor.
     ///
@@ -523,5 +533,19 @@ mod tests {
     fn advance_rejects_a_gap() {
         let mut r = recovered_with(&[(seg_key(), scanned(0, Some(4), 0))]);
         r.advance(seg_key(), 6); // skips 5
+    }
+
+    #[test]
+    fn cursors_yields_only_verified_segments() {
+        let verified = seg_key();
+        let unverified = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(9));
+        let r = recovered_with(&[
+            (verified, scanned(10, Some(14), 256)),
+            (unverified, scanned(0, None, 0)),
+        ]);
+
+        let cursors: std::collections::HashMap<SegmentKey, u64> = r.cursors().collect();
+        assert_eq!(cursors.len(), 1); // the unverified segment is omitted
+        assert_eq!(cursors.get(&verified), Some(&14));
     }
 }

--- a/src/data_plane/recovery/wal_scan.rs
+++ b/src/data_plane/recovery/wal_scan.rs
@@ -242,6 +242,18 @@ impl WalScanner {
             }
         }
     }
+
+    /// Deletes every discovered WAL file, consuming the scanner. The caller must
+    /// have made the WAL's contents durable in the segment files first (recovery
+    /// does this via `ReplayWriter::finish`) — only then is the WAL superseded
+    /// and safe to remove.
+    pub(crate) fn delete_files(mut self) -> io::Result<()> {
+        self.current = None; // close any still-open reader before unlinking
+        for file in &self.files {
+            fs::remove_file(&file.path)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -5,6 +5,7 @@ use super::messages::command::DataPlaneInterNodeCommand;
 use super::messages::command::*;
 use super::messages::pending::DataPlaneOutputs;
 use super::messages::query::{DataPlaneQuery, Fetch, FetchResult, ListOffsets, ListOffsetsResult};
+use super::recovery::inventory::LocalInventory;
 use super::states::replication::PendingReplicationBatch;
 use super::states::replication::ReplicationState;
 use super::states::segment_store::SegmentStore;
@@ -51,6 +52,11 @@ pub struct DataPlane<W: WalStorage> {
     cold_read_handoff_sender: crossbeam_channel::Sender<ColdReadRequest>,
 
     out: DataPlaneOutputs,
+
+    /// The verified local inventory recovery handed us (segment → highest durable entry id).
+    /// Held for boundary confirmation and segment registration (not read yet).
+    #[allow(dead_code)]
+    recovered: LocalInventory,
 }
 
 impl<W: WalStorage> DataPlane<W> {
@@ -60,6 +66,7 @@ impl<W: WalStorage> DataPlane<W> {
         wal: W,
         cold_read_handoff_sender: crossbeam_channel::Sender<ColdReadRequest>,
         out: DataPlaneOutputs,
+        recovered: LocalInventory,
     ) -> Self {
         DataPlane {
             node_id,
@@ -73,6 +80,7 @@ impl<W: WalStorage> DataPlane<W> {
             pending_seal_requests: HashMap::new(),
             cold_read_handoff_sender,
             out,
+            recovered,
         }
     }
 
@@ -776,6 +784,7 @@ mod tests {
     use crate::control_plane::membership::ShardGroupId;
     use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
     use crate::data_plane::cold_read::DEFAULT_POOL_SIZE;
+    use crate::data_plane::recovery::segment_scan::RecoveredSegments;
     use crate::data_plane::wal::WalWriter;
     use tokio::sync::oneshot;
 
@@ -808,6 +817,12 @@ mod tests {
         }
     }
 
+    /// A trivial empty-dir recovery: nothing on disk → an empty inventory. The
+    /// same shape production builds `DataPlane` with, just with no segments.
+    fn empty_inventory() -> LocalInventory {
+        LocalInventory::from_recovered(&RecoveredSegments::default())
+    }
+
     fn make_data_plane(dir: &tempfile::TempDir) -> DataPlane<WalWriter> {
         let wal = WalWriter::new(dir.path().to_path_buf()).unwrap();
         let out = DataPlaneOutputs::test();
@@ -821,6 +836,7 @@ mod tests {
             wal,
             cold_read_tx,
             out,
+            empty_inventory(),
         )
     }
 
@@ -1690,6 +1706,7 @@ mod tests {
             wal,
             cold_read_tx,
             DataPlaneOutputs::test(),
+            empty_inventory(),
         );
 
         // Assign + produce 3 records (single replica → commit inline on flush).

--- a/src/data_plane/states/segment/record.rs
+++ b/src/data_plane/states/segment/record.rs
@@ -62,6 +62,15 @@ impl RoutingHeader {
             record_count: u32::from_be_bytes(data[32..36].try_into().unwrap()),
         })
     }
+
+    /// Splits a WAL record payload (as built by [`RoutingHeader::build_wal_payload`])
+    /// back into its routing header and the bare entry data that follows it — the
+    /// inverse of `build_wal_payload`. Recovery replay uses it to route a WAL
+    /// record by its header while writing only the bare data the segment keeps.
+    pub(crate) fn split_wal_payload(payload: &[u8]) -> io::Result<(Self, &[u8])> {
+        let header = Self::decode(payload)?;
+        Ok((header, &payload[ROUTING_HEADER_SIZE..]))
+    }
 }
 
 pub(crate) struct StagedEntry {

--- a/src/data_plane/wal.rs
+++ b/src/data_plane/wal.rs
@@ -198,56 +198,6 @@ impl WalWriter {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn open_existing(data_dir: PathBuf, next_lsn: u64) -> io::Result<Self> {
-        let wal_dir = data_dir.join("wal");
-        fs::create_dir_all(&wal_dir)?;
-
-        let mut entries: Vec<(u64, PathBuf)> = Vec::new();
-        for entry in fs::read_dir(&wal_dir)? {
-            let entry = entry?;
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if let Some(seq) = parse_wal_filename(&name_str) {
-                entries.push((seq, entry.path()));
-            }
-        }
-        entries.sort_by_key(|e| e.0);
-
-        let mut files = VecDeque::new();
-
-        for (seq, path) in &entries {
-            let meta = fs::metadata(path)?;
-            files.push_back(WalFileEntry {
-                seq: *seq,
-                min_lsn: 0,
-                max_lsn: 0,
-                size: meta.len(),
-                path: path.clone(),
-            });
-        }
-
-        let mut writer = WalWriter {
-            files,
-            max_file_size: DEFAULT_MAX_FILE_SIZE,
-            next_lsn,
-            data_dir,
-            next_seq: entries.last().map(|(max_seq, _)| *max_seq).unwrap_or(0) + 1,
-            active_writer: None,
-            batch_buf: Vec::new(),
-        };
-
-        if writer.files.is_empty() {
-            writer.open_new_file()?;
-        } else {
-            let active = writer.files.back().expect("non-empty files");
-            let file = OpenOptions::new().append(true).open(&active.path)?;
-            writer.active_writer = Some(BufWriter::new(file));
-        }
-
-        Ok(writer)
-    }
-
     fn active_entry_mut(&mut self) -> &mut WalFileEntry {
         self.files.back_mut().expect("invariant: files non-empty")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use crate::control_plane::membership::actor::SwimSender;
 use crate::control_plane::membership::topology_channel;
 use crate::data_plane::actor::{DataPlaneActor, DataPlaneSender};
 use crate::data_plane::checkpoint::CheckpointWorker;
+use crate::data_plane::recovery;
 use crate::data_plane::transport::DataTransportActor;
 use crate::data_plane::transport::command::DataTransportCommand;
 use crate::impls::metadata_storage::MetadataStorage;
@@ -85,6 +86,14 @@ impl StartUp {
         // Single-writer / many-readers via ArcSwap — no locks, no contention.
         let (topology_pub, topology_reader) = topology_channel(state.topology.clone());
 
+        // Recover local durable state before this node serves or joins the
+        // cluster: scan + replay the WAL into the segment files, then clear the
+        // old WAL. Runs before any transport serves and before the SWIM join, so
+        // the node only becomes visible to the cluster once it is recovered.
+        let data_config = self.env.data_node_config();
+        let sparse_index = self.env.sparse_index_db();
+        let recovery_output = recovery::run(data_config.data_dir.clone(), &*sparse_index)?;
+
         // Transports
         tokio::spawn(SwimTransportActor::run(
             udp_socket,
@@ -109,16 +118,15 @@ impl StartUp {
             topology_pub,
         );
 
-        // Data plane (spawns its own three schedulers + crossbeam bridge internally).
-        let sparse_index = self.env.sparse_index_db();
         let (checkpoint_tx, checkpoint_rx) = crossbeam_channel::bounded(64);
         let data_plane_tx = DataPlaneActor::spawn(
             node_id.clone(),
-            self.env.data_node_config(),
+            data_config,
             checkpoint_tx,
             data_transport_tx.clone().into(),
             raft_tx.clone(),
             sparse_index.clone(),
+            recovery_output,
         );
         CheckpointWorker::spawn(sparse_index, checkpoint_rx, data_plane_tx.clone());
 


### PR DESCRIPTION
## What
Completes the single-node half of D5 crash recovery (diagrams/data-plane/d5_crash_recovery.md), taking it from the staged scanner/replay primitives (already merged) to a recovery that runs at node startup, enforced by the type system. After this PR a restarted node reconstructs its durable state from disk, starts a fresh WAL, and only then becomes visible to the cluster.


## Changes

### Replay indexes only what it appends (replay.rs): 
ReplayWriter tracks each appended record's byte offset and emits sparse-index anchors (via the shared is_index_anchor) for just the replayed suffix — never the checkpointed prefix. finish now returns ReplayOutput { recovered, suffix_index }; full index rebuild stays the fallback.

### LocalInventory + RecoveryOutput (inventory.rs): 
segment → highest verified entry id, built only from the post-replay cursors (no other constructor).

### recovery::run orchestrator (mod.rs): 
scan data dir → replay WAL → index suffix → build inventory. ScanError::Corrupt is non-fatal — replay stops at the last verified batch and recovery returns what was durable; only genuine I/O errors abort.

### Destructive WAL lifecycle: 
after the segments are fsynced, the consumed WAL is deleted (WalScanner::delete_files); WalWriter::open_existing is removed (the fresh-WAL decision makes it permanently unreachable, -50 lines in wal.rs). The fresh WAL is created by the serving side.

### Type-state pipeline (mod.rs): 
`run` is Replaying::start → replay_wal → commit. Deleting the WAL lives only on Durable, reachable only through replay_wal's fsync — so "delete only after durable" is a compile-time fact. Replaying can't delete; Durable can't replay.

### Recovery-before-serving (lib.rs, actor.rs, state.rs): 
bootstrap runs recovery before any transport serves and before the SWIM join. DataPlane::new requires the recovered LocalInventory, so the serving side cannot be constructed without a finished recovery. DataPlane<W> stays generic (WAL injected); the data-plane worker opens the fresh WAL from the recovered data_dir.

### Crash-simulation tests (mod.rs): 
produce through the real WalWriter, "kill" (drop + torn bytes) at three points — mid-batch torn tail, post-checkpoint/pre-WAL-delete, and mid-recovery torn segment — then recover and assert the result equals exactly what was ACKed.
