### PR TITLE
fix: handle_seal_response retires old segment without replaying stage…

### DIFF
--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -821,9 +821,15 @@ impl<W: WalStorage> DataPlane<W> {
             replayed_bytes += data.len();
             new_tracker.stage_entry(new_segment_key, data, record_count);
         }
-        // Staged replays count toward pending bytes like a fresh produce, so the
-        // `buffer_byte_count == staged bytes` invariant holds after this command.
+        // Published-uncommitted records were cleared from `buffer_byte_count` when
+        // they flushed, so re-staging them re-adds their bytes here.
         self.buffer_byte_count += replayed_bytes;
+
+        // Staged-but-unflushed produces (staged after the last flush) must also
+        // carry to the successor
+        for (data, record_count) in old_tracker.staged_for_replay() {
+            new_tracker.stage_entry(new_segment_key, data, record_count);
+        }
 
         self.replication
             .segment_handoff(cmd.old_segment_key, new_segment_key);
@@ -1258,6 +1264,21 @@ mod tests {
         (cmd.into(), rx)
     }
 
+    fn seal_response(
+        old: SegmentKey,
+        new_segment_id: SegmentId,
+        new_replica_set: Vec<NodeId>,
+    ) -> DataPlaneCommand {
+        DataPlaneCommand::DataPlaneInterNodeCommand(
+            SealResponse {
+                old_segment_key: old,
+                new_segment_id,
+                new_replica_set,
+            }
+            .into(),
+        )
+    }
+
     #[test]
     fn has_segment_returns_false_for_unknown() {
         let dir = tempfile::tempdir().unwrap();
@@ -1447,6 +1468,34 @@ mod tests {
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
         assert!(!dp.has_buffered_data());
+    }
+
+    /// A seal that arrives while the active segment still holds a staged-but-
+    /// unflushed produce must carry that produce into the successor. The old
+    /// tracker is retired (removed from the leader-staged sum), so dropping its
+    /// staged entry would strand `buffer_byte_count` above the real staged bytes
+    /// and trip `assert_invariants`. Regression for the `produce_then_fetch_hot`
+    /// flake (worker panic at the `buffer_byte_count` invariant).
+    #[test]
+    fn seal_carries_unflushed_staged_into_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.handle_command(assign_segment(test_key(), vec![]));
+
+        // Produce — staged into the active segment, no flush yet.
+        let (cmd, _rx) = produce(test_key());
+        dp.handle_command(cmd);
+        assert!(dp.has_buffered_data());
+
+        // Seal arrives before the batch flush. `handle_command` runs
+        // `assert_invariants` afterwards — pre-fix this panics on the stranded
+        // counter.
+        dp.handle_command(seal_response(test_key(), SegmentId(1), vec![]));
+
+        // The staged produce moved to the successor; the counter still matches.
+        let successor = test_key().with_segment_id(SegmentId(1));
+        assert!(dp.segments.get(&successor).unwrap().has_staged());
+        assert!(dp.has_buffered_data());
     }
 
     #[test]

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -142,6 +142,17 @@ impl SegmentTracker {
         })
     }
 
+    /// Staged-but-unpublished records, for replay into a successor on seal.
+    /// Unlike `uncommitted_entries` (the published cache), these never reached
+    /// the WAL, so a seal must carry them forward too — and they are already
+    /// counted in the data plane's `buffer_byte_count`, so the caller must not
+    /// re-count them.
+    pub(crate) fn staged_for_replay(&self) -> impl Iterator<Item = (EntryPayload, u32)> + '_ {
+        self.staged_entries
+            .iter()
+            .map(|s| (s.data.clone(), s.record_count))
+    }
+
     pub(crate) fn checkpoint(&self, key: SegmentKey) -> CheckpointJob {
         CheckpointJob {
             segment_key: key,


### PR DESCRIPTION
…d-but-not-published entries

handle_seal_response retired the old segment (take_active_and_seal → by_key.remove, and the invariant sums by_key.values()) but only replayed published-uncommitted entries (uncommitted_entries() reads the cache). Any staged-but-unflushed produce on the sealing segment was dropped — and buffer_byte_count has no decrement path, so its bytes were stranded → buffer_byte_count > leader staged sum → worker panic.

The new test seal_carries_unflushed_staged_into_successor (produce → no flush → seal) panicked with the exact flake assertion when I backed the fix out:

buffer_byte_count (4) != actual leader staged bytes (0)

With the fix, it passes. (Same assertion the original data-plane-worker died on; it then surfaced as "produce not acked" at client_protocol.rs:516.)

- SegmentTracker::staged_for_replay() — production accessor (the existing staged_entries() is debug/test-only).
- handle_seal_response now carries the old segment's staged entries into the successor, after the uncommitted ones (offset order), without re-counting — they're already in buffer_byte_count.