### PR TITLE
feat(data-plane): time-based gc

### DIFF
--- a/diagrams/data-plane/d7_retention_gc.md
+++ b/diagrams/data-plane/d7_retention_gc.md
@@ -133,9 +133,9 @@ segment command touches a single entity; retention is the only set-valued one.)
 | Aspect | Behavior |
 |---|---|
 | Scope | One range; `segment_ids` is a contiguous oldest-first prefix of that range's sealed segments. Multiple ranges → multiple commands. |
-| Precondition | Each named segment is `Sealed` and the set is a prefix (no surviving older sibling — see below). `Active` segments are rejected; already-`Deleting`/absent ids are skipped. |
-| Effect | State `Sealed → Deleting` for each. Nothing else changes — offsets, lineage, `replica_set`, timestamps stay frozen, exactly as `ReassignSegment` leaves them (metadata-state-machine.md #21). |
-| Idempotency | Re-applying is a no-op for any id already `Deleting`/gone, tolerating sweep re-runs and duplicate dispatch — same discipline as `RollSegment` (#19). |
+| Effect | Each named segment that is `Sealed` transitions `Sealed → Deleting`; nothing else changes — offsets, lineage, `replica_set`, timestamps stay frozen, exactly as `ReassignSegment` leaves them (metadata-state-machine.md #21). |
+| Skips, not rejects | An `Active` (write head) or already-`Deleting`/absent id is skipped, not an error — so apply can never delete the write head and is idempotent (sweep re-runs, duplicate dispatch). No-op'd entirely → `Noop`. |
+| No production prefix check | The oldest-first/no-hole property is guaranteed by the sweep's prefix construction and enforced as a *structural invariant* (`assert_retention_prefix`, #2), not re-validated on the apply path — a non-prefix would be a proposer bug, which the invariant catches in test/debug (cf. metadata-state-machine.md #11). |
 
 **Mark, don't remove.** The entity stays in metadata in the `Deleting` state rather
 than vanishing. Keeping it preserves the range's offset chain (a `Deleting` segment
@@ -156,10 +156,11 @@ the active head — never a hole in the middle.
 This is what keeps consumption safe. A consumer reading a range forward crosses the
 retained boundary exactly once: everything below it is gone, everything at and above it
 is present. There is no "deleted s1, present s2, deleted s3" state for a reader to fall
-into. Size- and time-based selection both produce a prefix naturally (seals advance in
-offset and time order), but the invariant is enforced at apply — `DeleteSegments`
-rejects a segment with a surviving older sibling — so a mis-ordered proposal can never
-punch a hole.
+into. The sweep produces a prefix naturally (it take-whiles expired sealed segments in
+segment_id order), and the property is pinned as the structural invariant
+`assert_retention_prefix` (#2) — so a proposer bug that named a non-prefix set is caught
+in test/debug rather than guarded on the hot path (cf. metadata-state-machine.md #11:
+precondition failures are a proposer bug, not a state-machine error).
 
 ---
 
@@ -167,19 +168,21 @@ punch a hole.
 
 A committed `DeleteSegments` reaches the data plane the same way every committed segment
 decision does — the leader dispatches on the post-commit drain (raft-actor.md #3). The
-metadata command is plural, but **dispatch fans out per segment**: segments in one
-range can have different `replica_set`s (seal-on-failure, reassign, and re-fill move
-them), so each segment's deletion goes to *its own* replicas. Each replica deletes the
-segment file, drops its in-memory cache, and range-deletes its sparse-index entries.
+dispatch **groups the deleted segments by `replica_set`** and sends one batched
+`DeleteSegments` per distinct set: segments in a range can sit on different sets
+(seal-on-failure, reassign, and re-fill move them), but the common case (a range's
+segments sharing replicas) collapses to a single message. Each replica, per key it
+holds, deletes the segment file, drops its in-memory cache, and range-deletes its
+sparse-index entries (skipping any key it no longer holds — idempotent).
 
 ```
-Coordinator (Raft leader)                     Each segment's own replica_set
+Coordinator (Raft leader)                     A replica_set's nodes
    |  retention sweep: oldest sealed segments past sealed_at + retention_ms
    |  propose DeleteSegments{ range, ids oldest-first } ──Raft──> committed on [A,B,C]
    |
-   |  (post-commit drain, leader only; fan out per segment)
-   |── delete segment ─────────────────────────> that segment's replicas
-   |                                              delete file + cache + index entries
+   |  (post-commit drain, leader only; group keys by replica_set)
+   |── DeleteSegments{ keys for this set } ─────> that set's nodes
+   |                                              per key: delete file + cache + index
 ```
 
 **Orphan GC is the backstop.** Dispatch is fire-and-forget, so a replica might miss a
@@ -253,14 +256,16 @@ about the command's behavior.
 
 1. **Optional retention config** — make `retention_ms` optional on the storage policy
    (default: off = keep forever).
-2. **`DeleteSegments` metadata command** — per-range oldest-first prefix (`{ topic_id,
-   range_id, segment_ids }`), `Sealed → Deleting`, prefix precondition, idempotent as a
-   set; add invariant checks #1 and #2 to `assert_invariants`.
+2. **`DeleteSegments` metadata command** — per-range prefix (`{ topic_id, range_id,
+   segment_ids }`); `Sealed → Deleting`, skipping active/absent/already-deleting
+   (idempotent, no production prefix/active rejection); add invariant checks #1 and #2
+   to `assert_invariants` — they pin the no-hole property.
 3. **Retention sweep on the coordinator** — leader-only, on the ring-check cadence:
    per owned range compute the deletable prefix by `sealed_at` age (with injected
    `now`), propose `DeleteSegments` carrying the ids oldest-first.
-4. **Data-plane deletion** — dispatch committed `DeleteSegments` to the segment's
-   replicas on the post-commit drain; each deletes file + cache + sparse-index
+4. **Data-plane deletion** — dispatch committed `DeleteSegments` grouped by
+   `replica_set` (one batched message per set) on the post-commit drain; each node, per
+   key it holds, deletes file + cache + sparse-index
    entries; idempotent (already-gone file is a no-op).
 5. **Orphan-GC backstop** — confirm a segment dropped from a node's assigned set is
    reclaimed by the existing sweep, so a missed dispatch self-heals.

--- a/diagrams/data-plane/d7_retention_gc.md
+++ b/diagrams/data-plane/d7_retention_gc.md
@@ -1,0 +1,290 @@
+# Phase D7: Retention GC — optional age-based bounding of a topic's history
+
+**Goal:** give topics an *optional* cap on how long they keep sealed history, by **age**,
+and reclaim the segments past it. EastGuard's default is to keep everything; D7 adds
+opt-in time retention for topics that want a bounded history window, deleting whole
+sealed segments oldest-first through the metadata log. The active segment (the write
+head) is never deleted.
+
+Retention here is purely **logical** (an age policy on a topic's data). It is *not* a
+disk-capacity mechanism — bounding a node's physical disk is a separate, node-level
+concern (see "Disk capacity is a separate concern" below). There is deliberately no
+size-based retention: a range that grows simply **rolls** a new segment (the existing
+`segment_size_limit_bytes` seal trigger); growth is never a reason to *delete* data.
+
+**Depends on:** D3 (coordinator-driven segment lifecycle), D5 (crash recovery + orphan
+GC — reused here as the deletion backstop).
+
+---
+
+## Retention is optional by design
+
+EastGuard scales storage **horizontally**: capacity is added by adding nodes, not by
+throwing data away. New segments are placed by the hash ring, and ranges auto-split
+under load, so a growing topic spreads its new segments across new capacity rather
+than piling onto one node. **Unbounded retention is a supported, first-class mode** —
+a topic with no retention policy keeps all its history forever, and that's a correct
+way to run.
+
+So retention here is not a rescue from inevitable disk death; it's a **per-topic
+opt-in** for workloads that explicitly want a bounded history window (a time-limited
+audit log, a replay buffer of the last N hours). It defaults to off:
+
+- `retention_ms = None` → no age cap; keep all history forever (the default).
+
+With it unset, nothing is ever expired — exactly today's behavior, now an explicit
+choice rather than the only choice.
+
+---
+
+## Granularity: whole segments (one file each)
+
+A **segment is one file on disk** — the unit the broker stores and the unit it
+deletes. A segment holds many **entries**, each an opaque blob the producer wrote
+(carrying a `record_count`); the broker stamps an `entry_id` per entry and never parses
+the records inside. The entity hierarchy is **topic → range → segment (file) → entry**.
+
+Retention deletes whole segments, never individual entries — every entry in a segment
+shares one lifecycle. (The broker has no per-entry delete at all; an entry's only path
+out is its segment file being removed.) This is the conventional unit:
+
+- **Kafka** retains at **segment** granularity — a partition's log is a chain of
+  immutable segment files, and time/size retention drops whole files oldest-first. It
+  cannot delete individual records (log compaction is a separate mode entirely).
+- **Pulsar** retains at **ledger** granularity (a topic is a sequence of BookKeeper
+  ledgers); retention drops whole ledgers once consumed and past policy.
+
+The mapping: an EastGuard **segment** ≈ a Kafka segment file / Pulsar ledger; an
+EastGuard **entry** ≈ a Kafka record batch (one produced blob); an EastGuard **range**
+≈ a Kafka partition. Retention is configured on the topic and enforced **per range** —
+each range's segment chain is bounded independently, exactly as Kafka applies a topic's
+`retention.*` per partition.
+
+---
+
+## The expiry rule (age only)
+
+A sealed segment is expired when `sealed_at + retention_ms < now`. `sealed_at` — the
+moment the segment became immutable — is the right clock-start (the active head has
+none and is never expired). Expired segments of a range are deleted **oldest-first**
+(see below). There is no size-based variant: a range over a size threshold rolls, it
+doesn't shed history.
+
+**The wall clock is contained.** Retention is the one age-based decision in the system,
+and it's confined so it threatens neither correctness nor testability:
+
+- **No clock agreement needed.** The decision is leader-only and the resulting command
+  names concrete segment ids, so cross-node skew can't make replicas diverge — at
+  worst it shifts the floor by the skew margin, harmless for a *floor*. Same
+  leader-only-decision / deterministic-apply shape as split/merge
+  (metadata-state-machine.md #16).
+- **One injectable read.** The expiry decision is a **pure function** `(sealed
+  segments, retention_ms, now) → deletable prefix`. Production passes the system clock
+  for `now`; tests pass a fixed value. Nothing in the apply path or state machine ever
+  reads the clock.
+
+---
+
+## Disk capacity is a separate concern
+
+It is tempting to also cap *bytes*, but byte limits don't belong here. A node's
+physical disk is observable only by **the node** (the data plane) — the coordinator
+has no view of it — and the right response to a full disk is **stop writing, keep
+reading**, not delete a topic's logical history. That is backpressure and placement,
+not retention, and it's a different subsystem:
+
+- **Detection: data plane.** The node watches its own disk (segment files + WAL vs
+  capacity) and crosses a high-water mark.
+- **Reaction: no new writes, reads continue.** Segments it currently leads can't grow,
+  so the next produce's fsync fails and the existing write-path-timeout → seal → relocate
+  path moves them elsewhere (the "leader disk failure" case). For *new* segments, the
+  node advertises an at-capacity bit through SWIM (coarse gossip, like membership), and
+  capacity-aware placement excludes it — mirroring `SealRequest`: data plane detects,
+  coordinator acts.
+- **Relief.** Time retention (this doc) frees space where a policy is set; tiered
+  storage (backlog) offloads cold segments without deleting; added nodes absorb new
+  ranges.
+
+So: **age retention is a coordinator decision about logical data; disk capacity is a
+data-plane decision about physical bytes.** This doc is the former; the latter is its
+own design (node capacity / write backpressure).
+
+---
+
+## Who decides
+
+The **coordinator** (the shard group's Raft leader — the authority that already
+proposes `RollSegment` and `ReassignSegment`) runs a periodic **retention sweep**,
+leader-only, on the existing ring-check cadence. For each range it owns it computes the
+deletable prefix by age and proposes a metadata command naming those segments. Apply on
+every replica is identical because the command carries ids, not predicates.
+
+---
+
+## The `DeleteSegments` command
+
+There is no segment delete today — only the topic-level `DeleteTopic` cascade. D7 adds
+one metadata command that marks an oldest-first **prefix of one range's sealed
+segments** `Deleting`. It is plural by nature: a retention sweep expires a *run* of old
+segments, not one, so the command carries the whole prefix — `{ topic_id, range_id,
+segment_ids }` (oldest-first) — and marks them in one atomic apply. (Every other
+segment command touches a single entity; retention is the only set-valued one.)
+
+| Aspect | Behavior |
+|---|---|
+| Scope | One range; `segment_ids` is a contiguous oldest-first prefix of that range's sealed segments. Multiple ranges → multiple commands. |
+| Precondition | Each named segment is `Sealed` and the set is a prefix (no surviving older sibling — see below). `Active` segments are rejected; already-`Deleting`/absent ids are skipped. |
+| Effect | State `Sealed → Deleting` for each. Nothing else changes — offsets, lineage, `replica_set`, timestamps stay frozen, exactly as `ReassignSegment` leaves them (metadata-state-machine.md #21). |
+| Idempotency | Re-applying is a no-op for any id already `Deleting`/gone, tolerating sweep re-runs and duplicate dispatch — same discipline as `RollSegment` (#19). |
+
+**Mark, don't remove.** The entity stays in metadata in the `Deleting` state rather
+than vanishing. Keeping it preserves the range's offset chain (a `Deleting` segment
+still carries its offsets, so offset-continuity — metadata-state-machine.md #8 — is
+untouched) and gives the data plane a concrete target to reclaim. Reclaiming the
+metadata *entity* (to bound metadata RAM and the Raft log) is a separate concern for
+Raft snapshotting/compaction, out of scope here — D7 bounds **disk**.
+
+---
+
+## Oldest-first: no holes
+
+Deletion within a range is strictly **oldest-first**: a segment may be deleted only
+once every lower-offset segment in its range is already `Deleting`/deleted. The
+surviving segments of a range are therefore always a **contiguous suffix** ending at
+the active head — never a hole in the middle.
+
+This is what keeps consumption safe. A consumer reading a range forward crosses the
+retained boundary exactly once: everything below it is gone, everything at and above it
+is present. There is no "deleted s1, present s2, deleted s3" state for a reader to fall
+into. Size- and time-based selection both produce a prefix naturally (seals advance in
+offset and time order), but the invariant is enforced at apply — `DeleteSegments`
+rejects a segment with a surviving older sibling — so a mis-ordered proposal can never
+punch a hole.
+
+---
+
+## Reclaiming the files
+
+A committed `DeleteSegments` reaches the data plane the same way every committed segment
+decision does — the leader dispatches on the post-commit drain (raft-actor.md #3). The
+metadata command is plural, but **dispatch fans out per segment**: segments in one
+range can have different `replica_set`s (seal-on-failure, reassign, and re-fill move
+them), so each segment's deletion goes to *its own* replicas. Each replica deletes the
+segment file, drops its in-memory cache, and range-deletes its sparse-index entries.
+
+```
+Coordinator (Raft leader)                     Each segment's own replica_set
+   |  retention sweep: oldest sealed segments past sealed_at + retention_ms
+   |  propose DeleteSegments{ range, ids oldest-first } ──Raft──> committed on [A,B,C]
+   |
+   |  (post-commit drain, leader only; fan out per segment)
+   |── delete segment ─────────────────────────> that segment's replicas
+   |                                              delete file + cache + index entries
+```
+
+**Orphan GC is the backstop.** Dispatch is fire-and-forget, so a replica might miss a
+delete (dropped message, restart mid-delete). That's fine: a file the cluster no longer
+assigns to a node is, by definition, a stray, and the D5 orphan sweep reclaims strays
+lazily and cluster-confirmed. The explicit dispatch is the fast path; orphan GC is the
+eventual guarantee — no single dropped message strands a file. (Same shape as the
+catch-up design, raft-actor.md #9: an eager one-shot dispatch over a lazy net.)
+
+---
+
+## Interaction with consumers
+
+Retention can delete a sealed segment a slow consumer hasn't finished reading — the
+classic retention-vs-lag race. Because retention is opt-in, a topic that can't tolerate
+it simply doesn't set a policy. For topics that do, a consumer that falls past the
+window sees "segment gone" on its next fetch and skips forward to the oldest surviving
+segment (`ListOffsets` gives the surviving start). Retention is a capacity guarantee for
+the cluster, not a delivery guarantee for laggards — operators size the policy against
+worst-case lag.
+
+---
+
+## Testing
+
+The clock is the only difficulty, and it's confined to one injectable input:
+
+- **Expiry decision, pure unit.** `(sealed segments, retention_ms, now) → deletable
+  prefix` is tested synchronously with an injected `now` (and `sealed_at` set on the
+  inputs) — no real-time wait, fully deterministic.
+- **Apply is clock-free.** `DeleteSegments` names ids and flips `Sealed → Deleting`, so
+  the state-machine test (precondition incl. oldest-first, idempotency, invariant
+  re-check) is deterministic.
+- **File reclamation is synchronous.** The data-plane delete (file + cache + index) is
+  covered by the synchronous data-plane state tests.
+- **No flaky age-based e2e.** A real-time retention e2e would race the virtual clock;
+  it's deliberately avoided (the same call already made for age-based seal). Coverage
+  comes from the decision/apply/reclamation units above, not a wall-clock sim run.
+
+---
+
+## Invariants (proposed)
+
+These extend the metadata-state-machine contract; implementing them needs the usual
+invariant sign-off (CLAUDE.md), since they ride in `assert_invariants`.
+
+1. **Only sealed segments are deleted; the active segment never is.** Every range
+   always retains its write head, so a topic under retention can still be produced to.
+   Snapshot-checkable: no `Deleting` state on a range's active segment.
+
+2. **Deletion is a contiguous prefix (oldest-first).** Within a range, every
+   `Deleting`/deleted segment has a lower start offset than every surviving
+   (`Active`/`Sealed`) segment — survivors are a contiguous suffix. This is the
+   no-holes guarantee a forward reader depends on. Snapshot-checkable per range.
+
+3. **`DeleteSegments` only advances state and freezes the rest** (`Sealed → Deleting`,
+   consistent with metadata-state-machine.md #20; offsets/lineage/`replica_set`/
+   timestamps unchanged). A retention delete is a state flip, not a rewrite, so a
+   sealed segment's history stays trustworthy until its file is gone. (Rule.)
+
+4. **The expiry decision is leader-only; the apply is deterministic.** The leader
+   evaluates the age policy and names the segments; replicas apply the named set with
+   no policy or clock of their own (metadata-state-machine.md #16). (Rule.)
+
+#1 and #2 are the genuinely new snapshot-checkable invariants; #3 and #4 are rules
+about the command's behavior.
+
+---
+
+## What needs to be done
+
+1. **Optional retention config** — make `retention_ms` optional on the storage policy
+   (default: off = keep forever).
+2. **`DeleteSegments` metadata command** — per-range oldest-first prefix (`{ topic_id,
+   range_id, segment_ids }`), `Sealed → Deleting`, prefix precondition, idempotent as a
+   set; add invariant checks #1 and #2 to `assert_invariants`.
+3. **Retention sweep on the coordinator** — leader-only, on the ring-check cadence:
+   per owned range compute the deletable prefix by `sealed_at` age (with injected
+   `now`), propose `DeleteSegments` carrying the ids oldest-first.
+4. **Data-plane deletion** — dispatch committed `DeleteSegments` to the segment's
+   replicas on the post-commit drain; each deletes file + cache + sparse-index
+   entries; idempotent (already-gone file is a no-op).
+5. **Orphan-GC backstop** — confirm a segment dropped from a node's assigned set is
+   reclaimed by the existing sweep, so a missed dispatch self-heals.
+6. **Consumer "segment gone" handling** — a fetch to a deleted segment returns a
+   skip-forward signal; the client advances to the surviving start via `ListOffsets`.
+7. **Tests** — expiry-decision unit (injected `now`), `DeleteSegments` apply (sealed-only,
+   oldest-first, idempotent, active rejected), data-plane file/cache/index removal.
+
+## Verification
+
+- `cargo clippy --all-targets --all-features -- -D warnings`; `cargo fmt --check`.
+- Unit: deletable-prefix selection by age (injected `now`), `DeleteSegments` apply,
+  data-plane removal.
+- Reasoning check (age): a range with sealed segments aged `2T, 1.5T, 0.5T` (by
+  `sealed_at`) plus an active head and `retention_ms = T` — the sweep deletes the first
+  two (oldest-first), leaving the third + head as a contiguous suffix.
+- Reasoning check (none): a topic with `retention_ms` unset keeps every segment forever
+  — no `DeleteSegments` is ever proposed.
+
+## See also
+
+- `d5_crash_recovery.md` — orphan GC (the reclamation backstop) and local inventory.
+- `.claude/rules/metadata-state-machine.md` — `Deleting` cascade (#5), state never
+  reverts (#20), `ReassignSegment` freeze semantics (#21), leader-only decision /
+  deterministic apply (#16), offset continuity (#8).
+- `.claude/rules/raft-actor.md` — post-commit dispatch by the leader (#3), periodic
+  leader-only sweeps and re-fill (#10).

--- a/diagrams/data-plane/data_plane_roadmap.md
+++ b/diagrams/data-plane/data_plane_roadmap.md
@@ -240,7 +240,8 @@ Port layout:
 | [D3: Segment Lifecycle Integration](d3_segment_roll_integration.md) | Size/time/failure seal triggers, lifecycle events | D2, metadata Phase 6 | Connect storage to metadata |
 | [D4: Consumer Range Tracking](d4_consumer_range_tracking.md) | Follow split/merge/seal transitions | D3 | Consumer discovers range changes |
 | [D5: Crash Recovery](d5_crash_recovery.md) | WAL replay, local inventory, sealed segment repair | D1 (D2 for repair) | Data plane recovery |
-| [D6: Produce/Consume API](d6_produce_consume_api.md) | Client produce/consume protocol, routing, connection management | D4, D5 | Client-facing protocol layer |
+| [D6: Produce/Consume API](d6_produce_consume_api.md) | Server-side produce/consume routing via redirects | D4, D5 | Server routing (client SDK: see clients/) |
+| [D7: Retention GC](d7_retention_gc.md) | Optional per-topic **age** retention; expire sealed segments oldest-first, reclaim files | D3, D5 | Opt-in, logical (time); keep-forever is the default. Disk capacity is a separate node-level concern |
 
 D1 defines the storage primitives (WAL, segment files, sparse index) and the threading model that drives them: DataPlaneActor on a dedicated OS thread (WAL + cache publish), lock-free per-segment `SegmentRingBuffer` (concurrent consumer reads without locking), and I/O thread pools (checkpoint writes + cold reads). D2–D5 extend the D1 foundation with replication, metadata integration, consumer tracking, and crash recovery. D6 adds the client-facing protocol layer (produce/consume wire format, connection management) — consumer tasks on tokio read directly from `SegmentRingBuffer`.
 
@@ -259,10 +260,14 @@ D3 (Segment Roll)   |
  v                  |
 D4 (Range Tracking) |
  |                  |
- ├──────────────────┘
- v
-D6 (Produce/Consume API)
+ ├──────────────────┤
+ v                  v
+D6 (Produce API)   D7 (Retention GC)   ← D7 also depends on D3
 ```
+
+D6 completes the **server-side** routing. The **client SDK** (producer, consumer,
+admin) that consumes those redirects is its own track — see
+[clients/client_roadmap.md](../clients/client_roadmap.md).
 
 ---
 
@@ -284,9 +289,6 @@ D6 (Produce/Consume API)
 ### Exactly-Once Semantics
 Producer idempotency keys, deduplication at segment leader. Requires producer session tracking.
 
-### Segment GC / Retention
-Deleting sealed segments past `retention_ms`. Triggered by periodic ticker, cascades `Deleting` state through metadata.
-
 ### Consumer Groups
 Multiple consumers sharing work across ranges. Offset commit tracking. Rebalancing on consumer join/leave. Consumer offset storage is a separate system concern — not part of the log storage layer.
 
@@ -304,6 +306,9 @@ Cold segments offloaded to object storage (S3). Hot segments on local disk. Cons
 
 ### Storage Health Heartbeat
 Periodic fsync-and-ack between segment replicas. Catches disk failure on idle segments (the one gap in the current failure detection model — see coverage matrix above).
+
+### Node Capacity / Write Backpressure
+Physical disk bounding, distinct from logical retention (D7). The data plane watches its own disk and, on crossing a high-water mark, stops taking new writes while still serving reads: in-flight segments it leads seal-and-relocate via the existing write-path failure path, and the node advertises an at-capacity bit (SWIM gossip) so capacity-aware placement excludes it from new segments. Decision-maker is the data plane (only it sees disk); the coordinator reacts in placement. Tiered storage is the relief valve for cold data instead of deletion.
 
 ---
 

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -618,7 +618,7 @@ mod tests {
             vec![node_id(leader)],
             0,
             StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 1,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -765,7 +765,7 @@ mod tests {
                     ControlPlaneRequest::CreateTopic {
                         name: "t1".into(),
                         storage_policy: StoragePolicy {
-                            retention_ms: 3_600_000,
+                            retention_ms: Some(3_600_000),
                             replication_factor: 1,
                             partition_strategy: PartitionStrategy::AutoSplit,
                         },
@@ -799,7 +799,7 @@ mod tests {
                 ControlPlaneRequest::CreateTopic {
                     name: "t1".into(),
                     storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
-                        retention_ms: 3_600_000,
+                        retention_ms: Some(3_600_000),
                         replication_factor: 1,
                         partition_strategy:
                             crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
@@ -833,7 +833,7 @@ mod tests {
             ControlPlaneRequest::CreateTopic {
                 name: "t1".into(),
                 storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
-                    retention_ms: 3_600_000,
+                    retention_ms: Some(3_600_000),
                     replication_factor: 1,
                     partition_strategy:
                         crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,

--- a/src/control_plane/consensus/messages/event.rs
+++ b/src/control_plane/consensus/messages/event.rs
@@ -74,6 +74,7 @@ impl MetadataCommitted {
             }
             ApplyResult::TopicDeleted | ApplyResult::Noop => vec![],
             ApplyResult::SegmentReassigned(r) => r.into_catch_up_commands(sgid),
+            ApplyResult::SegmentsDeleted(d) => d.into_commands(),
         }
     }
 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -1334,7 +1334,7 @@ mod tests {
         let cmd = MetadataCommand::CreateTopic(CreateTopic {
             name: "test-topic".to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -1406,7 +1406,7 @@ mod tests {
             MetadataCommand::CreateTopic(CreateTopic {
                 name: "blue".to_string(),
                 storage_policy: StoragePolicy {
-                    retention_ms: 3_600_000,
+                    retention_ms: Some(3_600_000),
                     replication_factor: 3,
                     partition_strategy: PartitionStrategy::AutoSplit,
                 },
@@ -1797,7 +1797,7 @@ mod tests {
                 command: MetadataCommand::CreateTopic(CreateTopic {
                     name: name.to_string(),
                     storage_policy: StoragePolicy {
-                        retention_ms: 3_600_000,
+                        retention_ms: Some(3_600_000),
                         replication_factor: rf,
                         partition_strategy: PartitionStrategy::AutoSplit,
                     },

--- a/src/control_plane/consensus/raft/command.rs
+++ b/src/control_plane/consensus/raft/command.rs
@@ -3,7 +3,7 @@ use bincode::{Decode, Encode};
 use crate::control_plane::NodeId;
 use crate::control_plane::metadata::ReassignSegment;
 use crate::control_plane::metadata::command::{
-    CreateTopic, DeleteTopic, MergeRange, MetadataCommand, RollSegment, SplitRange,
+    CreateTopic, DeleteSegments, DeleteTopic, MergeRange, MetadataCommand, RollSegment, SplitRange,
 };
 use crate::{impl_from_variant, impl_from_variant_via};
 
@@ -28,5 +28,6 @@ impl_from_variant_via!(
     SplitRange,
     MergeRange,
     DeleteTopic,
-    ReassignSegment
+    ReassignSegment,
+    DeleteSegments
 );

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -9,10 +9,12 @@ use crate::control_plane::consensus::raft::log::LogEntry;
 use crate::control_plane::consensus::raft::storage::RaftPersistentState;
 use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now_ms};
 use crate::control_plane::membership::{ShardGroupId, TopologyReader};
+use crate::control_plane::metadata::command::DeleteSegments;
 use crate::control_plane::metadata::event::ApplyResult;
 use crate::control_plane::metadata::state_machine::MetadataStateMachine;
 use crate::control_plane::metadata::{
-    MetadataCommand, ReassignSegment, ReplicaSet, RollSegment, TopicMeta, TopicStats,
+    MetadataCommand, RangeId, ReassignSegment, ReplicaSet, RollSegment, SegmentId, TopicId,
+    TopicMeta, TopicStats,
 };
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::{CatchUpAck, SegmentAssignment, SegmentAssignmentAck};
@@ -261,6 +263,7 @@ impl Raft {
         changed |= self.reconcile_peers(topology, &live_set);
         changed |= self.reconcile_segments(&live_set);
         changed |= self.refill_under_replicated_segments(topology);
+        changed |= self.reconcile_retention_deletes();
 
         // Record a ring observation every run, whether routine RingCheck or
         // leadership change. During a leadership change, evictions are paused
@@ -589,6 +592,47 @@ impl Raft {
                 tracing::warn!(
                     "under-replication re-fill for {:?} on {:?} rejected: {:?}",
                     segment_key,
+                    self.shard_group_id,
+                    e
+                );
+                continue;
+            }
+            changed = true;
+        }
+        changed
+    }
+
+    /// Retention sweep (D7): leader-only, on the ring-check cadence. For each owned
+    /// range compute the oldest-first prefix of sealed segments expired under the
+    /// topic's `retention_ms` (against the wall clock, the one age-based decision —
+    /// leader-only so cross-node skew can't diverge replicas), and propose
+    /// `DeleteSegments`. Topics with no retention policy contribute nothing.
+    fn reconcile_retention_deletes(&mut self) -> bool {
+        let now = now_ms();
+        let targets: Vec<(TopicId, RangeId, Box<[SegmentId]>)> = self
+            .state_machine
+            .topics
+            .values()
+            .flat_map(|t| {
+                let topic_id = t.id;
+                t.expired_segment_prefixes(now)
+                    .into_iter()
+                    .map(move |(range_id, ids)| (topic_id, range_id, ids))
+            })
+            .collect();
+
+        let mut changed = false;
+        for (topic_id, range_id, segment_ids) in targets {
+            let cmd = DeleteSegments {
+                topic_id,
+                range_id,
+                segment_ids,
+            };
+            if let Err(e) = self.propose(cmd.into()) {
+                tracing::warn!(
+                    "retention delete for {:?}/{:?} on {:?} rejected: {:?}",
+                    topic_id,
+                    range_id,
                     self.shard_group_id,
                     e
                 );
@@ -2838,7 +2882,7 @@ mod tests {
         let cmd = MetadataCommand::CreateTopic(CreateTopic {
             name: "blue".to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -2968,7 +3012,7 @@ mod tests {
         MetadataCommand::CreateTopic(CreateTopic {
             name: name.to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -3330,7 +3374,7 @@ mod tests {
         let cmd: RaftCommand = MetadataCommand::CreateTopic(CreateTopic {
             name: name.to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: rf as u64,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },

--- a/src/control_plane/metadata/command.rs
+++ b/src/control_plane/metadata/command.rs
@@ -3,7 +3,7 @@ use bincode::{Decode, Encode};
 use crate::{
     control_plane::{
         NodeId,
-        metadata::{RangeId, TopicId, strategy::StoragePolicy},
+        metadata::{RangeId, SegmentId, TopicId, strategy::StoragePolicy},
     },
     data_plane::SegmentKey,
     impl_from_variant,
@@ -58,6 +58,17 @@ pub struct ReassignSegment {
     pub replica_set: Vec<NodeId>,
 }
 
+/// Retention: mark an oldest-first **prefix** of one range's sealed segments
+/// `Deleting`. Plural by nature — a retention sweep expires a run of old segments,
+/// not one. See `diagrams/data-plane/d7_retention_gc.md`.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct DeleteSegments {
+    pub topic_id: TopicId,
+    pub range_id: RangeId,
+    /// Oldest-first prefix of the range's sealed segments to delete.
+    pub segment_ids: Box<[SegmentId]>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum MetadataCommand {
     CreateTopic(CreateTopic),
@@ -66,6 +77,7 @@ pub enum MetadataCommand {
     MergeRange(MergeRange),
     DeleteTopic(DeleteTopic),
     ReassignSegment(ReassignSegment),
+    DeleteSegments(DeleteSegments),
 }
 
 impl_from_variant!(
@@ -75,5 +87,6 @@ impl_from_variant!(
     SplitRange,
     MergeRange,
     DeleteTopic,
-    ReassignSegment
+    ReassignSegment,
+    DeleteSegments
 );

--- a/src/control_plane/metadata/event.rs
+++ b/src/control_plane/metadata/event.rs
@@ -3,7 +3,9 @@ use crate::control_plane::consensus::multi_raft::SealContext;
 use crate::control_plane::membership::ShardGroupId;
 use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
 use crate::data_plane::SegmentKey;
-use crate::data_plane::messages::command::{CatchUpAssignment, SealResponse, SegmentAssignment};
+use crate::data_plane::messages::command::{
+    CatchUpAssignment, DeleteSegments, SealResponse, SegmentAssignment,
+};
 use crate::data_plane::transport::command::DataTransportCommand;
 use crate::impl_from_variant;
 
@@ -145,6 +147,40 @@ impl RangeMerged {
     }
 }
 
+/// Retention deletion (D7). Carries each deleted segment's key + its `replica_set`
+/// so the leader fans out a per-segment file delete to that segment's own replicas —
+/// segments in a range can sit on different replica sets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentsDeleted {
+    pub deletions: Vec<(SegmentKey, Vec<NodeId>)>,
+}
+
+impl SegmentsDeleted {
+    /// One `DeleteSegments` per distinct `replica_set`, batching that set's segments
+    /// into a single message. Grouping is order-preserving (linear over a small
+    /// per-range prefix), so the dispatch is deterministic.
+    pub fn into_commands(self) -> Vec<DataTransportCommand> {
+        let mut groups: Vec<(Vec<NodeId>, Vec<SegmentKey>)> = Vec::new();
+        for (segment_key, replica_set) in self.deletions {
+            match groups.iter_mut().find(|(rs, _)| *rs == replica_set) {
+                Some((_, keys)) => keys.push(segment_key),
+                None => groups.push((replica_set, vec![segment_key])),
+            }
+        }
+        groups
+            .into_iter()
+            .map(|(replica_set, keys)| {
+                DataTransportCommand::send_to_targets(
+                    replica_set,
+                    DeleteSegments {
+                        segment_keys: keys.into_boxed_slice(),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApplyResult {
     TopicCreated(TopicCreated),
@@ -152,6 +188,7 @@ pub enum ApplyResult {
     RangeSplit(RangeSplit),
     RangeMerged(RangeMerged),
     SegmentReassigned(SegmentReassigned),
+    SegmentsDeleted(SegmentsDeleted),
     TopicDeleted,
     Noop,
 }
@@ -162,5 +199,6 @@ impl_from_variant!(
     SegmentRolled,
     RangeSplit,
     RangeMerged,
-    SegmentReassigned
+    SegmentReassigned,
+    SegmentsDeleted
 );

--- a/src/control_plane/metadata/event.rs
+++ b/src/control_plane/metadata/event.rs
@@ -147,27 +147,18 @@ impl RangeMerged {
     }
 }
 
-/// Retention deletion (D7). Carries each deleted segment's key + its `replica_set`
-/// so the leader fans out a per-segment file delete to that segment's own replicas —
-/// segments in a range can sit on different replica sets.
+/// Retention deletion (D7). The deleted segments are pre-grouped by `replica_set`
+/// (in `delete_segments`, which already reads each segment's set) — one group becomes
+/// one batched `DeleteSegments` to that set's nodes. Segments in a range can sit on
+/// different replica sets, so there may be several groups.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentsDeleted {
-    pub deletions: Vec<(SegmentKey, Vec<NodeId>)>,
+    pub groups: Vec<(Vec<NodeId>, Vec<SegmentKey>)>,
 }
 
 impl SegmentsDeleted {
-    /// One `DeleteSegments` per distinct `replica_set`, batching that set's segments
-    /// into a single message. Grouping is order-preserving (linear over a small
-    /// per-range prefix), so the dispatch is deterministic.
     pub fn into_commands(self) -> Vec<DataTransportCommand> {
-        let mut groups: Vec<(Vec<NodeId>, Vec<SegmentKey>)> = Vec::new();
-        for (segment_key, replica_set) in self.deletions {
-            match groups.iter_mut().find(|(rs, _)| *rs == replica_set) {
-                Some((_, keys)) => keys.push(segment_key),
-                None => groups.push((replica_set, vec![segment_key])),
-            }
-        }
-        groups
+        self.groups
             .into_iter()
             .map(|(replica_set, keys)| {
                 DataTransportCommand::send_to_targets(

--- a/src/control_plane/metadata/range.rs
+++ b/src/control_plane/metadata/range.rs
@@ -280,6 +280,51 @@ impl RangeMeta {
         }
     }
 
+    /// Retention: mark the named segments `Deleting`, returning the ids actually
+    /// transitioned. Only `Sealed → Deleting` — an `Active` (write head) or an
+    /// already-`Deleting`/absent id is skipped, so the call is idempotent and can
+    /// never delete the write head. Callers pass an oldest-first prefix (the sweep
+    /// does so by construction); that no-hole property is a structural invariant
+    /// (`assert_retention_prefix`, d7 #2), not re-checked on the hot path.
+    pub(crate) fn delete_segments(&mut self, segment_ids: &[SegmentId]) -> Vec<SegmentId> {
+        let mut deleted = Vec::new();
+        for sid in segment_ids {
+            if let Some(seg) = self.segments.get_mut(sid)
+                && seg.state == SegmentMetaState::Sealed
+            {
+                seg.state = SegmentMetaState::Deleting;
+                deleted.push(*sid);
+            }
+        }
+        deleted
+    }
+
+    /// Retention: sealed segments expired under `retention_ms` as of `now`
+    /// (`sealed_at + retention_ms < now`), as an oldest-first prefix by segment_id.
+    /// Take-while semantics — stops at the first non-expired sealed segment (or the
+    /// active head) so the result is always a contiguous prefix, never a hole.
+    pub(crate) fn expired_sealed_prefix(&self, now: u64, retention_ms: u64) -> Vec<SegmentId> {
+        let mut segs: Vec<&SegmentMeta> = self.segments.values().collect();
+        segs.sort_by_key(|s| s.segment_id.0);
+        let mut out = Vec::new();
+        for seg in segs {
+            match seg.state {
+                // Already gone from the live prefix; keep scanning newer segments.
+                SegmentMetaState::Deleting => continue,
+                SegmentMetaState::Sealed => match seg.sealed_at {
+                    Some(sealed_at) if sealed_at.saturating_add(retention_ms) < now => {
+                        out.push(seg.segment_id)
+                    }
+                    // First non-expired (or unknown sealed_at) → stop: prefix only.
+                    _ => break,
+                },
+                // Reached the write head.
+                SegmentMetaState::Active => break,
+            }
+        }
+        out
+    }
+
     /// Compute the midpoint of two byte-slice keyspace bounds.
     pub fn compute_midpoint(&self) -> Vec<u8> {
         let len = self
@@ -370,6 +415,7 @@ pub mod props {
             );
             self.assert_seal_history();
             self.assert_offset_chain();
+            self.assert_retention_prefix();
         }
     }
 
@@ -442,6 +488,45 @@ pub mod props {
             let ts = &self.seal_history.seal_timestamps;
             for i in 1..ts.len() {
                 assert!(ts[i - 1] <= ts[i], "seal_history timestamps not sorted");
+            }
+        }
+
+        /// D7 retention invariants: (#1) the active head is never `Deleting`, so a
+        /// range under retention can still be written; (#2) `Deleting` segments form
+        /// an oldest-first prefix by segment_id — every survivor has a higher
+        /// segment_id, so survivors are a contiguous suffix and a forward reader
+        /// crosses the retained boundary exactly once (no hole).
+        fn assert_retention_prefix(&self) {
+            if let Some(active_id) = self.active_segment
+                && let Some(seg) = self.segments.get(&active_id)
+            {
+                assert_ne!(
+                    seg.state,
+                    SegmentMetaState::Deleting,
+                    "range {:?}: active segment is Deleting",
+                    self.range_id,
+                );
+            }
+            let max_deleting = self
+                .segments
+                .values()
+                .filter(|s| s.state == SegmentMetaState::Deleting)
+                .map(|s| s.segment_id.0)
+                .max();
+            let min_surviving = self
+                .segments
+                .values()
+                .filter(|s| s.state != SegmentMetaState::Deleting)
+                .map(|s| s.segment_id.0)
+                .min();
+            if let (Some(md), Some(ms)) = (max_deleting, min_surviving) {
+                assert!(
+                    md < ms,
+                    "range {:?}: Deleting segment_id {} >= surviving {} (not an oldest-first prefix)",
+                    self.range_id,
+                    md,
+                    ms,
+                );
             }
         }
 

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -71,9 +71,7 @@ impl MetadataStateMachine {
             RollSegment(cmd) => {
                 let range = self
                     .get_active_topic_mut(cmd.segment_key.topic_id)?
-                    .ranges
-                    .get_mut(&cmd.segment_key.range_id)
-                    .ok_or(RangeNotFound)?;
+                    .get_range_mut(&cmd.segment_key.range_id)?;
 
                 if !range.is_active_segment(cmd.segment_key.segment_id)? {
                     range.correct_end_offset(cmd.segment_key.segment_id, cmd.end_entry_id);
@@ -118,10 +116,7 @@ impl MetadataStateMachine {
     fn roll_segment(&mut self, cmd: RollSegment) -> Result<SegmentRolled, MetadataError> {
         let topic = self.get_active_topic_mut(cmd.segment_key.topic_id)?;
         let can_split = topic.can_split();
-        let range = topic
-            .ranges
-            .get_mut(&cmd.segment_key.range_id)
-            .ok_or(RangeNotFound)?;
+        let range = topic.get_range_mut(&cmd.segment_key.range_id)?;
 
         let new_segment_id = range.roll_segment(cmd.clone())?;
 
@@ -170,19 +165,16 @@ impl MetadataStateMachine {
     }
 
     /// Retention: mark an oldest-first prefix of a range's sealed segments `Deleting`.
-    /// `Noop` when nothing transitions (all named ids already `Deleting`/absent),
-    /// else `SegmentsDeleted` carrying each deleted segment's key + `replica_set` so
-    /// the leader can dispatch the per-segment file deletion. Uses plain `get_mut`
-    /// (not `validate_active`) so a command applied after the topic is being deleted
-    /// is a harmless no-op (segments already `Deleting`).
+    /// `Noop` when nothing transitions (all named ids already `Deleting`/absent), else
+    /// `SegmentsDeleted` carrying the deleted segments grouped by `replica_set` for
+    /// batched dispatch. Uses plain `get_mut` (not `validate_active`) so a command
+    /// applied after the topic is being deleted is a harmless no-op (already `Deleting`).
     fn delete_segments(&mut self, cmd: DeleteSegments) -> Result<ApplyResult, MetadataError> {
         let range = self
             .topics
             .get_mut(&cmd.topic_id)
             .ok_or(TopicNotFound(cmd.topic_id))?
-            .ranges
-            .get_mut(&cmd.range_id)
-            .ok_or(RangeNotFound)?;
+            .get_range_mut(&cmd.range_id)?;
 
         let deleted_ids = range.delete_segments(&cmd.segment_ids);
         if deleted_ids.is_empty() {

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -188,18 +188,19 @@ impl MetadataStateMachine {
         if deleted_ids.is_empty() {
             return Ok(ApplyResult::Noop);
         }
-        let deletions = deleted_ids
-            .iter()
-            .filter_map(|sid| {
-                range.segments.get(sid).map(|seg| {
-                    (
-                        SegmentKey::new(cmd.topic_id, cmd.range_id, *sid),
-                        seg.replica_set.clone(),
-                    )
-                })
-            })
-            .collect();
-        Ok(SegmentsDeleted { deletions }.into())
+        // Group the deleted segments by replica_set here.
+        let mut groups: Vec<(Vec<NodeId>, Vec<SegmentKey>)> = Vec::new();
+        for sid in &deleted_ids {
+            let Some(seg) = range.segments.get(sid) else {
+                continue;
+            };
+            let key = SegmentKey::new(cmd.topic_id, cmd.range_id, *sid);
+            match groups.iter_mut().find(|(rs, _)| rs == &seg.replica_set) {
+                Some((_, keys)) => keys.push(key),
+                None => groups.push((seg.replica_set.clone(), vec![key])),
+            }
+        }
+        Ok(SegmentsDeleted { groups }.into())
     }
 
     fn get_active_topic_mut(&mut self, id: TopicId) -> Result<&mut TopicMeta, MetadataError> {
@@ -433,7 +434,9 @@ mod tests {
         let ApplyResult::SegmentsDeleted(d) = result else {
             panic!("expected SegmentsDeleted, got {result:?}");
         };
-        assert_eq!(d.deletions.len(), 2);
+        // All three sealed segments share one replica_set → a single group of 2 keys.
+        assert_eq!(d.groups.len(), 1);
+        assert_eq!(d.groups[0].1.len(), 2);
         assert_eq!(seg_state(&sm, t, SegmentId(0)), SegmentMetaState::Deleting);
         assert_eq!(seg_state(&sm, t, SegmentId(1)), SegmentMetaState::Deleting);
         assert_eq!(seg_state(&sm, t, SegmentId(2)), SegmentMetaState::Sealed);
@@ -450,7 +453,8 @@ mod tests {
         else {
             panic!("expected SegmentsDeleted");
         };
-        assert_eq!(d.deletions.len(), 3);
+        let total_keys: usize = d.groups.iter().map(|(_, keys)| keys.len()).sum();
+        assert_eq!(total_keys, 3);
         assert_eq!(seg_state(&sm, t, SegmentId(3)), SegmentMetaState::Active);
     }
 

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -86,6 +86,7 @@ impl MetadataStateMachine {
             MergeRange(cmd) => self.merge_range(cmd)?.into(),
             DeleteTopic(cmd) => self.delete_topic(cmd).map(|()| ApplyResult::TopicDeleted)?,
             ReassignSegment(cmd) => self.reassign_segment(cmd)?,
+            DeleteSegments(cmd) => self.delete_segments(cmd)?,
         };
         #[cfg(any(test, debug_assertions))]
         self.assert_invariants();
@@ -166,6 +167,39 @@ impl MetadataStateMachine {
         } else {
             Ok(ApplyResult::Noop)
         }
+    }
+
+    /// Retention: mark an oldest-first prefix of a range's sealed segments `Deleting`.
+    /// `Noop` when nothing transitions (all named ids already `Deleting`/absent),
+    /// else `SegmentsDeleted` carrying each deleted segment's key + `replica_set` so
+    /// the leader can dispatch the per-segment file deletion. Uses plain `get_mut`
+    /// (not `validate_active`) so a command applied after the topic is being deleted
+    /// is a harmless no-op (segments already `Deleting`).
+    fn delete_segments(&mut self, cmd: DeleteSegments) -> Result<ApplyResult, MetadataError> {
+        let range = self
+            .topics
+            .get_mut(&cmd.topic_id)
+            .ok_or(TopicNotFound(cmd.topic_id))?
+            .ranges
+            .get_mut(&cmd.range_id)
+            .ok_or(RangeNotFound)?;
+
+        let deleted_ids = range.delete_segments(&cmd.segment_ids);
+        if deleted_ids.is_empty() {
+            return Ok(ApplyResult::Noop);
+        }
+        let deletions = deleted_ids
+            .iter()
+            .filter_map(|sid| {
+                range.segments.get(sid).map(|seg| {
+                    (
+                        SegmentKey::new(cmd.topic_id, cmd.range_id, *sid),
+                        seg.replica_set.clone(),
+                    )
+                })
+            })
+            .collect();
+        Ok(SegmentsDeleted { deletions }.into())
     }
 
     fn get_active_topic_mut(&mut self, id: TopicId) -> Result<&mut TopicMeta, MetadataError> {
@@ -286,7 +320,7 @@ mod tests {
 
     fn default_policy() -> StoragePolicy {
         StoragePolicy {
-            retention_ms: 3_600_000,
+            retention_ms: Some(3_600_000),
             replication_factor: 3,
             partition_strategy: PartitionStrategy::AutoSplit,
         }
@@ -294,7 +328,7 @@ mod tests {
 
     fn fixed_policy() -> StoragePolicy {
         StoragePolicy {
-            retention_ms: 3_600_000,
+            retention_ms: Some(3_600_000),
             replication_factor: 3,
             partition_strategy: PartitionStrategy::Fixed,
         }
@@ -335,6 +369,158 @@ mod tests {
             end_entry_id: None,
         }));
         assert!(matches!(result.unwrap(), ApplyResult::SegmentRolled(_)));
+    }
+
+    // ── D7 retention ───────────────────────────────────────────────────────
+
+    /// Roll the active segment, sealing it at `end_entry_id` / `sealed_at` so the
+    /// resulting sealed segment has a known end and seal time (unlike the death-roll
+    /// `roll_segment` helper above which seals with `None`).
+    fn roll_with_end(
+        sm: &mut MetadataStateMachine,
+        topic_id: TopicId,
+        segment_id: SegmentId,
+        end_entry_id: u64,
+        sealed_at: u64,
+    ) {
+        let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
+            segment_key: SegmentKey::new(topic_id, RangeId(0), segment_id),
+            sealed_at,
+            new_replica_set: replica_set(),
+            end_entry_id: Some(end_entry_id),
+        }));
+        assert!(matches!(result.unwrap(), ApplyResult::SegmentRolled(_)));
+    }
+
+    fn seg_state(
+        sm: &MetadataStateMachine,
+        topic_id: TopicId,
+        segment_id: SegmentId,
+    ) -> SegmentMetaState {
+        sm.get_topic(&topic_id).unwrap().ranges[&RangeId(0)].segments[&segment_id]
+            .state
+            .clone()
+    }
+
+    /// Build a topic with sealed segments 0,1,2 (ends 9/19/29, sealed at 100/200/300)
+    /// and an active head 3.
+    fn topic_with_three_sealed(sm: &mut MetadataStateMachine) -> TopicId {
+        let t = create_topic(sm, "t");
+        roll_with_end(sm, t, SegmentId(0), 9, 100);
+        roll_with_end(sm, t, SegmentId(1), 19, 200);
+        roll_with_end(sm, t, SegmentId(2), 29, 300);
+        t
+    }
+
+    fn delete_segments(
+        sm: &mut MetadataStateMachine,
+        topic_id: TopicId,
+        ids: &[u64],
+    ) -> Result<ApplyResult, MetadataError> {
+        sm.apply(MetadataCommand::DeleteSegments(DeleteSegments {
+            topic_id,
+            range_id: RangeId(0),
+            segment_ids: ids.iter().map(|&i| SegmentId(i)).collect(),
+        }))
+    }
+
+    #[test]
+    fn delete_segments_marks_oldest_prefix_deleting() {
+        let mut sm = MetadataStateMachine::default();
+        let t = topic_with_three_sealed(&mut sm);
+
+        let result = delete_segments(&mut sm, t, &[0, 1]).unwrap();
+        let ApplyResult::SegmentsDeleted(d) = result else {
+            panic!("expected SegmentsDeleted, got {result:?}");
+        };
+        assert_eq!(d.deletions.len(), 2);
+        assert_eq!(seg_state(&sm, t, SegmentId(0)), SegmentMetaState::Deleting);
+        assert_eq!(seg_state(&sm, t, SegmentId(1)), SegmentMetaState::Deleting);
+        assert_eq!(seg_state(&sm, t, SegmentId(2)), SegmentMetaState::Sealed);
+        assert_eq!(seg_state(&sm, t, SegmentId(3)), SegmentMetaState::Active);
+    }
+
+    #[test]
+    fn delete_segments_skips_the_active_head() {
+        let mut sm = MetadataStateMachine::default();
+        let t = topic_with_three_sealed(&mut sm);
+        // Naming the active head (seg 3) alongside the sealed prefix: only the sealed
+        // ones transition; the write head is skipped, never deleted.
+        let ApplyResult::SegmentsDeleted(d) = delete_segments(&mut sm, t, &[0, 1, 2, 3]).unwrap()
+        else {
+            panic!("expected SegmentsDeleted");
+        };
+        assert_eq!(d.deletions.len(), 3);
+        assert_eq!(seg_state(&sm, t, SegmentId(3)), SegmentMetaState::Active);
+    }
+
+    /// The no-hole property is a structural invariant, not a hot-path check: a
+    /// non-prefix deletion (seg 1 while seg 0 survives) trips `assert_retention_prefix`.
+    #[test]
+    #[should_panic(expected = "not an oldest-first prefix")]
+    fn delete_segments_non_prefix_trips_invariant() {
+        let mut sm = MetadataStateMachine::default();
+        let t = topic_with_three_sealed(&mut sm);
+        let _ = delete_segments(&mut sm, t, &[1]);
+    }
+
+    #[test]
+    fn delete_segments_is_idempotent() {
+        let mut sm = MetadataStateMachine::default();
+        let t = topic_with_three_sealed(&mut sm);
+        assert!(matches!(
+            delete_segments(&mut sm, t, &[0]).unwrap(),
+            ApplyResult::SegmentsDeleted(_)
+        ));
+        // Re-applying for an already-Deleting segment is a no-op.
+        assert!(matches!(
+            delete_segments(&mut sm, t, &[0]).unwrap(),
+            ApplyResult::Noop
+        ));
+    }
+
+    #[test]
+    fn expired_prefix_selects_by_age_oldest_first() {
+        let mut sm = MetadataStateMachine::default();
+        let t = topic_with_three_sealed(&mut sm); // sealed_at 100/200/300, retention 3_600_000
+        let topic = sm.get_topic(&t).unwrap();
+
+        // now such that segs 0,1 are past the window but seg 2 isn't.
+        let now = 200 + 3_600_000 + 1;
+        let prefixes = topic.expired_segment_prefixes(now);
+        assert_eq!(prefixes.len(), 1);
+        let (range_id, ids) = &prefixes[0];
+        assert_eq!(*range_id, RangeId(0));
+        assert_eq!(ids.as_ref(), &[SegmentId(0), SegmentId(1)]);
+    }
+
+    #[test]
+    fn expired_prefix_empty_without_retention() {
+        let mut sm = MetadataStateMachine::default();
+        let t = sm
+            .apply(MetadataCommand::CreateTopic(CreateTopic {
+                name: "no-retention".into(),
+                storage_policy: StoragePolicy {
+                    retention_ms: None,
+                    replication_factor: 3,
+                    partition_strategy: PartitionStrategy::AutoSplit,
+                },
+                replica_set: replica_set(),
+                created_at: 1000,
+            }))
+            .map(|r| match r {
+                ApplyResult::TopicCreated(tc) => tc.segment_key.topic_id,
+                other => panic!("{other:?}"),
+            })
+            .unwrap();
+        roll_with_end(&mut sm, t, SegmentId(0), 9, 100);
+        // Far past any window, but no policy → nothing expires.
+        assert!(
+            sm.get_topic(&t)
+                .unwrap()
+                .expired_segment_prefixes(u64::MAX)
+                .is_empty()
+        );
     }
 
     fn split_range(

--- a/src/control_plane/metadata/strategy.rs
+++ b/src/control_plane/metadata/strategy.rs
@@ -10,7 +10,7 @@ pub enum PartitionStrategy {
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct StoragePolicy {
-    pub retention_ms: u64,
+    pub retention_ms: Option<u64>,
     pub replication_factor: u64,
     pub partition_strategy: PartitionStrategy,
 }

--- a/src/control_plane/metadata/topic.rs
+++ b/src/control_plane/metadata/topic.rs
@@ -273,6 +273,22 @@ impl TopicMeta {
         self.ranges.get(&range_id).and_then(|m| m.merged_from)
     }
 
+    /// Retention (D7): per-range oldest-first prefixes of sealed segments expired
+    /// under this topic's policy as of `now`. Empty when the topic has no retention
+    /// set (`retention_ms = None`, the default — keep everything).
+    pub(crate) fn expired_segment_prefixes(&self, now: u64) -> Vec<(RangeId, Box<[SegmentId]>)> {
+        let Some(retention_ms) = self.storage_policy.retention_ms else {
+            return Vec::new();
+        };
+        self.ranges
+            .values()
+            .filter_map(|range| {
+                let ids = range.expired_sealed_prefix(now, retention_ms);
+                (!ids.is_empty()).then(|| (range.range_id, ids.into_boxed_slice()))
+            })
+            .collect()
+    }
+
     pub(crate) fn find_mergeable_pair(&self, now: u64) -> Option<MetadataCommand> {
         if !self.is_merge_eligible() {
             return None;
@@ -516,7 +532,7 @@ mod routing_tests {
 
     fn policy() -> StoragePolicy {
         StoragePolicy {
-            retention_ms: 1000,
+            retention_ms: Some(1000),
             replication_factor: 1,
             partition_strategy: PartitionStrategy::AutoSplit,
         }

--- a/src/control_plane/metadata/topic.rs
+++ b/src/control_plane/metadata/topic.rs
@@ -75,6 +75,16 @@ impl TopicMeta {
         Ok(vec_ranges.try_into().unwrap())
     }
 
+    pub(crate) fn get_range_mut(
+        &mut self,
+        range_id: &RangeId,
+    ) -> Result<&mut RangeMeta, MetadataError> {
+        Ok(self
+            .ranges
+            .get_mut(range_id)
+            .ok_or(MetadataError::RangeNotFound)?)
+    }
+
     pub(crate) fn validate_active(&self) -> Result<(), MetadataError> {
         (self.state == TopicState::Active)
             .then_some(())

--- a/src/control_plane/metadata/topic.rs
+++ b/src/control_plane/metadata/topic.rs
@@ -79,10 +79,9 @@ impl TopicMeta {
         &mut self,
         range_id: &RangeId,
     ) -> Result<&mut RangeMeta, MetadataError> {
-        Ok(self
-            .ranges
+        self.ranges
             .get_mut(range_id)
-            .ok_or(MetadataError::RangeNotFound)?)
+            .ok_or(MetadataError::RangeNotFound)
     }
 
     pub(crate) fn validate_active(&self) -> Result<(), MetadataError> {

--- a/src/data_plane/checkpoint.rs
+++ b/src/data_plane/checkpoint.rs
@@ -60,6 +60,12 @@ impl CheckpointWorker {
                         tracing::error!("Catch-up anchor index write failed: {e}");
                     }
                 }
+                CheckpointTask::DeleteSegmentIndex(segment_key) => {
+                    // Retention (D7): the segment's file was reclaimed; drop its index.
+                    if let Err(e) = sparse_index.delete_segment_entries(segment_key) {
+                        tracing::warn!("retention index delete failed for {segment_key:?}: {e}");
+                    }
+                }
             }
         }
     }
@@ -108,6 +114,8 @@ pub(crate) enum CheckpointTask {
     /// Persist the sparse-index anchors for a segment the catch-up receive wrote
     /// directly (replacement side); the worker just `put_batch`es them.
     PutAnchors(Box<[SparseEntry]>),
+    /// Retention (D7): remove a reclaimed segment's sparse-index entries.
+    DeleteSegmentIndex(SegmentKey),
 }
 
 pub struct CheckpointJob {

--- a/src/data_plane/cold_read.rs
+++ b/src/data_plane/cold_read.rs
@@ -281,6 +281,9 @@ mod tests {
         fn put_batch(&self, _entries: Vec<SparseEntry>) -> std::io::Result<()> {
             Ok(())
         }
+        fn delete_segment_entries(&self, _segment_key: SegmentKey) -> std::io::Result<()> {
+            Ok(())
+        }
         fn seek_index(&self, _segment_key: SegmentKey, target_offset: u64) -> (u64, u64) {
             // Nearest anchor at or below target (seek_for_prev semantics),
             // returned as (anchor_id, byte_position).

--- a/src/data_plane/messages/command.rs
+++ b/src/data_plane/messages/command.rs
@@ -200,6 +200,17 @@ pub struct SealBoundaryReport {
     pub durable_end: Option<u64>,
 }
 
+/// Retention (D7): the coordinator tells replicas to reclaim sealed segments —
+/// delete the file, drop the cache, and remove the sparse-index entries. Sent per
+/// distinct `replica_set` (segments in a range can sit on different sets), batching
+/// all of that set's expired segments into one message. Idempotent per key: a node
+/// that no longer holds one (already gone / never had it) skips it; orphan GC is the
+/// backstop.
+#[derive(Debug, Clone, Encode, Decode)]
+pub struct DeleteSegments {
+    pub segment_keys: Box<[SegmentKey]>,
+}
+
 #[derive(Debug, Clone, Encode, Decode)]
 pub enum DataPlaneInterNodeCommand {
     SegmentAssignment(SegmentAssignment),
@@ -217,6 +228,7 @@ pub enum DataPlaneInterNodeCommand {
     CatchUpAck(CatchUpAck),
     SealBoundaryQuery(SealBoundaryQuery),
     SealBoundaryReport(SealBoundaryReport),
+    DeleteSegments(DeleteSegments),
 }
 
 impl_from_variant!(
@@ -236,6 +248,7 @@ impl_from_variant!(
     CatchUpAck,
     SealBoundaryQuery,
     SealBoundaryReport,
+    DeleteSegments,
 );
 
 #[derive(Debug)]

--- a/src/data_plane/messages/pending.rs
+++ b/src/data_plane/messages/pending.rs
@@ -4,6 +4,7 @@ use tokio::sync::oneshot;
 use crate::channels::BatchSender;
 use crate::control_plane::consensus::actor::MutlRaftSender;
 use crate::control_plane::consensus::messages::MultiRaftActorCommand;
+use crate::data_plane::SegmentKey;
 use crate::data_plane::checkpoint::{CheckpointJob, CheckpointTask};
 use crate::data_plane::messages::command::ProduceAck;
 use crate::data_plane::sparse_index::SparseEntry;
@@ -97,6 +98,11 @@ impl DataPlaneOutputs {
     pub(crate) fn store_put_anchors(&mut self, anchors: Vec<SparseEntry>) {
         self.checkpoint_tasks
             .push(CheckpointTask::PutAnchors(anchors.into_boxed_slice()));
+    }
+
+    pub(crate) fn store_delete_segment_index(&mut self, segment_key: SegmentKey) {
+        self.checkpoint_tasks
+            .push(CheckpointTask::DeleteSegmentIndex(segment_key));
     }
 
     #[cfg(test)]

--- a/src/data_plane/sparse_index.rs
+++ b/src/data_plane/sparse_index.rs
@@ -46,6 +46,11 @@ pub trait SparseIndex: Send + Sync + 'static {
     /// segment's first entry is always anchored), falls back to
     /// `(target_offset, 0)`.
     fn seek_index(&self, segment_key: SegmentKey, target_offset: u64) -> (u64, u64);
+
+    /// Retention (D7): remove every anchor for a segment (the 24-byte
+    /// topic/range/segment prefix). Called when the segment's file is reclaimed, so
+    /// the index doesn't leak entries for data that no longer exists.
+    fn delete_segment_entries(&self, segment_key: SegmentKey) -> io::Result<()>;
 }
 
 impl SparseIndex for rocksdb::DB {
@@ -75,6 +80,25 @@ impl SparseIndex for rocksdb::DB {
             return (anchor_id, byte_position);
         }
         (target_offset, 0)
+    }
+
+    fn delete_segment_entries(&self, segment_key: SegmentKey) -> io::Result<()> {
+        let mut prefix = Vec::with_capacity(24);
+        prefix.extend_from_slice(&segment_key.topic_id.to_be_bytes());
+        prefix.extend_from_slice(&segment_key.range_id.to_be_bytes());
+        prefix.extend_from_slice(&segment_key.segment_id.to_be_bytes());
+
+        let mut batch = rocksdb::WriteBatch::default();
+        let mut iter = self.raw_iterator();
+        iter.seek(&prefix);
+        while iter.valid()
+            && let Some(key) = iter.key()
+            && key.starts_with(&prefix)
+        {
+            batch.delete(key);
+            iter.next();
+        }
+        self.write(batch).map_err(io::Error::other)
     }
 }
 

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -434,6 +434,26 @@ impl<W: WalStorage> DataPlane<W> {
                 self.out
                     .store_coordinator_cmd(MultiRaftActorCommand::SealBoundaryReport(cmd));
             }
+
+            C::DeleteSegments(cmd) => self.handle_delete_segments(cmd),
+        }
+    }
+
+    /// Retention (D7): reclaim the named sealed segments the coordinator expired — for
+    /// each, drop the tracker/sealed-index slot, delete the file, and remove its
+    /// sparse-index entries. Idempotent per key: a segment this node no longer holds
+    /// (already gone, never had it) is skipped, and orphan GC is the eventual backstop
+    /// for a missed delete.
+    fn handle_delete_segments(&mut self, cmd: DeleteSegments) {
+        for key in cmd.segment_keys {
+            let Some(start_offset) = self.segments.remove_segment(&key) else {
+                continue;
+            };
+            self.recovered.remove(&key);
+            if let Err(e) = OrphanCandidate::new(key, start_offset).delete(&self.config.data_dir) {
+                tracing::warn!("retention: deleting segment file {key:?} failed: {e}");
+            }
+            self.out.store_delete_segment_index(key);
         }
     }
 
@@ -2867,6 +2887,64 @@ mod tests {
         assert!(
             matches!(reply_rx.try_recv(), Ok(OrphanGcSignal::KeepTicking)),
             "ticker told to keep going while an orphan is pending"
+        );
+    }
+
+    /// Retention (D7): a `DeleteSegment` for a sealed segment this node holds reclaims
+    /// the file, drops it from the store, and queues a sparse-index delete.
+    #[test]
+    fn retention_delete_reclaims_a_sealed_segment() {
+        use crate::data_plane::checkpoint::CheckpointTask;
+        let dir = tempfile::tempdir().unwrap();
+        let key = test_key();
+        let path = key.file_path(dir.path(), 0);
+        write_seg_file(&path, &[(b"a", 1)]);
+        let mut dp = make_data_plane(&dir);
+        dp.segments.insert_sealed_from_catch_up(key, 0, 0);
+        assert!(dp.segments.sealed_bounds(&key).is_some());
+
+        dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
+            DeleteSegments {
+                segment_keys: Box::new([key]),
+            }
+            .into(),
+        ));
+
+        assert!(!path.exists(), "segment file must be reclaimed");
+        assert!(
+            dp.segments.sealed_bounds(&key).is_none(),
+            "segment dropped from the store"
+        );
+        assert!(
+            dp.out
+                .checkpoint_tasks
+                .iter()
+                .any(|t| matches!(t, CheckpointTask::DeleteSegmentIndex(k) if *k == key)),
+            "sparse-index delete queued for the worker"
+        );
+    }
+
+    /// Idempotent: a `DeleteSegment` for a segment this node doesn't hold (already
+    /// gone, or never had it) is a no-op — no panic, no index-delete task.
+    #[test]
+    fn retention_delete_of_unheld_segment_is_a_noop() {
+        use crate::data_plane::checkpoint::CheckpointTask;
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+
+        dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
+            DeleteSegments {
+                segment_keys: Box::new([test_key()]),
+            }
+            .into(),
+        ));
+
+        assert!(
+            !dp.out
+                .checkpoint_tasks
+                .iter()
+                .any(|t| matches!(t, CheckpointTask::DeleteSegmentIndex(_))),
+            "no index delete for a segment not held here"
         );
     }
 

--- a/src/data_plane/states/segment_store.rs
+++ b/src/data_plane/states/segment_store.rs
@@ -232,6 +232,30 @@ impl SegmentStore {
         })
     }
 
+    /// Retention (D7): drop a segment this node holds, returning its `start_entry_id`
+    /// (needed to build the on-disk file path) so the caller can delete the file and
+    /// its sparse-index entries. Removes the live tracker (active) or the sealed-index
+    /// slot, whichever holds it. `None` if this node doesn't track it — already gone
+    /// or never had it; the caller no-ops and orphan GC is the backstop.
+    pub(crate) fn remove_segment(&mut self, key: &SegmentKey) -> Option<u64> {
+        if let Some(tracker) = self.by_key.remove(key) {
+            let start = tracker.start_entry_id();
+            self.unindex_active(*key, start);
+            return Some(start);
+        }
+        let sealed = self
+            .sealed_by_range
+            .get_mut(&(key.topic_id, key.range_id))?;
+        let start = sealed
+            .iter()
+            .find_map(|(&start, loc)| (loc.segment_id == key.segment_id).then_some(start))?;
+        sealed.remove(&start);
+        if sealed.is_empty() {
+            self.sealed_by_range.remove(&(key.topic_id, key.range_id));
+        }
+        Some(start)
+    }
+
     /// Look up a sealed segment's `(start_entry_id, end_entry_id)` by key.
     /// The catch-up source path uses this to stream `(local_end, end]` from its own
     /// committed bounds rather than bounds relayed by the requester — so it always

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -53,7 +53,7 @@ fn create_topic_and_describe_cluster() -> turmoil::Result {
         let req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
             name: "test-topic".to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -136,7 +136,7 @@ fn delete_topic() -> turmoil::Result {
         let create_req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
             name: "del-test".to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -274,7 +274,7 @@ fn list_topic_stats_after_create() -> turmoil::Result {
         let create_req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
             name: "stats-test".to_string(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -364,7 +364,7 @@ fn describe_topic_returns_topic_metadata() -> turmoil::Result {
         let create_req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
             name: "describe-test".into(),
             storage_policy: StoragePolicy {
-                retention_ms: 3_600_000,
+                retention_ms: Some(3_600_000),
                 replication_factor: 3,
                 partition_strategy: PartitionStrategy::AutoSplit,
             },
@@ -1761,7 +1761,7 @@ async fn create_topic_anywhere(topic: &str, nodes: &[(&str, u16)], replication_f
     let req = ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
         name: topic.into(),
         storage_policy: StoragePolicy {
-            retention_ms: 3_600_000,
+            retention_ms: Some(3_600_000),
             replication_factor,
             partition_strategy: PartitionStrategy::AutoSplit,
         },

--- a/src/it/sim/scenario.rs
+++ b/src/it/sim/scenario.rs
@@ -174,7 +174,7 @@ pub(super) fn make_create_topic_req(name: &str) -> ClientRequest {
     ClientRequest::ControlPlane(ControlPlaneRequest::CreateTopic {
         name: name.to_string(),
         storage_policy: StoragePolicy {
-            retention_ms: 3_600_000,
+            retention_ms: Some(3_600_000),
             replication_factor: 3,
             partition_strategy: PartitionStrategy::AutoSplit,
         },


### PR DESCRIPTION
- retention_ms: Option<u64> (opt-in, default keep-forever)
- DeleteSegments metadata command — marks an oldest-first prefix Deleting, skips active/absent (no production prefix/active rejection), grouped-by-replica_set in delete_segments itself
- invariants #1 (active never Deleting) + #2 (oldest-first prefix) in assert_invariants
- leader-only retention sweep in reconcile (early-returns for no-retention topics → negligible cost)
- data-plane batched DeleteSegments (per replica set) → file + cache + sparse-index reclamation, orphan-GC backstop
- unit tests (metadata apply/idempotent/skip-active/non-prefix-trips-invariant/expiry-by-age) + data-plane (reclaim/no-op)