### PR TITLE
feat: implement zero-controller consumer group coordination, offset management, and sdk refactoring

### DIFF
--- a/src/bin/eg-cli.rs
+++ b/src/bin/eg-cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use east_guard::client::{
-    Client, Consumer, ConsumerRecord, KeyInterest, PartitionStrategy, Producer, ProducerConfig,
-    StoragePolicy,
+    Client, Consumer, ConsumerConfig, ConsumerRecord, KeyInterest, PartitionStrategy, Producer,
+    ProducerConfig, StoragePolicy,
 };
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
@@ -44,6 +44,9 @@ enum Commands {
         /// Optional group ID for consumer group offset management
         #[arg(short, long)]
         group: Option<String>,
+        /// Optional auto-commit interval in milliseconds (default: 1000)
+        #[arg(long, default_value = "1000")]
+        auto_commit_ms: u64,
     },
     /// Exit the CLI
     Exit,
@@ -158,7 +161,19 @@ async fn execute_command(cmd: Commands, client: &Arc<Client>) -> anyhow::Result<
             count,
             timeout_sec,
             group,
-        } => handle_consume(client, topic, start, count, timeout_sec, group).await,
+            auto_commit_ms,
+        } => {
+            handle_consume(
+                client,
+                topic,
+                start,
+                count,
+                timeout_sec,
+                group,
+                auto_commit_ms,
+            )
+            .await
+        }
         Commands::Exit | Commands::Quit => {
             // Handled in main loop
             Ok(())
@@ -208,6 +223,7 @@ async fn handle_consume(
     count: usize,
     timeout_sec: Option<u64>,
     group: Option<String>,
+    auto_commit_ms: u64,
 ) -> anyhow::Result<()> {
     let start_policy = start.parse()?;
     println!(
@@ -215,14 +231,14 @@ async fn handle_consume(
         count, topic, start, group
     );
 
-    let consumer = Consumer::new(
-        client.clone(),
-        topic,
-        KeyInterest::AllKeys,
+    let config = ConsumerConfig {
         start_policy,
-        group.clone(),
-    )
-    .await?;
+        group_id: group.clone(),
+        auto_commit_interval_ms: auto_commit_ms,
+    };
+
+    let consumer =
+        Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, config).await?;
 
     let mut fetched = 0;
     let limit = if count == 0 { usize::MAX } else { count };
@@ -247,11 +263,6 @@ async fn handle_consume(
             Ok(Some(record)) => {
                 print_record(&record);
                 fetched += 1;
-
-                // Auto-commit periodically in unlimited mode
-                if count == 0 && group.is_some() && fetched % 10 == 0 {
-                    let _ = consumer.commit().await;
-                }
             }
             Ok(None) => {
                 println!("Topic drained.");

--- a/src/bin/eg-cli.rs
+++ b/src/bin/eg-cli.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use east_guard::client::{
-    Client, Consumer, KeyInterest, PartitionStrategy, Producer, ProducerConfig, StartPolicy,
+    Client, Consumer, ConsumerRecord, KeyInterest, PartitionStrategy, Producer, ProducerConfig,
     StoragePolicy,
 };
 use rustyline::completion::{Completer, Pair};
@@ -35,7 +35,8 @@ enum Commands {
         topic: String,
         #[arg(default_value = "earliest")]
         start: String,
-        #[arg(default_value = "10")]
+        /// 0 means no bound
+        #[arg(default_value = "0")]
         count: usize,
         /// Optional timeout in seconds to wait for new messages. If absent, waits indefinitely.
         #[arg(short, long)]
@@ -140,125 +141,174 @@ async fn main() -> anyhow::Result<()> {
     println!("Goodbye!");
     Ok(())
 }
-
 async fn execute_command(cmd: Commands, client: &Arc<Client>) -> anyhow::Result<()> {
     match cmd {
         Commands::CreateTopic {
             topic,
             replication_factor,
-        } => {
-            let policy = StoragePolicy {
-                retention_ms: None,
-                replication_factor,
-                partition_strategy: PartitionStrategy::AutoSplit,
-            };
-            println!("Creating topic '{}' (RF={})...", topic, replication_factor);
-            client.create_topic(&topic, policy).await?;
-            println!("Topic created successfully.");
-        }
+        } => handle_create_topic(client, topic, replication_factor).await,
         Commands::Publish {
             topic,
             key,
             message,
-        } => {
-            let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
-            let entry_id = producer.send(key.as_bytes(), message.into_bytes()).await?;
-            println!(
-                "Published to '{}' [key: '{}'] -> entry_id: {}",
-                topic, key, entry_id
-            );
-        }
+        } => handle_publish(client, topic, key, message).await,
         Commands::Consume {
             topic,
             start,
             count,
             timeout_sec,
             group,
-        } => {
-            let start_policy = match start.to_lowercase().as_str() {
-                "latest" => StartPolicy::Latest,
-                "earliest" => StartPolicy::Earliest,
-                _ => anyhow::bail!("Start policy must be 'earliest' or 'latest'"),
-            };
-
-            if let Some(ref g) = group {
-                println!(
-                    "Consuming up to {} records from '{}' (start: {}, group: {})...",
-                    count, topic, start, g
-                );
-            } else {
-                println!(
-                    "Consuming up to {} records from '{}' (start: {})...",
-                    count, topic, start
-                );
-            }
-
-            let consumer = Consumer::new_with_group(
-                client.clone(),
-                topic,
-                KeyInterest::AllKeys,
-                start_policy,
-                group.clone(),
-            )
-            .await?;
-
-            let mut fetched = 0;
-            while fetched < count {
-                let next_record_future = consumer.next_record();
-
-                let result = if let Some(sec) = timeout_sec {
-                    tokio::time::timeout(std::time::Duration::from_secs(sec), next_record_future)
-                        .await
-                } else {
-                    Ok(next_record_future.await)
-                };
-
-                match result {
-                    Ok(Ok(Some(record))) => {
-                        println!(
-                            "[{}] key: '{}', value: '{}'",
-                            record.offset,
-                            String::from_utf8_lossy(&record.key),
-                            String::from_utf8_lossy(&record.value)
-                        );
-                        fetched += 1;
-                    }
-                    Ok(Ok(None)) => {
-                        println!("Topic drained.");
-                        break;
-                    }
-                    Ok(Err(e)) => {
-                        println!("Consume error: {}", e);
-                        break;
-                    }
-                    Err(_) => {
-                        // Timeout reached, no more records immediately available
-                        break;
-                    }
-                }
-            }
-            if fetched == 0 {
-                println!("(No records found)");
-            } else if fetched == count {
-                println!("(Reached limit of {} records)", count);
-            } else {
-                println!("(Fetched {} records)", fetched);
-            }
-
-            if group.is_some() && fetched > 0 {
-                println!("Committing offsets...");
-                if let Err(e) = consumer.commit().await {
-                    println!("Failed to commit offsets: {}", e);
-                } else {
-                    println!("Offsets committed successfully.");
-                }
-            }
-        }
+        } => handle_consume(client, topic, start, count, timeout_sec, group).await,
         Commands::Exit | Commands::Quit => {
             // Handled in main loop
+            Ok(())
         }
     }
+}
+
+async fn handle_create_topic(
+    client: &Arc<Client>,
+    topic: String,
+    replication_factor: u64,
+) -> anyhow::Result<()> {
+    let policy = StoragePolicy {
+        retention_ms: None,
+        replication_factor,
+        partition_strategy: PartitionStrategy::AutoSplit,
+    };
+
+    println!("Creating topic '{}' (RF={})...", topic, replication_factor);
+    client.create_topic(&topic, policy).await?;
+    println!("Topic created successfully.");
+
     Ok(())
+}
+
+async fn handle_publish(
+    client: &Arc<Client>,
+    topic: String,
+    key: String,
+    message: String,
+) -> anyhow::Result<()> {
+    let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+    let entry_id = producer.send(key.as_bytes(), message.into_bytes()).await?;
+
+    println!(
+        "Published to '{}' [key: '{}'] -> entry_id: {}",
+        topic, key, entry_id
+    );
+
+    Ok(())
+}
+
+async fn handle_consume(
+    client: &Arc<Client>,
+    topic: String,
+    start: String,
+    count: usize,
+    timeout_sec: Option<u64>,
+    group: Option<String>,
+) -> anyhow::Result<()> {
+    let start_policy = start.parse()?;
+    println!(
+        "Consuming up to {} records from '{}' (start: {}, group: {:?})...",
+        count, topic, start, group
+    );
+
+    let consumer = Consumer::new_with_group(
+        client.clone(),
+        topic,
+        KeyInterest::AllKeys,
+        start_policy,
+        group.clone(),
+    )
+    .await?;
+
+    let mut fetched = 0;
+    let limit = if count == 0 { usize::MAX } else { count };
+
+    while fetched < limit {
+        let next_record_future = consumer.next_record();
+
+        let result = tokio::select! {
+            _ = shutdown_signal() => {
+                println!("\nGracefully stopping consumer...");
+                break;
+            }
+            r =  fetch_with_optional_timeout(next_record_future, timeout_sec) => r,
+        };
+
+        let Ok(result) = result else {
+            // Timeout reached
+            break;
+        };
+
+        match result {
+            Ok(Some(record)) => {
+                print_record(&record);
+                fetched += 1;
+
+                // Auto-commit periodically in unlimited mode
+                if count == 0 && group.is_some() && fetched % 10 == 0 {
+                    let _ = consumer.commit().await;
+                }
+            }
+            Ok(None) => {
+                println!("Topic drained.");
+                break;
+            }
+            Err(e) => {
+                println!("Consume error: {}", e);
+                break;
+            }
+        }
+    }
+
+    if fetched == 0 {
+        println!("(No records found)");
+    }
+
+    if group.is_some() && fetched > 0 {
+        if let Err(e) = consumer.commit().await {
+            println!("Failed to commit offsets: {}", e);
+        } else {
+            println!("Offsets committed successfully.");
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch_with_optional_timeout<F, T>(
+    fut: F,
+    timeout_sec: Option<u64>,
+) -> Result<T, tokio::time::error::Elapsed>
+where
+    F: Future<Output = T>,
+{
+    match timeout_sec {
+        Some(sec) => tokio::time::timeout(std::time::Duration::from_secs(sec), fut).await,
+        None => Ok(fut.await),
+    }
+}
+
+fn print_record(record: &ConsumerRecord) {
+    // Replace RecordType with your actual struct
+    let sys_time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+
+    print!(
+        "Fetched At:{}.{:03} ",
+        sys_time.as_secs() % 86_400,
+        sys_time.subsec_millis(),
+    );
+    println!(
+        "[[{}] key: '{}', value: '{}'",
+        record.offset,
+        String::from_utf8_lossy(&record.key),
+        String::from_utf8_lossy(&record.value)
+    );
 }
 
 struct CliHelper;
@@ -338,13 +388,13 @@ impl rustyline::hint::Hinter for CliHelper {
             }
             "consume" => {
                 if parts_count == 1 && ends_with_space {
-                    return Some("<TOPIC> [START] [COUNT] [-t TIMEOUT]".to_string());
+                    return Some("<TOPIC> [START] [COUNT] [-t TIMEOUT] [-g GROUP]".to_string());
                 } else if parts_count == 2 && ends_with_space {
-                    return Some("[START] [COUNT] [-t TIMEOUT]".to_string());
+                    return Some("[START] [COUNT] [-t TIMEOUT] [-g GROUP]".to_string());
                 } else if parts_count == 3 && ends_with_space {
-                    return Some("[COUNT] [-t TIMEOUT]".to_string());
+                    return Some("[COUNT] [-t TIMEOUT] [-g GROUP]".to_string());
                 } else if parts_count == 4 && ends_with_space {
-                    return Some("[-t TIMEOUT]".to_string());
+                    return Some("[-t TIMEOUT] [-g GROUP]".to_string());
                 }
             }
             _ => {}
@@ -361,3 +411,27 @@ impl rustyline::highlight::Highlighter for CliHelper {
 }
 impl rustyline::validate::Validator for CliHelper {}
 impl rustyline::Helper for CliHelper {}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/src/bin/eg-cli.rs
+++ b/src/bin/eg-cli.rs
@@ -40,6 +40,9 @@ enum Commands {
         /// Optional timeout in seconds to wait for new messages. If absent, waits indefinitely.
         #[arg(short, long)]
         timeout_sec: Option<u64>,
+        /// Optional group ID for consumer group offset management
+        #[arg(short, long)]
+        group: Option<String>,
     },
     /// Exit the CLI
     Exit,
@@ -170,6 +173,7 @@ async fn execute_command(cmd: Commands, client: &Arc<Client>) -> anyhow::Result<
             start,
             count,
             timeout_sec,
+            group,
         } => {
             let start_policy = match start.to_lowercase().as_str() {
                 "latest" => StartPolicy::Latest,
@@ -177,12 +181,26 @@ async fn execute_command(cmd: Commands, client: &Arc<Client>) -> anyhow::Result<
                 _ => anyhow::bail!("Start policy must be 'earliest' or 'latest'"),
             };
 
-            println!(
-                "Consuming up to {} records from '{}' (start: {})...",
-                count, topic, start
-            );
-            let consumer =
-                Consumer::new(client.clone(), topic, KeyInterest::AllKeys, start_policy).await?;
+            if let Some(ref g) = group {
+                println!(
+                    "Consuming up to {} records from '{}' (start: {}, group: {})...",
+                    count, topic, start, g
+                );
+            } else {
+                println!(
+                    "Consuming up to {} records from '{}' (start: {})...",
+                    count, topic, start
+                );
+            }
+
+            let consumer = Consumer::new_with_group(
+                client.clone(),
+                topic,
+                KeyInterest::AllKeys,
+                start_policy,
+                group.clone(),
+            )
+            .await?;
 
             let mut fetched = 0;
             while fetched < count {
@@ -225,6 +243,15 @@ async fn execute_command(cmd: Commands, client: &Arc<Client>) -> anyhow::Result<
                 println!("(Reached limit of {} records)", count);
             } else {
                 println!("(Fetched {} records)", fetched);
+            }
+
+            if group.is_some() && fetched > 0 {
+                println!("Committing offsets...");
+                if let Err(e) = consumer.commit().await {
+                    println!("Failed to commit offsets: {}", e);
+                } else {
+                    println!("Offsets committed successfully.");
+                }
             }
         }
         Commands::Exit | Commands::Quit => {

--- a/src/bin/eg-cli.rs
+++ b/src/bin/eg-cli.rs
@@ -215,7 +215,7 @@ async fn handle_consume(
         count, topic, start, group
     );
 
-    let consumer = Consumer::new_with_group(
+    let consumer = Consumer::new(
         client.clone(),
         topic,
         KeyInterest::AllKeys,

--- a/src/client/consumer/bootstrap.rs
+++ b/src/client/consumer/bootstrap.rs
@@ -43,6 +43,17 @@ pub enum StartPolicy {
     Earliest,
 }
 
+impl std::str::FromStr for StartPolicy {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "latest" => Ok(StartPolicy::Latest),
+            "earliest" => Ok(StartPolicy::Earliest),
+            _ => anyhow::bail!("Start policy must be 'earliest' or 'latest'"),
+        }
+    }
+}
+
 /// Module-local helper that bundles the `(detail, interest)` pair the
 /// bootstrap path walks.
 pub(crate) struct CursorBootstrap<'a> {
@@ -73,10 +84,6 @@ impl<'a> CursorBootstrap<'a> {
             .filter(|r| self.interest.matches(r))
             .map(|r| {
                 let start_offset = r.active_segment.as_ref().map_or(0, |s| s.start_entry_id);
-                println!(
-                    "[DEBUG LATEST] range_id={}, start_offset={}",
-                    *r.range_id, start_offset
-                );
                 RangeCursor::new(
                     r.range_id,
                     start_offset,

--- a/src/client/consumer/cursor.rs
+++ b/src/client/consumer/cursor.rs
@@ -75,7 +75,7 @@ impl From<&RangeDetail> for RangeCursor {
     fn from(r: &RangeDetail) -> Self {
         RangeCursor::new(
             r.range_id,
-            0,
+            r.first_segment_start_offset().unwrap_or(0),
             r.keyspace_start.clone(),
             r.keyspace_end.clone(),
         )

--- a/src/client/consumer/cursor_set.rs
+++ b/src/client/consumer/cursor_set.rs
@@ -34,10 +34,6 @@ impl RangeCursorSet {
         set
     }
 
-    pub fn bootstrap(detail: &TopicDetail, interest: KeyInterest, policy: StartPolicy) -> Self {
-        CursorBootstrap::build(detail, interest, policy)
-    }
-
     pub fn cursors(&self) -> &[RangeCursor] {
         &self.cursors
     }

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -26,13 +26,13 @@ enum RangeLookupResult {
 /// The asynchronous fetch loop for a single active range cursor.
 pub(crate) async fn run_fetch_actor(
     range_id: RangeId,
-    next_offset: u64,
+    next_entry_id: u64,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
 ) {
     let mut actor = FetchActor {
         range_id,
-        next_entry_id: next_offset,
+        next_entry_id,
         ctx,
         record_tx,
     };
@@ -241,8 +241,14 @@ impl ConsumerContext {
 
     /// Refresh the cached metadata snapshot by resolving the topic against the cluster.
     pub(crate) async fn refresh_metadata(&self) -> Result<(), ClientError> {
-        let detail = self.client.resolve_topic(&self.topic).await?;
-        self.metadata.store(Arc::new(detail));
+        if let Ok(Ok(detail)) = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.client.resolve_topic(&self.topic),
+        )
+        .await
+        {
+            self.metadata.store(Arc::new(detail));
+        }
         Ok(())
     }
 
@@ -280,6 +286,15 @@ impl ConsumerContext {
         }
 
         RangeLookupResult::NeedRefresh
+    }
+
+    pub(crate) fn all_ranges(&self) -> Vec<RangeId> {
+        self.metadata
+            .load()
+            .ranges
+            .iter()
+            .map(|r| r.range_id)
+            .collect::<Vec<_>>()
     }
 }
 

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -128,7 +128,7 @@ impl FetchActor {
                     for (i, rec) in records.iter().enumerate() {
                         let consumer_rec = ConsumerRecord {
                             topic: self.ctx.topic.clone(),
-                            range_id: self.range_id.0,
+                            range_id: self.range_id,
                             offset: entry.entry_id + i as u64,
                             key: rec.key.clone(),
                             value: rec.value.clone(),

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -164,8 +164,13 @@ impl FetchActor {
                 Ok(true)
             }
             DataPlaneResponse::EntryIdOutOfRange => {
-                 let prev_entry_id = self.next_entry_id;
-                 let (start_id, _) = self.ctx.client.fetch_range_offsets(&self.ctx.topic, self.range_id).await?;
+                let prev_entry_id = self.next_entry_id;
+                let (start_id, _) = self
+                    .ctx
+                    .client
+                    .fetch_range_offsets(&self.ctx.topic, self.range_id)
+                    .await?;
+
                 if self.next_entry_id < start_id {
                     self.next_entry_id = start_id;
                 }
@@ -233,7 +238,6 @@ impl ConsumerContext {
             // If we found either, try to pick a replica from it
             .and_then(|seg| seg.pick_replica())
     }
-
 
     /// Refresh the cached metadata snapshot by resolving the topic against the cluster.
     pub(crate) async fn refresh_metadata(&self) -> Result<(), ClientError> {

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -164,8 +164,8 @@ impl FetchActor {
                 Ok(true)
             }
             DataPlaneResponse::EntryIdOutOfRange => {
-                let prev_entry_id = self.next_entry_id;
-                let (start_id, _) = self.ctx.fetch_range_offsets(self.range_id).await?;
+                 let prev_entry_id = self.next_entry_id;
+                 let (start_id, _) = self.ctx.client.fetch_range_offsets(&self.ctx.topic, self.range_id).await?;
                 if self.next_entry_id < start_id {
                     self.next_entry_id = start_id;
                 }
@@ -234,31 +234,6 @@ impl ConsumerContext {
             .and_then(|seg| seg.pick_replica())
     }
 
-    pub(crate) async fn fetch_range_offsets(
-        &self,
-        range_id: RangeId,
-    ) -> Result<(u64, u64), ClientError> {
-        let addr = self
-            .pick_replica_for_range(range_id)
-            .unwrap_or_else(|| self.client.next_known_node());
-
-        let req = RangeOffsetRequest {
-            topic_name: self.topic.clone(),
-            range_id,
-        };
-
-        let served = self.client.call(addr, req).await?;
-
-        let ClientResponse::DataPlane(DataPlaneResponse::RangeOffset {
-            start_entry_id,
-            committed_entry_id,
-        }) = served.response
-        else {
-            return Err(ClientError::UnexpectedResponse);
-        };
-
-        Ok((start_entry_id, committed_entry_id))
-    }
 
     /// Refresh the cached metadata snapshot by resolving the topic against the cluster.
     pub(crate) async fn refresh_metadata(&self) -> Result<(), ClientError> {

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -168,7 +168,7 @@ impl FetchActor {
                 let (start_id, _) = self
                     .ctx
                     .client
-                    .fetch_range_offsets(&self.ctx.topic, self.range_id)
+                    .fetch_range_entry_ids(&self.ctx.topic, self.range_id)
                     .await?;
 
                 if self.next_entry_id < start_id {

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -1,11 +1,12 @@
 use crate::client::{
-    Client, ClientError, Consumer, ConsumerRecord, KeyInterest, Producer, ProducerConfig,
-    StartPolicy,
+    Client, ClientError, Consumer, ConsumerRecord, KeyInterest, PartitionStrategy, Producer,
+    ProducerConfig, StartPolicy, StoragePolicy,
 };
 use crate::control_plane::metadata::RangeId;
+use arc_swap::ArcSwap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use dashmap::DashMap;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
@@ -22,48 +23,123 @@ pub struct HeartbeatPayload {
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 pub struct OffsetCommitPayload {
-    pub range_id: u64,
+    pub range_id: RangeId,
     pub offset: u64,
 }
 
 pub struct ConsumerGroup {
     pub group_id: String,
+    pub topic: String,
     pub consumer_id: Uuid,
     pub client: Arc<Client>,
-    pub active_peers: Arc<DashMap<Uuid, u64>>,
-    // FIX: Hold the handles so we can kill them on drop!
-    hb_sender_task: tokio::task::JoinHandle<()>,
-    hb_receiver_task: tokio::task::JoinHandle<()>,
+    pub offset_producer: Producer,
+    pub active_peers: DashMap<Uuid, u64>,
+    pub owned_ranges: ArcSwap<Option<HashSet<RangeId>>>,
+    pub offsets: DashMap<RangeId, u64>,
+
+    // Hold the handles so we can kill them on drop
+    hb_sender_handle: tokio::task::AbortHandle,
+    hb_receiver_handle: tokio::task::AbortHandle,
 }
 
 impl ConsumerGroup {
-    pub fn new(client: Arc<Client>, group_id: String) -> Result<Self, ClientError> {
+    pub fn new(client: Arc<Client>, group_id: String, topic: String) -> Result<Self, ClientError> {
         let consumer_id = Uuid::new_v4();
-        let active_peers = Arc::new(DashMap::new());
+        let active_peers = DashMap::new();
 
-        let hb_sender_task = tokio::spawn(group_hb_sender(
+        let hb_sender_handle = tokio::spawn(group_heartbeat_sender(
             consumer_id,
             client.clone(),
-            group_id.clone(),
-        ));
+            format!("hb:{}", group_id.clone()),
+        ))
+        .abort_handle();
+        let offset_producer = Producer::new(
+            client.clone(),
+            SYSTEM_TOPIC_OFFSETS.to_string(),
+            ProducerConfig::default(),
+        );
 
-        let hb_receiver_task = tokio::spawn(hb_receiver(
+        let hb_receiver_handle = tokio::spawn(heartbeat_receiver(
             client.clone(),
             active_peers.clone(),
-            group_id.clone(),
-        ));
+            format!("hb:{}", group_id),
+        ))
+        .abort_handle();
+
+        let owned_ranges = ArcSwap::from_pointee(None);
+        let offsets = DashMap::new();
 
         Ok(Self {
             group_id,
+            topic,
             consumer_id,
             client,
+            offset_producer,
             active_peers,
-            hb_sender_task,
-            hb_receiver_task,
+            owned_ranges,
+            offsets,
+            hb_sender_handle,
+            hb_receiver_handle,
         })
     }
 
-    pub fn assigned_ranges(&self, available_ranges: &[RangeId]) -> Vec<RangeId> {
+    pub fn routing_key(&self) -> String {
+        format!("{}:{}", self.group_id, self.topic)
+    }
+
+    pub async fn bootstrap(&self) -> Result<(), ClientError> {
+        let policy = StoragePolicy {
+            retention_ms: None,
+            replication_factor: 1, // Single replica for system topics locally for now, or match cluster default
+            partition_strategy: PartitionStrategy::AutoSplit,
+        };
+
+        // Attempt to create system topics. Ignore errors if they already exist.
+        let _ = self
+            .client
+            .create_topic(SYSTEM_TOPIC_ASSIGNMENTS, policy.clone())
+            .await;
+        let _ = self.client.create_topic(SYSTEM_TOPIC_OFFSETS, policy).await;
+
+        Ok(())
+    }
+
+    pub(crate) fn is_responsible_for(&self, range_id: RangeId) -> bool {
+        let guard = self.owned_ranges.load();
+        if let Some(owned) = &**guard {
+            owned.contains(&range_id)
+        } else {
+            true
+        }
+    }
+
+    pub(crate) fn record_offset(&self, range_id: RangeId, offset: u64) {
+        self.offsets.insert(range_id, offset);
+    }
+
+    pub async fn commit(&self) -> Result<(), ClientError> {
+        for entry in self.offsets.iter() {
+            if let Some(owned) = &**self.owned_ranges.load()
+                && !owned.contains(entry.key())
+            {
+                continue;
+            }
+
+            let payload = OffsetCommitPayload {
+                range_id: *entry.key(),
+                offset: *entry.value(),
+            };
+            if let Ok(data) = borsh::to_vec(&payload) {
+                let _ = self
+                    .offset_producer
+                    .send(self.routing_key().as_bytes(), data)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn assigned_ranges(&self, available_ranges: &[RangeId]) -> Vec<RangeId> {
         let mut peers: Vec<Uuid> = Vec::new();
         peers.push(self.consumer_id); // Always include self
 
@@ -86,7 +162,7 @@ impl ConsumerGroup {
             }
         }
 
-        let mut my_ranges = Vec::new();
+        let mut ranges = Vec::new();
 
         for &range in available_ranges {
             let range_bytes = range.0.to_le_bytes();
@@ -100,48 +176,15 @@ impl ConsumerGroup {
                 .1;
 
             if assigned_peer == &self.consumer_id {
-                my_ranges.push(range);
+                ranges.push(range);
             }
         }
 
-        my_ranges
-    }
-
-    pub fn fetch_saved_offset<'a>(
-        &'a self,
-        topic: &'a str,
-        range_id: u64,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<u64>> + Send + 'a>> {
-        Box::pin(async move {
-            let offsets_consumer = Consumer::new(
-                self.client.clone(),
-                SYSTEM_TOPIC_OFFSETS.to_string(),
-                KeyInterest::AllKeys,
-                StartPolicy::Earliest,
-            )
-            .await
-            .ok()?;
-
-            let routing_key = format!("{}:{}", self.group_id, topic);
-            let mut latest_offset = None;
-
-            while let Ok(Ok(Some(record))) =
-                tokio::time::timeout(Duration::from_millis(2000), offsets_consumer.next_record())
-                    .await
-            {
-                if record.key == routing_key.as_bytes()
-                    && let Ok(payload) = OffsetCommitPayload::try_from_slice(&record.value)
-                    && payload.range_id == range_id
-                {
-                    latest_offset = Some(payload.offset);
-                }
-            }
-            latest_offset
-        })
+        ranges
     }
 }
 
-async fn group_hb_sender(consumer_id: Uuid, hb_client: Arc<Client>, hb_group: String) {
+async fn group_heartbeat_sender(consumer_id: Uuid, hb_client: Arc<Client>, routing_key: String) {
     let producer = Producer::new(
         hb_client,
         SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
@@ -157,35 +200,42 @@ async fn group_hb_sender(consumer_id: Uuid, hb_client: Arc<Client>, hb_group: St
         };
 
         if let Ok(data) = borsh::to_vec(&payload) {
-            let _ = producer.send(hb_group.as_bytes(), data).await;
+            let _ = producer.send(routing_key.as_bytes(), data).await;
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 
-async fn hb_receiver(rx_client: Arc<Client>, rx_peers: Arc<DashMap<Uuid, u64>>, rx_group: String) {
+async fn heartbeat_receiver(
+    client: Arc<Client>,
+    active_peers: DashMap<Uuid, u64>,
+    heartbeat_key: String,
+) {
     let consumer_res = Consumer::new(
-        rx_client,
+        client,
         SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
         KeyInterest::AllKeys,
         StartPolicy::Latest,
+        None,
     )
     .await;
 
-    if let Ok(consumer) = consumer_res {
-        while let Ok(Some(record)) = consumer.next_record().await {
-            if record.key == rx_group.as_bytes()
-                && let Ok(payload) = HeartbeatPayload::try_from_slice(&record.value)
-                && let Ok(cid) = Uuid::from_slice(&payload.consumer_id)
-            {
-                // Store the highest sequence number seen
-                if let Some(mut current) = rx_peers.get_mut(&cid) {
-                    if payload.sequence_number > *current {
-                        *current = payload.sequence_number;
-                    }
-                } else {
-                    rx_peers.insert(cid, payload.sequence_number);
+    let Ok(consumer) = consumer_res else {
+        return;
+    };
+
+    while let Ok(Some(record)) = consumer.next_record().await {
+        if record.key_match(heartbeat_key.as_bytes().iter())
+            && let Ok(payload) = HeartbeatPayload::try_from_slice(&record.value)
+            && let Ok(cid) = Uuid::from_slice(&payload.consumer_id)
+        {
+            // Store the highest sequence number seen
+            if let Some(mut current) = active_peers.get_mut(&cid) {
+                if payload.sequence_number > *current {
+                    *current = payload.sequence_number;
                 }
+            } else {
+                active_peers.insert(cid, payload.sequence_number);
             }
         }
     }
@@ -193,7 +243,7 @@ async fn hb_receiver(rx_client: Arc<Client>, rx_peers: Arc<DashMap<Uuid, u64>>, 
 
 impl Drop for ConsumerGroup {
     fn drop(&mut self) {
-        self.hb_sender_task.abort();
-        self.hb_receiver_task.abort();
+        self.hb_sender_handle.abort();
+        self.hb_receiver_handle.abort();
     }
 }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -182,6 +182,29 @@ impl ConsumerGroup {
 
         ranges
     }
+
+    pub fn rebalance(&self, active_ranges: &[RangeId]) -> (Vec<RangeId>, Vec<RangeId>) {
+        let latest_assignments = self.assigned_ranges(active_ranges);
+        let current_owned = self.owned_ranges.load();
+        let current_set = current_owned.as_ref().as_ref().cloned().unwrap_or_default();
+        let latest_set: HashSet<RangeId> = latest_assignments.into_iter().collect();
+        let to_drop: Vec<RangeId> = current_set
+            .iter()
+            .filter(|r| !latest_set.contains(r))
+            .copied()
+            .collect();
+        let to_start: Vec<RangeId> = latest_set
+            .iter()
+            .filter(|r| !current_set.contains(r))
+            .copied()
+            .collect();
+
+        if !to_drop.is_empty() || !to_start.is_empty() {
+            self.owned_ranges.store(Arc::new(Some(latest_set)));
+        }
+
+        (to_drop, to_start)
+    }
 }
 
 async fn group_heartbeat_sender(consumer_id: Uuid, hb_client: Arc<Client>, routing_key: String) {

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -198,7 +198,11 @@ impl ConsumerGroup {
         ranges
     }
 
-    pub fn rebalance(&self, active_ranges: &[RangeId]) -> (Vec<RangeId>, Vec<RangeId>) {
+    pub fn rebalance(
+        &self,
+        ranges: &[RangeId],
+        active_ranges: HashSet<RangeId>,
+    ) -> (Vec<RangeId>, Vec<RangeId>) {
         let current_set = self
             .owned_ranges
             .load()
@@ -206,20 +210,24 @@ impl ConsumerGroup {
             .as_ref()
             .cloned()
             .unwrap_or_default();
-        let latest_set: HashSet<RangeId> =
-            self.assigned_ranges(active_ranges).into_iter().collect();
+        let latest_set: HashSet<RangeId> = self.assigned_ranges(ranges).into_iter().collect();
         let to_drop: Vec<RangeId> = current_set
             .iter()
             .filter(|r| !latest_set.contains(r))
             .copied()
             .collect();
+
+        // Start tasks for any range in the target assignments that does not currently have an active task.
+        // This covers both:
+        //   1. Newly assigned ranges (which won't be in active_ranges)
+        //   2. Previously owned ranges whose fetch tasks crashed or stopped running (reconciliation)
         let to_start: Vec<RangeId> = latest_set
             .iter()
-            .filter(|r| !current_set.contains(r))
+            .filter(|r| !active_ranges.contains(r))
             .copied()
             .collect();
 
-        if !to_drop.is_empty() || !to_start.is_empty() {
+        if current_set != latest_set {
             self.owned_ranges.store(Arc::new(Some(latest_set)));
         }
 

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -33,7 +33,7 @@ pub struct ConsumerGroup {
     pub consumer_id: Uuid,
     pub client: Arc<Client>,
     pub offset_producer: Producer,
-    pub active_peers: DashMap<Uuid, u64>,
+    pub active_peers: Arc<DashMap<Uuid, u64>>,
     pub owned_ranges: ArcSwap<Option<HashSet<RangeId>>>,
     pub offsets: DashMap<RangeId, u64>,
 
@@ -45,7 +45,7 @@ pub struct ConsumerGroup {
 impl ConsumerGroup {
     pub fn new(client: Arc<Client>, group_id: String, topic: String) -> Result<Self, ClientError> {
         let consumer_id = Uuid::new_v4();
-        let active_peers = DashMap::new();
+        let active_peers = Arc::new(DashMap::new());
 
         let hb_sender_handle = tokio::spawn(group_heartbeat_sender(
             consumer_id,
@@ -66,9 +66,6 @@ impl ConsumerGroup {
         ))
         .abort_handle();
 
-        let owned_ranges = ArcSwap::from_pointee(None);
-        let offsets = DashMap::new();
-
         Ok(Self {
             group_id,
             topic,
@@ -76,8 +73,8 @@ impl ConsumerGroup {
             client,
             offset_producer,
             active_peers,
-            owned_ranges,
-            offsets,
+            owned_ranges: ArcSwap::from_pointee(None),
+            offsets: DashMap::new(),
             hb_sender_handle,
             hb_receiver_handle,
         })
@@ -134,6 +131,24 @@ impl ConsumerGroup {
                     .offset_producer
                     .send(self.routing_key().as_bytes(), data)
                     .await;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn commit_ranges(&self, ranges: &[RangeId]) -> Result<(), ClientError> {
+        for range in ranges {
+            if let Some(entry) = self.offsets.get(range) {
+                let payload = OffsetCommitPayload {
+                    range_id: *entry.key(),
+                    offset: *entry.value(),
+                };
+                if let Ok(data) = borsh::to_vec(&payload) {
+                    let _ = self
+                        .offset_producer
+                        .send(self.routing_key().as_bytes(), data)
+                        .await;
+                }
             }
         }
         Ok(())
@@ -231,7 +246,7 @@ async fn group_heartbeat_sender(consumer_id: Uuid, hb_client: Arc<Client>, routi
 
 async fn heartbeat_receiver(
     client: Arc<Client>,
-    active_peers: DashMap<Uuid, u64>,
+    active_peers: Arc<DashMap<Uuid, u64>>,
     heartbeat_key: String,
 ) {
     let consumer_res = Consumer::new(

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -1,0 +1,199 @@
+use crate::client::{
+    Client, ClientError, Consumer, ConsumerRecord, KeyInterest, Producer, ProducerConfig,
+    StartPolicy,
+};
+use crate::control_plane::metadata::RangeId;
+use borsh::{BorshDeserialize, BorshSerialize};
+use dashmap::DashMap;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+pub const SYSTEM_TOPIC_OFFSETS: &str = "__eastguard_offsets";
+pub const SYSTEM_TOPIC_ASSIGNMENTS: &str = "__eastguard_assignments";
+const VIRTUAL_NODES: u32 = 20;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub struct HeartbeatPayload {
+    pub consumer_id: [u8; 16],
+    pub sequence_number: u64, // Repurposed from timestamp to be a deterministic counter
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub struct OffsetCommitPayload {
+    pub range_id: u64,
+    pub offset: u64,
+}
+
+pub struct ConsumerGroup {
+    pub group_id: String,
+    pub consumer_id: Uuid,
+    pub client: Arc<Client>,
+    pub active_peers: Arc<DashMap<Uuid, u64>>,
+    // FIX: Hold the handles so we can kill them on drop!
+    hb_sender_task: tokio::task::JoinHandle<()>,
+    hb_receiver_task: tokio::task::JoinHandle<()>,
+}
+
+impl ConsumerGroup {
+    pub fn new(client: Arc<Client>, group_id: String) -> Result<Self, ClientError> {
+        let consumer_id = Uuid::new_v4();
+        let active_peers = Arc::new(DashMap::new());
+
+        let hb_sender_task = tokio::spawn(group_hb_sender(
+            consumer_id,
+            client.clone(),
+            group_id.clone(),
+        ));
+
+        let hb_receiver_task = tokio::spawn(hb_receiver(
+            client.clone(),
+            active_peers.clone(),
+            group_id.clone(),
+        ));
+
+        Ok(Self {
+            group_id,
+            consumer_id,
+            client,
+            active_peers,
+            hb_sender_task,
+            hb_receiver_task,
+        })
+    }
+
+    pub fn assigned_ranges(&self, available_ranges: &[RangeId]) -> Vec<RangeId> {
+        let mut peers: Vec<Uuid> = Vec::new();
+        peers.push(self.consumer_id); // Always include self
+
+        // Because we don't have a clock in this function, we rely on the manager's background
+        // tick to eventually clear out stale peers if they haven't advanced their sequence number.
+        // For the Hash Ring calculation itself, we just use whoever is currently in the DashMap.
+        for peer in self.active_peers.iter() {
+            if *peer.key() != self.consumer_id {
+                peers.push(*peer.key());
+            }
+        }
+
+        let mut ring: BTreeMap<u32, Uuid> = BTreeMap::new();
+        for peer in peers {
+            for vnode in 0..VIRTUAL_NODES {
+                let key = format!("{}-{}", peer, vnode);
+                let hash =
+                    murmur3::murmur3_32(&mut std::io::Cursor::new(key.as_bytes()), 0).unwrap_or(0);
+                ring.insert(hash, peer);
+            }
+        }
+
+        let mut my_ranges = Vec::new();
+
+        for &range in available_ranges {
+            let range_bytes = range.0.to_le_bytes();
+            let range_hash =
+                murmur3::murmur3_32(&mut std::io::Cursor::new(&range_bytes), 0).unwrap_or(0);
+
+            let assigned_peer = ring
+                .range(range_hash..)
+                .next()
+                .unwrap_or_else(|| ring.iter().next().unwrap())
+                .1;
+
+            if assigned_peer == &self.consumer_id {
+                my_ranges.push(range);
+            }
+        }
+
+        my_ranges
+    }
+
+    pub fn fetch_saved_offset<'a>(
+        &'a self,
+        topic: &'a str,
+        range_id: u64,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<u64>> + Send + 'a>> {
+        Box::pin(async move {
+            let offsets_consumer = Consumer::new(
+                self.client.clone(),
+                SYSTEM_TOPIC_OFFSETS.to_string(),
+                KeyInterest::AllKeys,
+                StartPolicy::Earliest,
+            )
+            .await
+            .ok()?;
+
+            let routing_key = format!("{}:{}", self.group_id, topic);
+            let mut latest_offset = None;
+
+            while let Ok(Ok(Some(record))) =
+                tokio::time::timeout(Duration::from_millis(2000), offsets_consumer.next_record())
+                    .await
+            {
+                if record.key == routing_key.as_bytes()
+                    && let Ok(payload) = OffsetCommitPayload::try_from_slice(&record.value)
+                    && payload.range_id == range_id
+                {
+                    latest_offset = Some(payload.offset);
+                }
+            }
+            latest_offset
+        })
+    }
+}
+
+async fn group_hb_sender(consumer_id: Uuid, hb_client: Arc<Client>, hb_group: String) {
+    let producer = Producer::new(
+        hb_client,
+        SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
+        ProducerConfig::default(),
+    );
+
+    let mut seq = 0;
+    loop {
+        seq += 1;
+        let payload = HeartbeatPayload {
+            consumer_id: *consumer_id.as_bytes(),
+            sequence_number: seq,
+        };
+
+        if let Ok(data) = borsh::to_vec(&payload) {
+            let _ = producer.send(hb_group.as_bytes(), data).await;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn hb_receiver(rx_client: Arc<Client>, rx_peers: Arc<DashMap<Uuid, u64>>, rx_group: String) {
+    let consumer_res = Consumer::new(
+        rx_client,
+        SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
+        KeyInterest::AllKeys,
+        StartPolicy::Latest,
+    )
+    .await;
+
+    if let Ok(consumer) = consumer_res {
+        while let Ok(Some(record)) = consumer.next_record().await {
+            if record.key == rx_group.as_bytes()
+                && let Ok(payload) = HeartbeatPayload::try_from_slice(&record.value)
+                && let Ok(cid) = Uuid::from_slice(&payload.consumer_id)
+            {
+                // Store the highest sequence number seen
+                if let Some(mut current) = rx_peers.get_mut(&cid) {
+                    if payload.sequence_number > *current {
+                        *current = payload.sequence_number;
+                    }
+                } else {
+                    rx_peers.insert(cid, payload.sequence_number);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for ConsumerGroup {
+    fn drop(&mut self) {
+        self.hb_sender_task.abort();
+        self.hb_receiver_task.abort();
+    }
+}

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -1,6 +1,6 @@
 use crate::client::{
-    Client, ClientError, Consumer, ConsumerRecord, KeyInterest, PartitionStrategy, Producer,
-    ProducerConfig, StartPolicy, StoragePolicy,
+    Client, ClientError, Consumer, ConsumerConfig, ConsumerRecord, KeyInterest, PartitionStrategy,
+    Producer, ProducerConfig, StartPolicy, StoragePolicy,
 };
 use crate::control_plane::metadata::RangeId;
 use arc_swap::ArcSwap;
@@ -199,10 +199,15 @@ impl ConsumerGroup {
     }
 
     pub fn rebalance(&self, active_ranges: &[RangeId]) -> (Vec<RangeId>, Vec<RangeId>) {
-        let latest_assignments = self.assigned_ranges(active_ranges);
-        let current_owned = self.owned_ranges.load();
-        let current_set = current_owned.as_ref().as_ref().cloned().unwrap_or_default();
-        let latest_set: HashSet<RangeId> = latest_assignments.into_iter().collect();
+        let current_set = self
+            .owned_ranges
+            .load()
+            .as_ref()
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        let latest_set: HashSet<RangeId> =
+            self.assigned_ranges(active_ranges).into_iter().collect();
         let to_drop: Vec<RangeId> = current_set
             .iter()
             .filter(|r| !latest_set.contains(r))
@@ -253,8 +258,7 @@ async fn heartbeat_receiver(
         client,
         SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
         KeyInterest::AllKeys,
-        StartPolicy::Latest,
-        None,
+        ConsumerConfig::new(StartPolicy::Latest),
     )
     .await;
 

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -1,60 +1,265 @@
 use super::RangeCursorSet;
 use crate::client::ClientError;
+use crate::client::consumer::bootstrap::{KeyInterest, StartPolicy};
 use crate::client::consumer::fetch::run_fetch_actor;
+use crate::client::consumer::group::ConsumerGroup;
 use crate::client::consumer::{ConsumerContext, ConsumerRecord};
 use crate::connections::protocol::RangeTransition;
 use crate::control_plane::metadata::RangeId;
 
-/// Sent when a fetch loop hits the end of a sealed segment and is fully drained.
-/// The fetch loop will terminate immediately after sending this.
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::time::Interval;
+use uuid::Uuid;
+
 pub(crate) struct CursorDrained {
     pub range_id: RangeId,
     pub transition: RangeTransition,
 }
 
-/// The dedicated actor task that owns and mutates the RangeCursorSet without locks.
-pub(crate) async fn run_cursor_manager(
-    mut cursors: RangeCursorSet,
-    rx: flume::Receiver<CursorDrained>,
-    weak_ctx: std::sync::Weak<ConsumerContext>,
-    record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-) {
-    // If the cursor set is empty from the start, disconnect immediately and exit.
-    if cursors.is_empty() {
-        return;
-    }
+struct CursorManagerState {
+    /// Active partition range cursors and their next entry IDs to fetch.
+    cursors: RangeCursorSet,
+    /// Active background fetch actors (running tasks) keyed by their partition RangeId.
+    active_tasks: HashMap<RangeId, JoinHandle<()>>,
+    /// The last observed heartbeat sequence number for each active group peer.
+    last_seen_sequences: HashMap<Uuid, u64>,
+    /// Consecutive rebalance ticks where a peer's heartbeat sequence number has not advanced.
+    /// Peers are declared dead and pruned when this count reaches 3.
+    stale_ticks: HashMap<Uuid, u8>,
+    /// The optional shared consumer group context for dynamic partition rebalancing.
+    consumer_group: Option<Arc<ConsumerGroup>>,
+    /// The policy (Earliest/Latest) used to start consumption on newly assigned ranges.
+    start_policy: StartPolicy,
+}
 
-    // Spawn the initial fetch loops.
-    if let Some(ctx) = weak_ctx.upgrade() {
-        for cursor in cursors.cursors() {
-            let ctx_clone = ctx.clone();
-            tokio::spawn(run_fetch_actor(
-                cursor.range_id,
-                cursor.next_entry_id,
-                ctx_clone,
-                record_tx.clone(),
-            ));
+impl CursorManagerState {
+    fn new(
+        cursors: RangeCursorSet,
+        consumer_group: Option<Arc<ConsumerGroup>>,
+        start_policy: StartPolicy,
+    ) -> Self {
+        if let Some(ref group) = consumer_group {
+            group.owned_ranges.store(Arc::new(Some(HashSet::new())));
+        }
+        Self {
+            cursors,
+            active_tasks: HashMap::new(),
+            last_seen_sequences: HashMap::new(),
+            stale_ticks: HashMap::new(),
+            consumer_group,
+            start_policy,
         }
     }
 
-    while let Ok(event) = rx.recv_async().await {
-        let added = cursors.apply_drained(event.range_id, event.transition);
+    fn should_exit(&self) -> bool {
+        self.cursors.is_empty() && self.consumer_group.is_none()
+    }
 
-        if let Some(ctx) = weak_ctx.upgrade() {
-            for new_cursor in added.iter() {
-                let ctx_clone = ctx.clone();
-                tokio::spawn(run_fetch_actor(
-                    new_cursor.range_id,
-                    new_cursor.next_entry_id,
-                    ctx_clone,
-                    record_tx.clone(),
-                ));
+    fn provision_initial_tasks(
+        &mut self,
+        ctx: &Arc<ConsumerContext>,
+        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
+    ) {
+        // If a consumer_group  is present, partition ownership is dynamic and determined entirely by the
+        // group rebalancer. We return early to prevent the consumer from starting fetch tasks before
+        // partitions are assigned to it.
+        if self.consumer_group.is_some() {
+            return;
+        }
+        for cursor in self.cursors.cursors() {
+            let handle = tokio::spawn(run_fetch_actor(
+                cursor.range_id,
+                cursor.next_entry_id,
+                ctx.clone(),
+                record_tx.clone(),
+            ));
+            self.active_tasks.insert(cursor.range_id, handle);
+        }
+    }
+
+    fn handle_cursor_drained(
+        &mut self,
+        event: CursorDrained,
+        ctx: &Arc<ConsumerContext>,
+        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
+    ) {
+        self.active_tasks.remove(&event.range_id);
+        let added = self.cursors.apply_drained(event.range_id, event.transition);
+
+        for new_cursor in added.iter() {
+            let handle = tokio::spawn(run_fetch_actor(
+                new_cursor.range_id,
+                new_cursor.next_entry_id,
+                ctx.clone(),
+                record_tx.clone(),
+            ));
+            self.active_tasks.insert(new_cursor.range_id, handle);
+        }
+    }
+
+    async fn handle_rebalance(
+        &mut self,
+        ctx: &Arc<ConsumerContext>,
+        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
+    ) {
+        let Some(group) = &self.consumer_group else {
+            return;
+        };
+        let mut dead_peers = Vec::new();
+
+        // 1. cleanup dead peers
+        let peers_copy: Vec<(Uuid, u64)> = group
+            .active_peers
+            .iter()
+            .map(|kv| (*kv.key(), *kv.value()))
+            .collect();
+
+        for (peer_id, current_seq) in peers_copy {
+            let last_seq = self
+                .last_seen_sequences
+                .entry(peer_id)
+                .or_insert(current_seq);
+            let ticks = self.stale_ticks.entry(peer_id).or_insert(0);
+
+            if current_seq == *last_seq {
+                *ticks += 1;
+                if *ticks >= 3 {
+                    dead_peers.push(peer_id);
+                }
+            } else {
+                *last_seq = current_seq;
+                *ticks = 0;
             }
         }
 
-        // If all cursors have been drained and no active cursors remain, disconnect the channel and exit
-        if cursors.is_empty() {
-            break;
+        for dead_id in dead_peers {
+            group.active_peers.remove(&dead_id);
+            self.last_seen_sequences.remove(&dead_id);
+            self.stale_ticks.remove(&dead_id);
+        }
+
+        // 2. Perform rebalance inside ConsumerGroup
+        let active_ranges = ctx.metadata.load().active_ranges();
+        let (to_drop, to_start) = group.rebalance(&active_ranges);
+
+        // 3. Drop revoked tasks
+        for range in to_drop {
+            if let Some(handle) = self.active_tasks.remove(&range) {
+                handle.abort();
+            }
+        }
+
+        if to_start.is_empty() {
+            return;
+        }
+
+        // 4. Start new tasks
+        let saved_offsets = group
+            .client
+            .clone()
+            .fetch_all_saved_offsets(&group.group_id, &ctx.topic)
+            .await
+            .unwrap_or_default();
+
+        for range in to_start {
+            let resolved_entry_id = self
+                .resolve_start_entry_id(range, ctx, saved_offsets.get(&range).copied())
+                .await;
+
+            let handle = tokio::spawn(run_fetch_actor(
+                range,
+                resolved_entry_id,
+                ctx.clone(),
+                record_tx.clone(),
+            ));
+            self.active_tasks.insert(range, handle);
         }
     }
+
+    /// Resolves the starting entry ID for a range cursor when it is dynamically started.
+    ///
+    /// In EastGuard:
+    /// - **Entry ID** refers to the physical index of a record in the range's log.
+    /// - **Offset** refers to the logical consumer-committed checkpoint (which is the last processed entry ID).
+    async fn resolve_start_entry_id(
+        &self,
+        range: RangeId,
+        ctx: &Arc<ConsumerContext>,
+        committed_offset: Option<u64>,
+    ) -> u64 {
+        // 1. Prefer explicitly saved offsets. If a consumer committed offset `N`,
+        // the next record to fetch starts at entry ID `N + 1`.
+        if let Some(offset) = committed_offset {
+            return offset + 1;
+        }
+
+        // 2. Fetch the latest boundary from the replica if the start policy is Latest.
+        // Note: fetch_range_entry_ids returns (start_entry_id, committed_entry_id).
+        if matches!(self.start_policy, StartPolicy::Latest)
+            && let Ok((_, committed_entry_id)) =
+                ctx.client.fetch_range_entry_ids(&ctx.topic, range).await
+        {
+            return committed_entry_id;
+        }
+
+        // 3. Fallback to the local cursor's next entry ID.
+        if let Some(cursor) = self.cursors.cursors().iter().find(|c| c.range_id == range) {
+            return cursor.next_entry_id;
+        }
+
+        // 4. Default start entry ID is 0
+        0
+    }
+
+    fn abort_all(&mut self) {
+        for (_, handle) in self.active_tasks.drain() {
+            handle.abort();
+        }
+    }
+}
+
+pub(crate) async fn run_cursor_manager(
+    cursors: RangeCursorSet,
+    rx: flume::Receiver<CursorDrained>,
+    weak_ctx: std::sync::Weak<ConsumerContext>,
+    record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+    consumer_group: Option<Arc<ConsumerGroup>>,
+    start_policy: StartPolicy,
+) {
+    let mut state = CursorManagerState::new(cursors, consumer_group, start_policy);
+    if state.should_exit() {
+        return;
+    }
+
+    if let Some(ctx) = weak_ctx.upgrade() {
+        state.provision_initial_tasks(&ctx, &record_tx);
+    }
+
+    let mut rebalance_interval = tokio::time::interval(Duration::from_secs(1));
+
+    loop {
+        let Some(ctx) = weak_ctx.upgrade() else {
+            break;
+        };
+
+        tokio::select! {
+            res = rx.recv_async() => {
+                let Ok(event) = res else { break };
+                state.handle_cursor_drained(event, &ctx, &record_tx);
+
+                if state.should_exit() {
+                    break;
+                }
+            }
+
+            _ = rebalance_interval.tick(), if state.consumer_group.is_some() => {
+                state.handle_rebalance(&ctx, &record_tx).await;
+            }
+        }
+    }
+
+    state.abort_all();
 }

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -145,7 +145,12 @@ impl CursorManagerState {
         let active_ranges = ctx.metadata.load().active_ranges();
         let (to_drop, to_start) = group.rebalance(&active_ranges);
 
-        // 3. Drop revoked tasks
+        // 3. Commit offsets for revoked tasks BEFORE dropping them
+        if !to_drop.is_empty() {
+            let _ = group.commit_ranges(&to_drop).await;
+        }
+
+        // 4. Drop revoked tasks
         for range in to_drop {
             if let Some(handle) = self.active_tasks.remove(&range) {
                 handle.abort();
@@ -156,7 +161,7 @@ impl CursorManagerState {
             return;
         }
 
-        // 4. Start new tasks
+        // 5. Start new tasks
         let saved_offsets = group
             .client
             .clone()
@@ -240,6 +245,9 @@ pub(crate) async fn run_cursor_manager(
 
     let mut rebalance_interval = tokio::time::interval(Duration::from_secs(1));
 
+    // Waiting exactly 2 tickets(~2secs) before the first rebalance.
+    let mut startup_grace_ticks = if state.consumer_group.is_some() { 2 } else { 0 };
+
     loop {
         let Some(ctx) = weak_ctx.upgrade() else {
             break;
@@ -256,7 +264,11 @@ pub(crate) async fn run_cursor_manager(
             }
 
             _ = rebalance_interval.tick(), if state.consumer_group.is_some() => {
-                state.handle_rebalance(&ctx, &record_tx).await;
+                if startup_grace_ticks > 0 {
+                    startup_grace_ticks -= 1;
+                } else {
+                    state.handle_rebalance(&ctx, &record_tx).await;
+                }
             }
         }
     }

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -69,14 +69,13 @@ impl CursorManagerState {
         if self.consumer_group.is_some() {
             return;
         }
-        for cursor in self.cursors.cursors() {
-            let handle = tokio::spawn(run_fetch_actor(
+        for cursor in self.cursors.cursors().to_vec() {
+            self.spawn_fetch_actor(
                 cursor.range_id,
                 cursor.next_entry_id,
                 ctx.clone(),
                 record_tx.clone(),
-            ));
-            self.active_tasks.insert(cursor.range_id, handle);
+            );
         }
     }
 
@@ -90,13 +89,12 @@ impl CursorManagerState {
         let added = self.cursors.apply_drained(event.range_id, event.transition);
 
         for new_cursor in added.iter() {
-            let handle = tokio::spawn(run_fetch_actor(
+            self.spawn_fetch_actor(
                 new_cursor.range_id,
                 new_cursor.next_entry_id,
                 ctx.clone(),
                 record_tx.clone(),
-            ));
-            self.active_tasks.insert(new_cursor.range_id, handle);
+            );
         }
     }
 
@@ -110,7 +108,7 @@ impl CursorManagerState {
         };
         let mut dead_peers = Vec::new();
 
-        // 1. cleanup dead peers
+        // Cleanup dead peers
         let peers_copy: Vec<(Uuid, u64)> = group
             .active_peers
             .iter()
@@ -141,16 +139,17 @@ impl CursorManagerState {
             self.stale_ticks.remove(&dead_id);
         }
 
-        // 2. Perform rebalance inside ConsumerGroup
-        let active_ranges = ctx.metadata.load().active_ranges();
-        let (to_drop, to_start) = group.rebalance(&active_ranges);
+        // Perform rebalance inside ConsumerGroup
+        let (to_drop, to_start) = group.rebalance(
+            &ctx.all_ranges(),
+            self.active_tasks.keys().cloned().collect(),
+        );
 
-        // 3. Commit offsets for revoked tasks BEFORE dropping them
+        // Commit offsets for revoked tasks BEFORE dropping them
         if !to_drop.is_empty() {
             let _ = group.commit_ranges(&to_drop).await;
         }
 
-        // 4. Drop revoked tasks
         for range in to_drop {
             if let Some(handle) = self.active_tasks.remove(&range) {
                 handle.abort();
@@ -161,27 +160,41 @@ impl CursorManagerState {
             return;
         }
 
-        // 5. Start new tasks
-        let saved_offsets = group
-            .client
-            .clone()
-            .fetch_all_saved_offsets(&group.group_id, &ctx.topic)
-            .await
-            .unwrap_or_default();
+        // Fetch committed offsets with a 5-second timeout, falling back to empty offsets on timeout/error.
+        let saved_offsets = tokio::time::timeout(
+            Duration::from_secs(5),
+            group
+                .client
+                .clone()
+                .fetch_all_saved_offsets(&group.group_id, &ctx.topic),
+        )
+        .await
+        .map(|res| res.unwrap_or_default())
+        .unwrap_or_default();
 
         for range in to_start {
             let resolved_entry_id = self
                 .resolve_start_entry_id(range, ctx, saved_offsets.get(&range).copied())
                 .await;
 
-            let handle = tokio::spawn(run_fetch_actor(
-                range,
-                resolved_entry_id,
-                ctx.clone(),
-                record_tx.clone(),
-            ));
-            self.active_tasks.insert(range, handle);
+            self.spawn_fetch_actor(range, resolved_entry_id, ctx.clone(), record_tx.clone());
         }
+    }
+
+    fn spawn_fetch_actor(
+        &mut self,
+        range_id: RangeId,
+        entry_id: u64,
+        ctx: Arc<ConsumerContext>,
+        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+    ) {
+        let handle = tokio::spawn(run_fetch_actor(
+            range_id,
+            entry_id,
+            ctx.clone(),
+            record_tx.clone(),
+        ));
+        self.active_tasks.insert(range_id, handle);
     }
 
     /// Resolves the starting entry ID for a range cursor when it is dynamically started.
@@ -266,14 +279,19 @@ pub(crate) async fn run_cursor_manager(
             }
 
             _ = commit_interval.tick(), if state.consumer_group.is_some() => {
-                let group = state.consumer_group.as_ref().unwrap();
-                let _ = group.commit().await;
+                let group = state.consumer_group.as_ref().unwrap().clone();
+                tokio::spawn(async move {
+                    let _ = group.commit().await;
+                });
             }
 
             _ = rebalance_interval.tick(), if state.consumer_group.is_some() => {
                 if startup_grace_ticks > 0 {
                     startup_grace_ticks -= 1;
                 } else {
+                    if state.active_tasks.is_empty() {
+                        let _ = ctx.refresh_metadata().await;
+                    }
                     state.handle_rebalance(&ctx, &record_tx).await;
                 }
             }

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -1,9 +1,9 @@
 use super::RangeCursorSet;
-use crate::client::ClientError;
 use crate::client::consumer::bootstrap::{KeyInterest, StartPolicy};
 use crate::client::consumer::fetch::run_fetch_actor;
 use crate::client::consumer::group::ConsumerGroup;
 use crate::client::consumer::{ConsumerContext, ConsumerRecord};
+use crate::client::{ClientError, ConsumerConfig};
 use crate::connections::protocol::RangeTransition;
 use crate::control_plane::metadata::RangeId;
 
@@ -232,9 +232,9 @@ pub(crate) async fn run_cursor_manager(
     weak_ctx: std::sync::Weak<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
     consumer_group: Option<Arc<ConsumerGroup>>,
-    start_policy: StartPolicy,
+    config: ConsumerConfig,
 ) {
-    let mut state = CursorManagerState::new(cursors, consumer_group, start_policy);
+    let mut state = CursorManagerState::new(cursors, consumer_group, config.start_policy);
     if state.should_exit() {
         return;
     }
@@ -244,6 +244,8 @@ pub(crate) async fn run_cursor_manager(
     }
 
     let mut rebalance_interval = tokio::time::interval(Duration::from_secs(1));
+    let mut commit_interval =
+        tokio::time::interval(Duration::from_millis(config.auto_commit_interval_ms));
 
     // Waiting exactly 2 tickets(~2secs) before the first rebalance.
     let mut startup_grace_ticks = if state.consumer_group.is_some() { 2 } else { 0 };
@@ -261,6 +263,11 @@ pub(crate) async fn run_cursor_manager(
                 if state.should_exit() {
                     break;
                 }
+            }
+
+            _ = commit_interval.tick(), if state.consumer_group.is_some() => {
+                let group = state.consumer_group.as_ref().unwrap();
+                let _ = group.commit().await;
             }
 
             _ = rebalance_interval.tick(), if state.consumer_group.is_some() => {

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -62,10 +62,10 @@ impl Consumer {
             for cursor in cursors.cursors_mut() {
                 let has_saved_offset = consumer_group.is_some() && cursor.next_entry_id > 0;
                 if !has_saved_offset
-                    && let Ok((_, committed_id)) =
-                        client.fetch_range_offsets(&topic, cursor.range_id).await
+                    && let Ok((_, committed_entry_id)) =
+                        client.fetch_range_entry_ids(&topic, cursor.range_id).await
                 {
-                    cursor.next_entry_id = committed_id;
+                    cursor.next_entry_id = committed_entry_id;
                 }
             }
         }

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -26,6 +26,23 @@ pub(crate) use cursor::RangeCursor;
 pub(crate) use cursor_set::RangeCursorSet;
 pub use record::ConsumerRecord;
 
+#[derive(Debug, Clone)]
+pub struct ConsumerConfig {
+    pub start_policy: StartPolicy,
+    pub group_id: Option<String>,
+    pub auto_commit_interval_ms: u64,
+}
+
+impl ConsumerConfig {
+    pub fn new(start_policy: StartPolicy) -> Self {
+        Self {
+            start_policy,
+            group_id: None,
+            auto_commit_interval_ms: 5000, // Default to 1 second for groups
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Consumer {
     ctx: Arc<ConsumerContext>,
@@ -38,17 +55,15 @@ impl Consumer {
         client: Arc<Client>,
         topic: String,
         interest: KeyInterest,
-        start_policy: StartPolicy,
-        group_id: impl Into<Option<String>>,
+        config: ConsumerConfig,
     ) -> Result<Self, ClientError> {
-        let group_id = group_id.into();
         let detail = client.resolve_topic(&topic).await?;
-        let mut cursors = CursorBootstrap::build(&detail, interest, start_policy);
+        let mut cursors = CursorBootstrap::build(&detail, interest, config.start_policy);
 
         let mut consumer_group = None;
 
         // Consolidate all group-specific logic into a single block
-        if let Some(gid) = &group_id {
+        if let Some(gid) = config.group_id.clone() {
             let group = Arc::new(ConsumerGroup::new(
                 client.clone(),
                 gid.to_string(),
@@ -58,7 +73,7 @@ impl Consumer {
             consumer_group = Some(group);
         }
 
-        if matches!(start_policy, StartPolicy::Latest) {
+        if matches!(config.start_policy, StartPolicy::Latest) {
             for cursor in cursors.cursors_mut() {
                 let has_saved_offset = consumer_group.is_some() && cursor.next_entry_id > 0;
                 if !has_saved_offset
@@ -87,7 +102,7 @@ impl Consumer {
             &ctx,
             record_tx,
             consumer_group.clone(),
-            start_policy,
+            config,
         );
 
         Ok(Self {
@@ -103,7 +118,7 @@ impl Consumer {
         ctx: &Arc<ConsumerContext>,
         record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
         consumer_group: Option<Arc<ConsumerGroup>>,
-        start_policy: StartPolicy,
+        config: ConsumerConfig,
     ) {
         tokio::spawn(run_cursor_manager(
             cursors,
@@ -111,7 +126,7 @@ impl Consumer {
             Arc::downgrade(ctx),
             record_tx,
             consumer_group,
-            start_policy,
+            config,
         ));
     }
 

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -131,7 +131,7 @@ impl Consumer {
             let rec = res?;
 
             if let Some(group) = &self.group {
-                if !group.is_range_owned(rec.range_id) {
+                if !group.is_responsible_for(rec.range_id) {
                     continue;
                 }
                 group.record_offset(rec.range_id, rec.offset);

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -49,7 +49,11 @@ impl Consumer {
 
         // Consolidate all group-specific logic into a single block
         if let Some(gid) = &group_id {
-            let group = Arc::new(ConsumerGroup::new(client.clone(), gid.to_string())?);
+            let group = Arc::new(ConsumerGroup::new(
+                client.clone(),
+                gid.to_string(),
+                topic.clone(),
+            )?);
             group.bootstrap().await?;
             consumer_group = Some(group);
         }
@@ -113,7 +117,7 @@ impl Consumer {
 
     pub async fn commit(&self) -> Result<(), ClientError> {
         if let Some(group) = &self.group {
-            group.commit(&self.ctx.topic).await?;
+            group.commit().await?;
         }
         Ok(())
     }

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -1,18 +1,23 @@
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use std::sync::Arc;
+use uuid::Uuid;
 
+use crate::client::consumer::bootstrap::CursorBootstrap;
 use crate::client::consumer::fetch::ConsumerContext;
+use crate::client::consumer::group::{ConsumerGroup, OffsetCommitPayload, SYSTEM_TOPIC_OFFSETS};
 use crate::client::consumer::manager::{CursorDrained, run_cursor_manager};
-use crate::client::{Client, ClientError};
+use crate::client::{Client, ClientError, Producer, ProducerConfig};
 use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientResponse, DataPlaneResponse, FetchByIdRequest,
     RangeOffsetRequest, SegmentDetail, TopicDetail,
 };
-use crate::control_plane::metadata::RangeId;
+use crate::control_plane::metadata::{RangeId, RangeState};
 pub(crate) mod bootstrap;
 pub(crate) mod cursor;
 pub(crate) mod cursor_set;
 mod fetch;
+pub(crate) mod group;
 pub(crate) mod manager;
 pub(crate) mod parked_merges;
 mod record;
@@ -21,60 +26,66 @@ pub(crate) use cursor::RangeCursor;
 pub(crate) use cursor_set::RangeCursorSet;
 pub use record::ConsumerRecord;
 
-/// A thread-safe, internally synchronized consumer client for a single topic.
-/// Cheap to clone and share across tasks.
 #[derive(Clone)]
 pub struct Consumer {
-    //  The  `ctx`  is completely private and not exposed to the user, but it serves a critical role:
-    // it is the ownership anchor(reference count) for the consumer's context.
     ctx: Arc<ConsumerContext>,
     record_rx: flume::Receiver<Result<ConsumerRecord, ClientError>>,
+    group: Option<Arc<ConsumerGroup>>,
 }
 
 impl Consumer {
-    /// Create and bootstrap a new consumer for the specified topic.
     pub async fn new(
         client: Arc<Client>,
         topic: String,
         interest: KeyInterest,
         start_policy: StartPolicy,
+        group_id: impl Into<Option<String>>,
     ) -> Result<Self, ClientError> {
+        let group_id = group_id.into();
         let detail = client.resolve_topic(&topic).await?;
-        let mut cursors = RangeCursorSet::bootstrap(&detail, interest, start_policy);
+        let cursors = CursorBootstrap::build(&detail, interest, start_policy);
+
+        let mut consumer_group = None;
+
+        // Consolidate all group-specific logic into a single block
+        if let Some(gid) = &group_id {
+            let group = Arc::new(ConsumerGroup::new(client.clone(), gid.to_string())?);
+            group.bootstrap().await?;
+            consumer_group = Some(group);
+        }
 
         let (record_tx, record_rx) = flume::unbounded();
         let (cursor_tx, cursor_rx) = flume::bounded(100);
 
         let ctx = Arc::new(ConsumerContext {
-            client: client.clone(),
-            topic: topic.clone(),
+            client,
+            topic,
             topic_id: detail.topic_id,
             metadata: ArcSwap::from_pointee(detail),
             cursor_tx,
         });
 
-        if matches!(start_policy, StartPolicy::Latest) {
-            for cursor in cursors.cursors_mut() {
-                match ctx.fetch_range_offsets(cursor.range_id).await {
-                    Ok((_, committed_id)) => {
-                        cursor.next_entry_id = committed_id;
-                    }
-                    Err(_) => {
-                        // Keep the bootstrap offset if we fail to fetch
-                    }
-                }
-            }
-        }
-
-        // Spawn the asynchronous manager loop for RangeCursorSet
         tokio::spawn(run_cursor_manager(
             cursors,
             cursor_rx,
             Arc::downgrade(&ctx),
             record_tx,
+            consumer_group.clone(),
+            start_policy,
         ));
 
-        Ok(Self { ctx, record_rx })
+        Ok(Self {
+            ctx,
+            record_rx,
+            group: consumer_group,
+        })
+    }
+
+    pub async fn commit(&self) -> Result<(), ClientError> {
+        if let Some(group) = &self.group {
+            group.commit(&self.ctx.topic).await?;
+        }
+        Ok(())
     }
 
     /// Retrieve the next record from the topic.
@@ -82,13 +93,20 @@ impl Consumer {
     /// been fully consumed (i.e. all lineage paths have been drained to their ends and no active
     /// cursors remain).
     pub async fn next_record(&self) -> Result<Option<ConsumerRecord>, ClientError> {
-        match self.record_rx.recv_async().await {
-            Ok(Ok(rec)) => Ok(Some(rec)),
-            Ok(Err(e)) => Err(e),
-            Err(_) => {
-                // All fetch tasks have terminated and the channel is closed
-                Ok(None)
+        loop {
+            let Ok(res) = self.record_rx.recv_async().await else {
+                return Ok(None);
+            };
+
+            let rec = res?;
+
+            if let Some(group) = &self.group {
+                if !group.is_range_owned(rec.range_id) {
+                    continue;
+                }
+                group.record_offset(rec.range_id, rec.offset);
             }
+            return Ok(Some(rec));
         }
     }
 }

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -65,20 +65,38 @@ impl Consumer {
             cursor_tx,
         });
 
-        tokio::spawn(run_cursor_manager(
+        Self::spawn_manager(
             cursors,
             cursor_rx,
-            Arc::downgrade(&ctx),
+            &ctx,
             record_tx,
             consumer_group.clone(),
             start_policy,
-        ));
+        );
 
         Ok(Self {
             ctx,
             record_rx,
             group: consumer_group,
         })
+    }
+
+    fn spawn_manager(
+        cursors: RangeCursorSet,
+        cursor_rx: flume::Receiver<CursorDrained>,
+        ctx: &Arc<ConsumerContext>,
+        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+        consumer_group: Option<Arc<ConsumerGroup>>,
+        start_policy: StartPolicy,
+    ) {
+        tokio::spawn(run_cursor_manager(
+            cursors,
+            cursor_rx,
+            Arc::downgrade(ctx),
+            record_tx,
+            consumer_group,
+            start_policy,
+        ));
     }
 
     pub async fn commit(&self) -> Result<(), ClientError> {

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -43,7 +43,7 @@ impl Consumer {
     ) -> Result<Self, ClientError> {
         let group_id = group_id.into();
         let detail = client.resolve_topic(&topic).await?;
-        let cursors = CursorBootstrap::build(&detail, interest, start_policy);
+        let mut cursors = CursorBootstrap::build(&detail, interest, start_policy);
 
         let mut consumer_group = None;
 
@@ -52,6 +52,18 @@ impl Consumer {
             let group = Arc::new(ConsumerGroup::new(client.clone(), gid.to_string())?);
             group.bootstrap().await?;
             consumer_group = Some(group);
+        }
+
+        if matches!(start_policy, StartPolicy::Latest) {
+            for cursor in cursors.cursors_mut() {
+                let has_saved_offset = consumer_group.is_some() && cursor.next_entry_id > 0;
+                if !has_saved_offset
+                    && let Ok((_, committed_id)) =
+                        client.fetch_range_offsets(&topic, cursor.range_id).await
+                {
+                    cursor.next_entry_id = committed_id;
+                }
+            }
         }
 
         let (record_tx, record_rx) = flume::unbounded();

--- a/src/client/consumer/record.rs
+++ b/src/client/consumer/record.rs
@@ -1,8 +1,10 @@
+use crate::control_plane::metadata::RangeId;
+
 /// A record returned to the consumer application.
 #[derive(Debug, Clone)]
 pub struct ConsumerRecord {
     pub topic: String,
-    pub range_id: u64,
+    pub range_id: RangeId,
     pub offset: u64,
     pub key: Vec<u8>,
     pub value: Vec<u8>,

--- a/src/client/consumer/record.rs
+++ b/src/client/consumer/record.rs
@@ -9,3 +9,9 @@ pub struct ConsumerRecord {
     pub key: Vec<u8>,
     pub value: Vec<u8>,
 }
+
+impl ConsumerRecord {
+    pub fn key_match<'a>(&'a self, key: impl Iterator<Item = &'a u8>) -> bool {
+        self.key.iter().eq(key)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,8 +25,7 @@ use crate::client::nodes::KnownNodes;
 pub use crate::connections::protocol::{TopicDetail, TopicSummary};
 pub use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
 pub use codec::CompressionCodec;
-pub use consumer::{Consumer, ConsumerRecord};
-pub use consumer::{KeyInterest, StartPolicy};
+pub use consumer::{Consumer, ConsumerConfig, ConsumerRecord, KeyInterest, StartPolicy};
 pub use error::ClientError;
 use pool::ConnectionPool;
 pub use producer::{BufferConfig, Producer, ProducerConfig};
@@ -141,8 +140,7 @@ impl Client {
             self,
             SYSTEM_TOPIC_OFFSETS.to_string(),
             KeyInterest::AllKeys,
-            StartPolicy::Earliest,
-            None,
+            ConsumerConfig::new(StartPolicy::Earliest),
         )
         .await?;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -95,7 +95,7 @@ impl Client {
         }
     }
 
-    pub async fn fetch_range_offsets(
+    pub async fn fetch_range_entry_ids(
         &self,
         topic: &str,
         range_id: RangeId,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,9 +31,17 @@ pub use error::ClientError;
 use pool::ConnectionPool;
 pub use producer::{BufferConfig, Producer, ProducerConfig};
 
+use crate::client::consumer::group::OffsetCommitPayload;
+use crate::client::consumer::group::SYSTEM_TOPIC_OFFSETS;
+use crate::connections::protocol::{ClientResponse, DataPlaneResponse, RangeOffsetRequest};
+use crate::control_plane::metadata::RangeId;
+use borsh::BorshDeserialize;
+
 pub use redirect::RetryPolicy;
 use routing::RoutingCache;
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 /// A connection to an EastGuard cluster. Cheap to construct (connections are lazy);
 /// share one across tasks behind an `Arc` — every method takes `&self` and the pool
@@ -85,6 +93,80 @@ impl Client {
                 }
             }
         }
+    }
+
+    pub async fn fetch_range_offsets(
+        &self,
+        topic: &str,
+        range_id: RangeId,
+    ) -> Result<(u64, u64), ClientError> {
+        let detail = self.resolve_topic(topic).await?;
+        let addr = detail
+            .ranges
+            .iter()
+            .find(|r| r.range_id == range_id)
+            .and_then(|r| {
+                r.active_segment
+                    .as_ref()
+                    .or_else(|| r.sealed_segments.last())
+            })
+            .and_then(|seg| seg.pick_replica())
+            .unwrap_or_else(|| self.next_known_node());
+
+        let req = RangeOffsetRequest {
+            topic_name: topic.to_string(),
+            range_id,
+        };
+
+        let served = self.call(addr, req).await?;
+
+        let ClientResponse::DataPlane(DataPlaneResponse::RangeOffset {
+            start_entry_id,
+            committed_entry_id,
+        }) = served.response
+        else {
+            return Err(ClientError::UnexpectedResponse);
+        };
+
+        Ok((start_entry_id, committed_entry_id))
+    }
+
+    pub async fn fetch_all_saved_offsets(
+        self: Arc<Self>,
+        group_id: &str,
+        topic: &str,
+    ) -> Result<HashMap<RangeId, u64>, ClientError> {
+        let mut map = HashMap::new();
+        let offsets_consumer = Consumer::new(
+            self,
+            SYSTEM_TOPIC_OFFSETS.to_string(),
+            KeyInterest::AllKeys,
+            StartPolicy::Earliest,
+            None,
+        )
+        .await?;
+
+        let g_bytes = group_id.as_bytes();
+        let t_bytes = topic.as_bytes();
+        let routing_key = g_bytes.iter().chain(b":".iter()).chain(t_bytes.iter());
+
+        let mut timeout_ms = 2000;
+        while let Ok(Ok(Some(record))) = tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            offsets_consumer.next_record(),
+        )
+        .await
+        {
+            timeout_ms = 100;
+
+            let is_key_match = record.key_match(routing_key.clone());
+
+            if is_key_match && let Ok(payload) = OffsetCommitPayload::try_from_slice(&record.value)
+            {
+                map.insert(payload.range_id, payload.offset);
+            }
+        }
+        Ok(map)
     }
 }
 

--- a/src/client/produce.rs
+++ b/src/client/produce.rs
@@ -19,10 +19,6 @@ impl Client {
         data: Vec<u8>,
         record_count: u32,
     ) -> Result<u64, ClientError> {
-        println!(
-            "[DEBUG CLIENT PRODUCE] starting produce for topic={}, key={:?}",
-            topic, routing_key
-        );
         // Describe once to seed the cache (gives the first hop).
         if self.cache.get(topic).is_none() {
             self.resolve_topic(topic).await?;
@@ -43,10 +39,6 @@ impl Client {
         };
 
         let served = self.call(start, request).await?;
-        println!(
-            "[DEBUG CLIENT PRODUCE] served: redirected={}, response={:?}",
-            served.redirected, served.response
-        );
         // A redirect -> the cached leader was stale; drop it so the next produce re-describes.
         if served.redirected {
             self.cache.invalidate(topic);

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -35,6 +35,16 @@ impl Producer {
         // Generate a globally unique UUID for the producer session ID (idempotency seam)
         let producer_id = Uuid::new_v4();
 
+        Self::new_with_producer_id(client, topic, config, producer_id)
+    }
+    pub fn new_with_producer_id(
+        client: Arc<Client>,
+        topic: String,
+        config: ProducerConfig,
+        producer_id: Uuid,
+    ) -> Self {
+        // Generate a globally unique UUID for the producer session ID (idempotency seam)
+
         Self {
             inner: Arc::new(Inner {
                 client,

--- a/src/client/redirect.rs
+++ b/src/client/redirect.rs
@@ -43,6 +43,7 @@ impl Default for RetryPolicy {
 
 /// The response that served the call. `redirected` ⇒ the starting target was wrong
 /// (a follow/re-resolve happened), so the caller can refresh its cache.
+#[derive(Debug)]
 pub(crate) struct Served {
     pub response: ClientResponse,
     pub redirected: bool,

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -311,7 +311,7 @@ impl ClientController {
             record_count: req.record_count,
             reply: reply_tx,
         };
-        let _ = self.data_plane_tx.send(cmd);
+        let _ = self.data_plane_tx.send_async(cmd).await;
 
         let ack = reply_rx
             .await
@@ -356,7 +356,7 @@ impl ClientController {
             reply: reply_tx,
         };
 
-        if self.data_plane_tx.send(query).is_err() {
+        if self.data_plane_tx.send_async(query).await.is_err() {
             return Ok(DataPlaneResponse::InternalError("data plane closed".into()).into());
         }
         let result = reply_rx
@@ -382,7 +382,7 @@ impl ClientController {
             progress_signal: RangeProgressSignal::Active,
             reply: reply_tx,
         });
-        if self.data_plane_tx.send(query).is_err() {
+        if self.data_plane_tx.send_async(query).await.is_err() {
             return Ok(DataPlaneResponse::InternalError("data plane closed".into()).into());
         }
         let result = reply_rx
@@ -406,7 +406,7 @@ impl ClientController {
         }
         .into();
 
-        let _ = self.data_plane_tx.send(query);
+        let _ = self.data_plane_tx.send_async(query).await;
 
         let list_offset_result = reply_rx.await.context("data plane dropped reply")?;
         let result = DataPlaneResponse::from_list_offset_result(list_offset_result);

--- a/src/connections/protocol/control_plane.rs
+++ b/src/connections/protocol/control_plane.rs
@@ -119,6 +119,14 @@ impl TopicDetail {
             ranges,
         }
     }
+
+    pub(crate) fn active_ranges(&self) -> Vec<RangeId> {
+        self.ranges
+            .iter()
+            .filter(|r| r.state == RangeState::Active)
+            .map(|r| r.range_id)
+            .collect()
+    }
 }
 
 /// Per-range metadata. Lineage fields (`split_into`, `merged_into`, `merged_from`)

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -1857,7 +1857,7 @@ mod tests {
         store.flush();
         create_topic_via_store(&mut store, "t", vec![node("x"), node("y"), node("z")]);
 
-        let seg0 = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
+        let seg0 = SegmentKey::new(TopicId((TEST_GROUP_ID.0) << 32), RangeId(0), SegmentId(0));
 
         // x (the leader) crashed: the death drives reconcile, which finds the
         // leaderless segment and starts a seal-end gather querying both
@@ -1914,7 +1914,7 @@ mod tests {
         store.flush();
         create_topic_via_store(&mut store, "t", vec![node("x"), node("y"), node("z")]);
 
-        let seg0 = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
+        let seg0 = SegmentKey::new(TopicId((TEST_GROUP_ID.0) << 32), RangeId(0), SegmentId(0));
         let before = proposals_after_become_leader(&store).len();
 
         // No reports ever arrive: each death-driven reconcile re-drives the
@@ -1947,7 +1947,7 @@ mod tests {
         store.flush();
         create_topic_via_store(&mut store, "t", vec![node("x"), node("y"), node("z")]);
 
-        let seg0 = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
+        let seg0 = SegmentKey::new(TopicId((TEST_GROUP_ID.0) << 32), RangeId(0), SegmentId(0));
         store.handle_node_death(node("x"));
         assert!(
             store.seal_recovery.contains(&seg0),

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -3872,7 +3872,11 @@ mod tests {
     fn seal_segment_zero_with(raft: &mut Raft, sealed_set: Vec<NodeId>) -> SegmentKey {
         use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
         create_topic_in_raft(raft, "t", sealed_set.clone());
-        let seg0 = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
+        let seg0 = SegmentKey::new(
+            TopicId((raft.shard_group_id.0) << 32),
+            RangeId(0),
+            SegmentId(0),
+        );
         raft.propose(
             MetadataCommand::RollSegment(RollSegment {
                 segment_key: seg0,

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -174,7 +174,7 @@ impl Raft {
             last_applied_index: 0,
             role: Role::Follower,
             current_leader: None,
-            state_machine: MetadataStateMachine::default(),
+            state_machine: MetadataStateMachine::new(shard_group_id),
             pending_proposals: Vec::new(),
             leaderless_segments: Vec::new(),
             peer_states: HashMap::new(),

--- a/src/control_plane/membership/messages/packet.rs
+++ b/src/control_plane/membership/messages/packet.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::control_plane::{NodeId, SwimNode};
+use crate::control_plane::{NodeAddress, NodeId, SwimNode};
 
 use super::dissemination_buffer::ShardLeaderInfo;
 
@@ -11,6 +11,7 @@ use super::dissemination_buffer::ShardLeaderInfo;
 pub struct SwimHeader {
     pub seq: u64,
     pub source_node_id: NodeId,
+    pub source_addr: NodeAddress,
     pub source_incarnation: u64,
     pub gossip: Vec<SwimNode>,
     pub shard_leaders: Vec<ShardLeaderInfo>,

--- a/src/control_plane/membership/swim.rs
+++ b/src/control_plane/membership/swim.rs
@@ -128,6 +128,7 @@ impl Swim {
         SwimHeader {
             seq,
             source_node_id: self.node_id.clone(),
+            source_addr: self.self_addr,
             source_incarnation: self.incarnation,
             gossip,
             shard_leaders,
@@ -423,7 +424,7 @@ impl Swim {
             src,
             header.seq
         );
-        self.handle_incarnation_check(header.source_node_id, src, header.source_incarnation);
+        self.handle_incarnation_check(&header, src);
         let ack = SwimPacket::Ack(self.generate_swim_header(header.seq));
         self.pending_events
             .push(SwimEvent::Packet(OutboundPacket::new(src, ack)));
@@ -437,11 +438,7 @@ impl Swim {
             src,
             header.seq
         );
-        self.handle_incarnation_check(
-            header.source_node_id.clone(),
-            src,
-            header.source_incarnation,
-        );
+        self.handle_incarnation_check(&header, src);
         self.pending_events
             .push(SwimEvent::Timer(TimerCommand::CancelSchedule {
                 seq: header.seq,
@@ -465,6 +462,7 @@ impl Swim {
         let forwarded_ack = SwimPacket::Ack(SwimHeader {
             seq: request_seq,
             source_node_id: header.source_node_id.clone(),
+            source_addr: header.source_addr,
             source_incarnation: header.source_incarnation,
             gossip,
             shard_leaders,
@@ -477,11 +475,7 @@ impl Swim {
     }
 
     fn handle_ping_req(&mut self, src: SocketAddr, header: SwimHeader, target: SocketAddr) {
-        self.handle_incarnation_check(
-            header.source_node_id.clone(),
-            src,
-            header.source_incarnation,
-        );
+        self.handle_incarnation_check(&header, src);
         let seq = self.next_seq();
         self.pending_indirect_pings.insert(
             seq,
@@ -545,25 +539,27 @@ impl Swim {
         member.node_id == self.node_id
     }
 
-    fn handle_incarnation_check(
-        &mut self,
-        source_node_id: NodeId,
-        addr: SocketAddr,
-        remote_inc: u64,
-    ) {
-        if let Some(member) = self.members.get(&source_node_id) {
-            if remote_inc > member.incarnation {
-                let mut node_addr = member.addr;
+    fn handle_incarnation_check(&mut self, header: &SwimHeader, addr: SocketAddr) {
+        if let Some(member) = self.members.get(&header.source_node_id) {
+            if header.source_incarnation > member.incarnation {
+                let mut node_addr = header.source_addr;
                 node_addr.cluster_addr = addr;
-                self.cancel_suspect_timer(&source_node_id);
-                self.update_member(source_node_id, node_addr, SwimNodeState::Alive, remote_inc);
+                self.cancel_suspect_timer(&header.source_node_id);
+                self.update_member(
+                    header.source_node_id.clone(),
+                    node_addr,
+                    SwimNodeState::Alive,
+                    header.source_incarnation,
+                );
             }
         } else {
+            let mut node_addr = header.source_addr;
+            node_addr.cluster_addr = addr;
             self.update_member(
-                source_node_id,
-                NodeAddress::new(addr, addr, addr),
+                header.source_node_id.clone(),
+                node_addr,
                 SwimNodeState::Alive,
-                remote_inc,
+                header.source_incarnation,
             );
         }
     }
@@ -847,6 +843,10 @@ mod tests {
         SwimPacket::Ping(SwimHeader {
             seq,
             source_node_id: NodeId::new(from_id),
+            source_addr: NodeAddress::test(
+                "127.0.0.1:0".parse().unwrap(),
+                "127.0.0.1:0".parse().unwrap(),
+            ),
             source_incarnation: from_inc,
             gossip,
             shard_leaders: vec![],
@@ -869,6 +869,10 @@ mod tests {
         SwimPacket::Ack(SwimHeader {
             seq,
             source_node_id: NodeId::new(from_id),
+            source_addr: NodeAddress::test(
+                "127.0.0.1:0".parse().unwrap(),
+                "127.0.0.1:0".parse().unwrap(),
+            ),
             source_incarnation: from_inc,
             gossip,
             shard_leaders: vec![],
@@ -887,6 +891,10 @@ mod tests {
             header: SwimHeader {
                 seq,
                 source_node_id: NodeId::new(from_id),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: from_inc,
                 gossip,
                 shard_leaders: vec![],
@@ -1651,6 +1659,10 @@ mod tests {
             let header = SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-b"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![],
                 shard_leaders: vec![ShardLeaderInfo {
@@ -1681,6 +1693,10 @@ mod tests {
             let header = SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-b"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![],
                 shard_leaders: vec![ShardLeaderInfo {
@@ -1718,6 +1734,10 @@ mod tests {
             let header1 = SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-b"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![],
                 shard_leaders: vec![ShardLeaderInfo {
@@ -1734,6 +1754,10 @@ mod tests {
             let header2 = SwimHeader {
                 seq: 2,
                 source_node_id: NodeId::new("node-b"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![],
                 shard_leaders: vec![ShardLeaderInfo {
@@ -1830,6 +1854,10 @@ mod tests {
             let header = SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-b"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![],
                 shard_leaders: vec![ShardLeaderInfo {

--- a/src/control_plane/membership/tests.rs
+++ b/src/control_plane/membership/tests.rs
@@ -203,6 +203,10 @@ async fn test_ping_response() {
     let ping = SwimPacket::Ping(SwimHeader {
         seq: 100,
         source_node_id: NodeId::new("node-remote"),
+        source_addr: NodeAddress::test(
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+        ),
         source_incarnation: 0,
         gossip: vec![],
         shard_leaders: vec![],
@@ -248,6 +252,10 @@ async fn test_refutation_mechanism() {
     let ping = SwimPacket::Ping(SwimHeader {
         seq: 200,
         source_node_id: NodeId::new("node-remote"),
+        source_addr: NodeAddress::test(
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+        ),
         source_incarnation: 0,
         gossip: vec![lie],
         shard_leaders: vec![],
@@ -302,6 +310,10 @@ async fn test_gossip_propagation() {
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 300,
                 source_node_id: NodeId::new("node-sender"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 0,
                 gossip: vec![gossip_msg],
                 shard_leaders: vec![],
@@ -323,6 +335,10 @@ async fn test_gossip_propagation() {
                 packet: SwimPacket::Ping(SwimHeader {
                     seq: 400 + i, // Increment seq to keep packets distinct
                     source_node_id: NodeId::new("node-probe"),
+                    source_addr: NodeAddress::test(
+                        "127.0.0.1:0".parse().unwrap(),
+                        "127.0.0.1:0".parse().unwrap(),
+                    ),
                     source_incarnation: 0,
                     gossip: vec![],
                     shard_leaders: vec![],
@@ -397,6 +413,10 @@ async fn test_indirect_ping_trigger() {
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-peer-1"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![
                     make_peer("node-peer-1", peer_1),
@@ -453,6 +473,10 @@ async fn test_alive_gossip_adds_node_to_topology() {
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 1,
                 source_node_id: NodeId::new("node-sender"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![SwimNode {
                     node_id: NodeId::new("node-new"),
@@ -488,6 +512,10 @@ async fn test_dead_gossip_removes_node_from_topology() {
                 packet: SwimPacket::Ping(SwimHeader {
                     seq: 1,
                     source_node_id: NodeId::new("node-sender"),
+                    source_addr: NodeAddress::test(
+                        "127.0.0.1:0".parse().unwrap(),
+                        "127.0.0.1:0".parse().unwrap(),
+                    ),
                     source_incarnation: 1,
                     gossip: vec![SwimNode {
                         node_id: NodeId::new("node-target"),
@@ -516,6 +544,10 @@ async fn test_dead_gossip_removes_node_from_topology() {
             packet: SwimPacket::Ping(SwimHeader {
                 seq: 2,
                 source_node_id: NodeId::new("node-sender"),
+                source_addr: NodeAddress::test(
+                    "127.0.0.1:0".parse().unwrap(),
+                    "127.0.0.1:0".parse().unwrap(),
+                ),
                 source_incarnation: 1,
                 gossip: vec![SwimNode {
                     node_id: NodeId::new("node-target"),

--- a/src/control_plane/metadata/mod.rs
+++ b/src/control_plane/metadata/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use segment::*;
 pub(crate) use state_machine::*;
 
 use crate::smart_pointer;
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ser, Deser)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Ser, Deser)]
 pub struct TopicId(pub(crate) u64);
 
 smart_pointer!(TopicId, u64);

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -10,7 +10,6 @@ use crate::test_traits::TAssertInvariant;
 use MetadataError::*;
 use std::collections::HashMap;
 
-#[derive(Default)]
 pub struct MetadataStateMachine {
     pub(crate) topics: HashMap<TopicId, TopicMeta>,
     topic_name_index: HashMap<String, TopicId>,
@@ -19,6 +18,15 @@ pub struct MetadataStateMachine {
 }
 
 impl MetadataStateMachine {
+    pub(crate) fn new(shard_group_id: crate::control_plane::membership::ShardGroupId) -> Self {
+        MetadataStateMachine {
+            topics: HashMap::new(),
+            topic_name_index: HashMap::new(),
+            next_topic_id: shard_group_id.0 << 32,
+            pending_proposals: Vec::new(),
+        }
+    }
+
     pub(crate) fn get_topic(&self, id: &TopicId) -> Option<&TopicMeta> {
         self.topics.get(id)
     }
@@ -325,8 +333,7 @@ mod tests {
     use super::super::constants::*;
     use super::super::range::*;
     use super::*;
-    use std::collections::VecDeque;
-
+    use crate::control_plane::membership::ShardGroupId;
     use crate::control_plane::{
         NodeId,
         metadata::{
@@ -334,6 +341,7 @@ mod tests {
             strategy::{PartitionStrategy, StoragePolicy},
         },
     };
+    use std::collections::VecDeque;
 
     fn default_policy() -> StoragePolicy {
         StoragePolicy {
@@ -443,7 +451,7 @@ mod tests {
 
     #[test]
     fn delete_segments_marks_oldest_prefix_deleting() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = topic_with_three_sealed(&mut sm);
 
         let result = delete_segments(&mut sm, t, &[0, 1]).unwrap();
@@ -461,7 +469,7 @@ mod tests {
 
     #[test]
     fn delete_segments_skips_the_active_head() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = topic_with_three_sealed(&mut sm);
         // Naming the active head (seg 3) alongside the sealed prefix: only the sealed
         // ones transition; the write head is skipped, never deleted.
@@ -479,14 +487,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "not an oldest-first prefix")]
     fn delete_segments_non_prefix_trips_invariant() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = topic_with_three_sealed(&mut sm);
         let _ = delete_segments(&mut sm, t, &[1]);
     }
 
     #[test]
     fn delete_segments_is_idempotent() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = topic_with_three_sealed(&mut sm);
         assert!(matches!(
             delete_segments(&mut sm, t, &[0]).unwrap(),
@@ -501,7 +509,7 @@ mod tests {
 
     #[test]
     fn expired_prefix_selects_by_age_oldest_first() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = topic_with_three_sealed(&mut sm); // sealed_at 100/200/300, retention 3_600_000
         let topic = sm.get_topic(&t).unwrap();
 
@@ -516,7 +524,7 @@ mod tests {
 
     #[test]
     fn expired_prefix_empty_without_retention() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t = sm
             .apply(MetadataCommand::CreateTopic(CreateTopic {
                 name: "no-retention".into(),
@@ -598,7 +606,7 @@ mod tests {
 
     #[test]
     fn reassign_swaps_a_sealed_segments_replica_set() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let topic_id = create_topic(&mut sm, "blue");
         // Roll so SegmentId(0) becomes Sealed (SegmentId(1) is the new write head).
         roll_segment(&mut sm, topic_id, RangeId(0), SegmentId(0), 2000);
@@ -626,7 +634,7 @@ mod tests {
 
     #[test]
     fn reassign_same_set_is_a_noop() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let topic_id = create_topic(&mut sm, "blue");
         roll_segment(&mut sm, topic_id, RangeId(0), SegmentId(0), 2000);
         let sealed = SegmentKey::new(topic_id, RangeId(0), SegmentId(0));
@@ -650,7 +658,7 @@ mod tests {
 
     #[test]
     fn reassign_rejects_an_active_segment() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let topic_id = create_topic(&mut sm, "blue");
         // SegmentId(0) is the active write head — no roll yet.
         let active = SegmentKey::new(topic_id, RangeId(0), SegmentId(0));
@@ -664,7 +672,7 @@ mod tests {
 
     #[test]
     fn reassign_rejects_an_unknown_segment() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let topic_id = create_topic(&mut sm, "blue");
         let unknown = SegmentKey::new(topic_id, RangeId(0), SegmentId(99));
 
@@ -679,7 +687,7 @@ mod tests {
 
     #[test]
     fn create_topic_basic() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let id = create_topic(&mut sm, "blue");
 
         let topic = sm.get_topic(&id).unwrap();
@@ -696,7 +704,7 @@ mod tests {
 
     #[test]
     fn create_topic_duplicate_name_rejected() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         create_topic(&mut sm, "blue");
 
         let result = sm.apply(MetadataCommand::CreateTopic(CreateTopic {
@@ -710,7 +718,7 @@ mod tests {
 
     #[test]
     fn create_topic_increments_id() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let id1 = create_topic(&mut sm, "alpha");
         let id2 = create_topic(&mut sm, "beta");
 
@@ -721,7 +729,7 @@ mod tests {
 
     #[test]
     fn create_topic_initial_offsets() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let id = create_topic(&mut sm, "blue");
 
         let topic = sm.get_topic(&id).unwrap();
@@ -735,7 +743,7 @@ mod tests {
 
     #[test]
     fn create_topic_name_index() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let id = create_topic(&mut sm, "blue");
 
         let found = sm.get_topic_by_name("blue").unwrap();
@@ -747,7 +755,7 @@ mod tests {
 
     #[test]
     fn roll_segment_creates_next() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
@@ -759,7 +767,7 @@ mod tests {
 
     #[test]
     fn roll_segment_increments_segment_id() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
@@ -773,7 +781,7 @@ mod tests {
 
     #[test]
     fn roll_segment_bad_topic() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
             segment_key: SegmentKey::new(TopicId(99), RangeId(0), SegmentId(0)),
             sealed_at: 2000,
@@ -785,7 +793,7 @@ mod tests {
 
     #[test]
     fn roll_segment_bad_range() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
@@ -799,7 +807,7 @@ mod tests {
 
     #[test]
     fn roll_segment_stale_is_rejected() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
@@ -819,7 +827,7 @@ mod tests {
 
     #[test]
     fn split_range_basic() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
@@ -840,7 +848,7 @@ mod tests {
 
     #[test]
     fn split_range_updates_active_ranges() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
@@ -852,7 +860,7 @@ mod tests {
 
     #[test]
     fn split_range_lineage() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
@@ -863,7 +871,7 @@ mod tests {
 
     #[test]
     fn split_range_fixed_rejected() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let result = sm.apply(MetadataCommand::CreateTopic(CreateTopic {
             name: "ordered".to_string(),
             storage_policy: fixed_policy(),
@@ -888,7 +896,7 @@ mod tests {
 
     #[test]
     fn split_range_invalid_split_point() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let upper_bound = sm.apply(MetadataCommand::SplitRange(SplitRange {
@@ -914,7 +922,7 @@ mod tests {
 
     #[test]
     fn split_range_keyspace_coverage() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
@@ -932,7 +940,7 @@ mod tests {
 
     #[test]
     fn merge_range_basic() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -947,7 +955,7 @@ mod tests {
 
     #[test]
     fn merge_range_active_ranges_updated() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -959,7 +967,7 @@ mod tests {
 
     #[test]
     fn merge_range_lineage() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -973,7 +981,7 @@ mod tests {
 
     #[test]
     fn merge_range_non_adjacent_rejected() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
         let (c1a, _c1b) = split_range(&mut sm, tid, c1, vec![0x40], 3000);
@@ -992,7 +1000,7 @@ mod tests {
 
     #[test]
     fn delete_topic_cascades() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         sm.apply(MetadataCommand::DeleteTopic(DeleteTopic {
@@ -1014,7 +1022,7 @@ mod tests {
 
     #[test]
     fn delete_topic_removes_name_index() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let _tid = create_topic(&mut sm, "blue");
 
         sm.apply(MetadataCommand::DeleteTopic(DeleteTopic {
@@ -1027,7 +1035,7 @@ mod tests {
 
     #[test]
     fn delete_topic_nonexistent() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let result = sm.apply(MetadataCommand::DeleteTopic(DeleteTopic {
             name: "nope".into(),
         }));
@@ -1038,7 +1046,7 @@ mod tests {
 
     #[test]
     fn create_split_seal() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, _c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -1051,7 +1059,7 @@ mod tests {
 
     #[test]
     fn split_merge_roundtrip() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -1066,7 +1074,7 @@ mod tests {
 
     #[test]
     fn multiple_topics_independent() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let t1 = create_topic(&mut sm, "alpha");
         let t2 = create_topic(&mut sm, "beta");
 
@@ -1084,7 +1092,7 @@ mod tests {
 
     #[test]
     fn roll_already_rolled_segment_is_stale() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
@@ -1106,7 +1114,7 @@ mod tests {
 
     #[test]
     fn seal_history_records_timestamps() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 1000);
@@ -1119,7 +1127,7 @@ mod tests {
 
     #[test]
     fn seal_history_prunes_old_entries() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 1000);
@@ -1170,7 +1178,7 @@ mod tests {
 
     #[test]
     fn auto_proposal_on_hot_range() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         for i in 0..SPLIT_SEAL_THRESHOLD {
@@ -1190,7 +1198,7 @@ mod tests {
 
     #[test]
     fn no_auto_proposal_below_threshold() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         for i in 0..(SPLIT_SEAL_THRESHOLD - 1) {
@@ -1209,7 +1217,7 @@ mod tests {
 
     #[test]
     fn no_auto_proposal_for_fixed_strategy() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let result = sm.apply(MetadataCommand::CreateTopic(CreateTopic {
             name: "ordered".to_string(),
             storage_policy: fixed_policy(),
@@ -1237,7 +1245,7 @@ mod tests {
 
     #[test]
     fn evaluate_merges_cold_adjacent() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -1249,7 +1257,7 @@ mod tests {
 
     #[test]
     fn evaluate_merges_one_hot() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, _c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
         sm.take_pending_proposals(); // discard any split proposals
@@ -1263,7 +1271,7 @@ mod tests {
 
     #[test]
     fn split_clears_seal_history() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
@@ -1276,7 +1284,7 @@ mod tests {
 
     #[test]
     fn split_sets_cooldown() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         let (c1, c2) = split_range(&mut sm, tid, RangeId(0), vec![0x80], 2000);
 
@@ -1295,7 +1303,7 @@ mod tests {
 
     #[test]
     fn active_segments_for_node_returns_matching() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let segments = sm.active_segments_for_node(&NodeId::new("node-1"));
@@ -1309,7 +1317,7 @@ mod tests {
 
     #[test]
     fn active_segments_for_node_excludes_non_member() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         create_topic(&mut sm, "blue");
 
         let segments = sm.active_segments_for_node(&NodeId::new("node-99"));
@@ -1318,7 +1326,7 @@ mod tests {
 
     #[test]
     fn active_segments_for_node_excludes_sealed() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
         roll_segment(&mut sm, tid, RangeId(0), SegmentId(0), 2000);
 
@@ -1331,7 +1339,7 @@ mod tests {
 
     #[test]
     fn roll_segment_uses_end_entry_id() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         let result = sm.apply(MetadataCommand::RollSegment(RollSegment {
@@ -1361,7 +1369,7 @@ mod tests {
 
     #[test]
     fn end_offset_correction_updates_placeholder() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         // Death-triggered roll with end_entry_id=0 (placeholder)
@@ -1393,7 +1401,7 @@ mod tests {
 
     #[test]
     fn end_offset_correction_rejected_when_already_set() {
-        let mut sm = MetadataStateMachine::default();
+        let mut sm = MetadataStateMachine::new(ShardGroupId(0));
         let tid = create_topic(&mut sm, "blue");
 
         // Normal roll with actual end_entry_id

--- a/src/data_plane/actor.rs
+++ b/src/data_plane/actor.rs
@@ -164,4 +164,11 @@ impl DataPlaneSender {
     ) -> Result<(), flume::SendError<DataPlaneMessage>> {
         self.0.send(msg.into())
     }
+
+    pub async fn send_async(
+        &self,
+        msg: impl Into<DataPlaneMessage>,
+    ) -> Result<(), flume::SendError<DataPlaneMessage>> {
+        self.0.send_async(msg.into()).await
+    }
 }

--- a/src/data_plane/checkpoint.rs
+++ b/src/data_plane/checkpoint.rs
@@ -97,7 +97,9 @@ impl CheckpointWorker {
         appender.flush_sync_and_release()?;
 
         sparse_index.put_batch(index_entries)?;
-        job.cache.advance_eviction_frontier(checkpoint.new_frontier);
+        // We do NOT advance the eviction frontier here. We defer it to the DataPlane thread
+        // via CheckpointComplete to prevent an invariant race condition where the frontier 
+        // advances before checkpoint_lsn is updated.
 
         println!(
             "[DEBUG CHECKPOINT] process_job completed successfully for {:?}",
@@ -106,6 +108,7 @@ impl CheckpointWorker {
         let completion: DataPlaneCommand = CheckpointComplete {
             segment_key: job.segment_key,
             checkpointed_lsn: checkpoint.last_lsn(),
+            new_frontier: checkpoint.new_frontier,
         }
         .into();
         let _ = data_plane_tx.send(DataPlaneMessage::Command(completion));

--- a/src/data_plane/messages/command.rs
+++ b/src/data_plane/messages/command.rs
@@ -267,6 +267,7 @@ pub enum ProduceAck {
 pub struct CheckpointComplete {
     pub segment_key: SegmentKey,
     pub checkpointed_lsn: u64,
+    pub new_frontier: u64,
 }
 
 /// The cold-read pool's reply for a catch-up *source* read.

--- a/src/data_plane/messages/pending.rs
+++ b/src/data_plane/messages/pending.rs
@@ -54,7 +54,7 @@ impl DataPlaneOutputs {
 
     pub(crate) async fn flush(&mut self) {
         for cmd in self.coordinator_cmds.drain(..) {
-            let _ = self.coordinator_tx.try_send(cmd);
+            let _ = self.coordinator_tx.send(cmd).await;
         }
         for (entry_id, reply) in self.produce_replies.drain(..) {
             let _ = reply.send(ProduceAck::Ok { entry_id });
@@ -62,7 +62,10 @@ impl DataPlaneOutputs {
 
         let checkpoint_tasks = std::mem::take(&mut self.checkpoint_tasks);
         if !checkpoint_tasks.is_empty() {
-            let _ = self.checkpoint_tx.send(checkpoint_tasks.into_boxed_slice());
+            let _ = self
+                .checkpoint_tx
+                .send_async(checkpoint_tasks.into_boxed_slice())
+                .await;
         }
         self.batch_scheduler
             .send_timer_batch(self.batch_timer_cmds.drain(..).collect())

--- a/src/data_plane/mod.rs
+++ b/src/data_plane/mod.rs
@@ -22,7 +22,9 @@ pub(crate) mod timer;
 pub(crate) mod transport;
 pub(crate) mod wal;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, BorshSerialize, BorshDeserialize,
+)]
 pub struct SegmentKey {
     pub topic_id: TopicId,
     pub range_id: RangeId,

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -30,7 +30,7 @@ use crate::data_plane::transport::command::DataTransportSendToCoordinator;
 use crate::schedulers::ticker_message::TimerCommand;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 /// Same rational as the Raft transport's 4MiB cap, Per-`CatchUpChunk` read cap.
 /// A large segment streams as several chunks via the read-complete re-arm loop.
@@ -67,7 +67,7 @@ pub struct DataPlane<W: WalStorage> {
     /// All locally-resident segments + the secondary indexes the consume
     /// read path needs. See `states::segment_store::SegmentStore`.
     segments: SegmentStore,
-    dirty_segments: Vec<SegmentKey>,
+    dirty_segments: BTreeSet<SegmentKey>,
     buffer_byte_count: usize,
     needs_flush: bool,
 
@@ -106,7 +106,7 @@ impl<W: WalStorage> DataPlane<W> {
             config,
             wal,
             segments: SegmentStore::new(),
-            dirty_segments: Vec::new(),
+            dirty_segments: BTreeSet::new(),
             buffer_byte_count: 0,
             needs_flush: false,
             replication: ReplicationState::default(),
@@ -187,7 +187,7 @@ impl<W: WalStorage> DataPlane<W> {
 
         self.buffer_byte_count += cmd.data.len();
         tracker.stage_entry(cmd.segment_key, cmd.data, cmd.record_count);
-        self.dirty_segments.push(cmd.segment_key);
+        self.dirty_segments.insert(cmd.segment_key);
 
         self.out
             .store_batch_produce_timer(TimerCommand::SetSchedule {
@@ -340,7 +340,7 @@ impl<W: WalStorage> DataPlane<W> {
 
     fn handle_checkpoint_complete(&mut self, complete: CheckpointComplete) {
         if let Some(tracker) = self.segments.get_mut(&complete.segment_key) {
-            tracker.advance_checkpoint(complete.checkpointed_lsn);
+            tracker.advance_checkpoint(complete.checkpointed_lsn, complete.new_frontier);
         }
 
         let watermark = self.compute_checkpoint_watermark();
@@ -907,7 +907,7 @@ impl<W: WalStorage> DataPlane<W> {
         };
 
         tracker.stage_entry_from_replica(cmd.segment_key, cmd.data, cmd.record_count, cmd.entry_id);
-        self.dirty_segments.push(cmd.segment_key);
+        self.dirty_segments.insert(cmd.segment_key);
 
         self.needs_flush = true;
     }
@@ -987,7 +987,7 @@ impl<W: WalStorage> DataPlane<W> {
             }
         }
         self.buffer_byte_count += replayed_bytes;
-        self.dirty_segments.push(new_segment_key);
+        self.dirty_segments.insert(new_segment_key);
         self.needs_flush = true;
     }
 
@@ -1775,12 +1775,14 @@ mod tests {
         dp.handle_command(DataPlaneCommand::CheckpointComplete(CheckpointComplete {
             segment_key: key1,
             checkpointed_lsn: 10,
+            new_frontier: 0,
         }));
         assert_eq!(wal_file_count(), initial_count);
 
         dp.handle_command(DataPlaneCommand::CheckpointComplete(CheckpointComplete {
             segment_key: key2,
             checkpointed_lsn: 5,
+            new_frontier: 0,
         }));
     }
 

--- a/src/data_plane/states/segment/cache.rs
+++ b/src/data_plane/states/segment/cache.rs
@@ -90,13 +90,12 @@ impl SegmentRingBuffer {
         self.write_cursor.store(tail + 1, Ordering::Release);
     }
 
-    pub(super) fn advance_read_cursor(&self, new_offset: u64) {
+    pub(in crate::data_plane::states::segment) fn advance_read_cursor(&self, new_offset: u64) {
         self.read_cursor.store(new_offset, Ordering::Release);
         self.notify.notify_waiters();
     }
 
     // Read path (called by consumer tasks)
-
     pub(crate) fn load_read_cursor(&self) -> u64 {
         self.read_cursor.load(Ordering::Acquire)
     }
@@ -139,7 +138,6 @@ impl SegmentRingBuffer {
         self.eviction_frontier.load(Ordering::Acquire)
     }
 
-    // Checkpoint path (called by checkpoint worker)
     pub(crate) fn drain_for_checkpoint(&self) -> CheckpointBatch {
         let frontier = self.eviction_frontier.load(Ordering::Acquire);
         let commit = self.read_cursor.load(Ordering::Acquire);
@@ -162,7 +160,10 @@ impl SegmentRingBuffer {
         }
     }
 
-    pub(crate) fn advance_eviction_frontier(&self, new_frontier: u64) {
+    pub(in crate::data_plane::states::segment) fn advance_eviction_frontier(
+        &self,
+        new_frontier: u64,
+    ) {
         self.eviction_frontier
             .store(new_frontier, Ordering::Release);
     }

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -176,8 +176,9 @@ impl SegmentTracker {
         self.committed_entry_id = entry_id;
     }
 
-    pub(crate) fn advance_checkpoint(&mut self, checkpointed_lsn: u64) {
+    pub(crate) fn advance_checkpoint(&mut self, checkpointed_lsn: u64, new_frontier: u64) {
         self.checkpoint_lsn = self.checkpoint_lsn.max(checkpointed_lsn);
+        self.cache.advance_eviction_frontier(new_frontier);
     }
 
     pub(crate) fn checkpoint_lsn(&self) -> u64 {
@@ -435,9 +436,12 @@ pub mod tests {
     #[test]
     fn advance_checkpoint_is_monotonic() {
         let mut t = make_tracker(SegmentRole::Leader);
-        t.advance_checkpoint(10);
-        t.advance_checkpoint(5);
-        t.advance_checkpoint(20);
+        assert_eq!(t.checkpoint_lsn(), 0);
+        t.advance_checkpoint(10, 0);
+        assert_eq!(t.checkpoint_lsn(), 10);
+        t.advance_checkpoint(5, 0); // shouldn't go backward
+        assert_eq!(t.checkpoint_lsn(), 10);
+        t.advance_checkpoint(20, 0);
         assert_eq!(t.checkpoint_lsn(), 20);
     }
 

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -12,7 +12,10 @@ use std::time::Duration;
 use turmoil::Builder;
 
 use super::{NodeSpec, host_cluster};
-use crate::client::{Client, ClientError, PartitionStrategy, RetryPolicy, StoragePolicy};
+use crate::client::{
+    Client, ClientError, Consumer, ConsumerConfig, KeyInterest, PartitionStrategy, RetryPolicy,
+    StartPolicy, StoragePolicy,
+};
 use crate::config::Environment;
 use crate::control_plane::metadata::RangeId;
 
@@ -819,12 +822,11 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
         }
 
         // Consume them with Earliest
-        let consumer = crate::client::Consumer::new(
+        let consumer = Consumer::new(
             client.clone(),
             "basic-consume".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Earliest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Earliest),
         )
         .await
         .expect("create consumer");
@@ -847,12 +849,11 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
 
         // Start a consumer with StartPolicy::Latest. It should skip the sealed segment 0
         // and start at segment 1 (offset 5).
-        let consumer_latest = crate::client::Consumer::new(
+        let consumer_latest = Consumer::new(
             client.clone(),
             "basic-consume".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Latest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Latest),
         )
         .await
         .expect("create latest consumer");
@@ -947,12 +948,11 @@ fn consumer_latest_starts_at_end_of_active_segment() -> turmoil::Result {
 
         // Start a Latest consumer. Because it's Latest, it should skip all 5 existing
         // records in the active segment and wait at offset 5.
-        let consumer_latest = crate::client::Consumer::new(
+        let consumer_latest = Consumer::new(
             client.clone(),
             "basic-consume-latest".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Latest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Latest),
         )
         .await
         .expect("create latest consumer");
@@ -1041,15 +1041,14 @@ fn consumer_key_filtering_multi_range() -> turmoil::Result {
         // Create a consumer with KeyInterest for the right child only ([144, 149))
         // Since midpoint is 127, the right child is [127, 255), which overlaps with [144, 149).
         // The left child is [0, 127), which does not overlap with [144, 149).
-        let consumer = crate::client::Consumer::new(
+        let consumer = Consumer::new(
             client.clone(),
             "key-filter-multi".to_string(),
-            crate::client::KeyInterest::KeySpan {
-                start: vec![0x90], // 144
-                end: vec![0x95],   // 149
+            KeyInterest::KeySpan {
+                start: vec![0x90],
+                end: vec![0x95],
             },
-            crate::client::StartPolicy::Latest,
-            None,
+            ConsumerConfig::new(StartPolicy::Latest),
         )
         .await
         .expect("create consumer");
@@ -1152,12 +1151,11 @@ fn consumer_range_split_consume() -> turmoil::Result {
             .expect("send right");
 
         // 3. Consume all records starting from Earliest
-        let consumer = crate::client::Consumer::new(
+        let consumer = Consumer::new(
             client.clone(),
             "split-consume".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Earliest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Earliest),
         )
         .await
         .expect("create consumer");
@@ -1258,12 +1256,11 @@ fn consumer_retention_recovery() -> turmoil::Result {
             .expect("send");
 
         // 5. Start consumer at Earliest (tries to read offset 0)
-        let consumer = crate::client::Consumer::new(
+        let consumer = Consumer::new(
             client.clone(),
             "retention-recover".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Earliest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Earliest),
         )
         .await
         .expect("create consumer");
@@ -1348,12 +1345,11 @@ fn consumer_prefetch_sealed_segments() -> turmoil::Result {
 
         // Now we have sealed segment 0, sealed segment 1, and active segment 2.
         // Start consumer at Earliest to read them.
-        let consumer = crate::client::Consumer::new(
+        let consumer = Consumer::new(
             client.clone(),
             "prefetch-topic".to_string(),
-            crate::client::KeyInterest::AllKeys,
-            crate::client::StartPolicy::Earliest,
-            None,
+            KeyInterest::AllKeys,
+            ConsumerConfig::new(StartPolicy::Earliest),
         )
         .await
         .expect("create consumer");

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -824,6 +824,7 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
             "basic-consume".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Earliest,
+            None,
         )
         .await
         .expect("create consumer");
@@ -851,6 +852,7 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
             "basic-consume".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Latest,
+            None,
         )
         .await
         .expect("create latest consumer");
@@ -950,6 +952,7 @@ fn consumer_latest_starts_at_end_of_active_segment() -> turmoil::Result {
             "basic-consume-latest".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Latest,
+            None,
         )
         .await
         .expect("create latest consumer");
@@ -1046,6 +1049,7 @@ fn consumer_key_filtering_multi_range() -> turmoil::Result {
                 end: vec![0x95],   // 149
             },
             crate::client::StartPolicy::Latest,
+            None,
         )
         .await
         .expect("create consumer");
@@ -1153,6 +1157,7 @@ fn consumer_range_split_consume() -> turmoil::Result {
             "split-consume".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Earliest,
+            None,
         )
         .await
         .expect("create consumer");
@@ -1258,6 +1263,7 @@ fn consumer_retention_recovery() -> turmoil::Result {
             "retention-recover".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Earliest,
+            None,
         )
         .await
         .expect("create consumer");
@@ -1347,6 +1353,7 @@ fn consumer_prefetch_sealed_segments() -> turmoil::Result {
             "prefetch-topic".to_string(),
             crate::client::KeyInterest::AllKeys,
             crate::client::StartPolicy::Earliest,
+            None,
         )
         .await
         .expect("create consumer");

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -1,5 +1,5 @@
 use super::{NodeSpec, host_cluster};
-use crate::client::{Client, Consumer, KeyInterest, Producer, ProducerConfig, StartPolicy};
+use crate::client::{Client, Consumer, ConsumerConfig, KeyInterest, Producer, ProducerConfig, StartPolicy};
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
 use std::sync::Arc;
 use std::time::Duration;
@@ -85,8 +85,11 @@ fn consumer_group_assignment_and_offsets() {
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
-            StartPolicy::Earliest,
-            Some(group_id.clone()),
+            ConsumerConfig {
+                start_policy: StartPolicy::Earliest,
+                group_id: Some(group_id.clone()),
+                auto_commit_interval_ms: 1000,
+            },
         )
         .await
         .unwrap();
@@ -128,8 +131,11 @@ fn consumer_group_assignment_and_offsets() {
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
-            StartPolicy::Earliest,
-            Some(group_id.clone()),
+            ConsumerConfig {
+                start_policy: StartPolicy::Earliest,
+                group_id: Some(group_id.clone()),
+                auto_commit_interval_ms: 1000,
+            },
         )
         .await
         .unwrap();
@@ -182,7 +188,7 @@ fn consumer_group_scale_out_and_rebalance() {
         let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
         let group_id = "scale-group".to_string();
 
-        let c1 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c1 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
 
         for i in 0..10 {
             producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
@@ -202,7 +208,7 @@ fn consumer_group_scale_out_and_rebalance() {
         c1.commit().await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let c2 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c2 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         for i in 10..30 {
@@ -265,8 +271,8 @@ fn consumer_group_failover() {
 
         let group_id = "failover-group".to_string();
 
-        let c1 = Consumer::new(client_c1.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
-        let c2 = Consumer::new(client_c2.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c1 = Consumer::new(client_c1.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
+        let c2 = Consumer::new(client_c2.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
 
         tokio::time::sleep(Duration::from_secs(3)).await;
 
@@ -346,8 +352,8 @@ fn consumer_group_independent_groups() {
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let c_alpha = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-alpha".to_string())).await.unwrap();
-        let c_beta = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-beta".to_string())).await.unwrap();
+        let c_alpha = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some("group-alpha".to_string()), auto_commit_interval_ms: 1000 }).await.unwrap();
+        let c_beta = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some("group-beta".to_string()), auto_commit_interval_ms: 1000 }).await.unwrap();
 
         let mut alpha_count = 0;
         let mut beta_count = 0;

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -81,7 +81,7 @@ fn consumer_group_assignment_and_offsets() {
         let group_id = "test-group".to_string();
 
         // Start a consumer with the group
-        let c1 = Consumer::new_with_group(
+        let c1 = Consumer::new(
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
@@ -94,7 +94,7 @@ fn consumer_group_assignment_and_offsets() {
         let mut c1_records = 0;
         // With 3 partitions and only 1 consumer, c1 should consume everything
         loop {
-            match tokio::time::timeout(Duration::from_secs(1), c1.next_record()).await {
+            match tokio::time::timeout(Duration::from_secs(6), c1.next_record()).await {
                 Ok(Ok(Some(_))) => {
                     c1_records += 1;
                 }
@@ -124,7 +124,7 @@ fn consumer_group_assignment_and_offsets() {
 
         // Start a second consumer in the SAME group
         // It should pick up the committed offsets and only read the new 5 messages
-        let c2 = Consumer::new_with_group(
+        let c2 = Consumer::new(
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
@@ -182,7 +182,7 @@ fn consumer_group_scale_out_and_rebalance() {
         let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
         let group_id = "scale-group".to_string();
 
-        let c1 = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c1 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
 
         for i in 0..10 {
             producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
@@ -202,7 +202,7 @@ fn consumer_group_scale_out_and_rebalance() {
         c1.commit().await.unwrap();
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let c2 = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c2 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         for i in 10..30 {
@@ -265,8 +265,8 @@ fn consumer_group_failover() {
 
         let group_id = "failover-group".to_string();
 
-        let c1 = Consumer::new_with_group(client_c1.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
-        let c2 = Consumer::new_with_group(client_c2.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c1 = Consumer::new(client_c1.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c2 = Consumer::new(client_c2.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
 
         tokio::time::sleep(Duration::from_secs(3)).await;
 
@@ -346,8 +346,8 @@ fn consumer_group_independent_groups() {
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let c_alpha = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-alpha".to_string())).await.unwrap();
-        let c_beta = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-beta".to_string())).await.unwrap();
+        let c_alpha = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-alpha".to_string())).await.unwrap();
+        let c_beta = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-beta".to_string())).await.unwrap();
 
         let mut alpha_count = 0;
         let mut beta_count = 0;

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -1,0 +1,160 @@
+use super::{NodeSpec, host_cluster};
+use crate::client::{Client, Consumer, KeyInterest, Producer, ProducerConfig, StartPolicy};
+use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
+use std::sync::Arc;
+use std::time::Duration;
+use turmoil::Builder;
+use uuid::Uuid;
+
+static NODES: &[NodeSpec] = &[("n1", 9091, 9191), ("n2", 9092, 9192), ("n3", 9093, 9193)];
+
+#[test]
+fn consumer_group_assignment_and_offsets() {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(10))
+        .simulation_duration(Duration::from_secs(30))
+        .build();
+
+    host_cluster(&mut sim, NODES, |env| {
+        env.node_id_suffix = Some(String::new());
+        env.vnodes_per_node = 16;
+    });
+
+    sim.client("client", async move {
+        let client_addr: std::net::SocketAddr =
+            format!("{}:9091", turmoil::lookup("n1")).parse().unwrap();
+        let client = Arc::new(Client::connect([client_addr]).unwrap());
+
+        // Create a topic with 3 ranges
+        let topic = format!("test_group_{}", Uuid::new_v4());
+        client
+            .create_topic(
+                &topic,
+                StoragePolicy {
+                    retention_ms: None,
+                    replication_factor: 3,
+                    partition_strategy: PartitionStrategy::Fixed,
+                },
+            )
+            .await
+            .unwrap();
+
+        // System topics will be auto-created upon first use, or we can just produce to them directly.
+        // Actually they are created on demand, but let's just create them to be safe if they aren't.
+        let _ = client
+            .create_topic(
+                "__eastguard_assignments",
+                StoragePolicy {
+                    retention_ms: None,
+                    replication_factor: 3,
+                    partition_strategy: PartitionStrategy::AutoSplit,
+                },
+            )
+            .await;
+
+        let _ = client
+            .create_topic(
+                "__eastguard_offsets",
+                StoragePolicy {
+                    retention_ms: None,
+                    replication_factor: 3,
+                    partition_strategy: PartitionStrategy::AutoSplit,
+                },
+            )
+            .await;
+
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+
+        // Publish some messages to different ranges
+        for i in 0..10 {
+            // Keys that hash to different ranges (ideally)
+            let key = format!("key_{}", i);
+            producer
+                .send(key.as_bytes(), b"hello".to_vec())
+                .await
+                .unwrap();
+        }
+
+        // Wait a bit for them to flush
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let group_id = "test-group".to_string();
+
+        // Start a consumer with the group
+        let c1 = Consumer::new_with_group(
+            client.clone(),
+            topic.clone(),
+            KeyInterest::AllKeys,
+            StartPolicy::Earliest,
+            Some(group_id.clone()),
+        )
+        .await
+        .unwrap();
+
+        let mut c1_records = 0;
+        // With 3 partitions and only 1 consumer, c1 should consume everything
+        loop {
+            match tokio::time::timeout(Duration::from_secs(1), c1.next_record()).await {
+                Ok(Ok(Some(_))) => {
+                    c1_records += 1;
+                }
+                Ok(Err(e)) => {
+                    panic!("Consumer error: {:?}", e);
+                }
+                Ok(Ok(None)) => break, // Done
+                Err(_) => break,       // Timeout
+            }
+        }
+
+        assert_eq!(c1_records, 10, "First consumer should read all records");
+
+        // Commit offsets
+        c1.commit().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Produce 5 more messages
+        for i in 10..15 {
+            let key = format!("key_{}", i);
+            producer
+                .send(key.as_bytes(), b"hello_again".to_vec())
+                .await
+                .unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Start a second consumer in the SAME group
+        // It should pick up the committed offsets and only read the new 5 messages
+        let c2 = Consumer::new_with_group(
+            client.clone(),
+            topic.clone(),
+            KeyInterest::AllKeys,
+            StartPolicy::Earliest,
+            Some(group_id.clone()),
+        )
+        .await
+        .unwrap();
+
+        let mut c2_records = 0;
+        while let Ok(Ok(Some(_))) =
+            tokio::time::timeout(Duration::from_secs(1), c2.next_record()).await
+        {
+            c2_records += 1;
+        }
+
+        // Wait, actually c1 is still running in the background. So ranges might be split between c1 and c2!
+        // But c2's cursors are initialized based on the assignments at the time it started.
+        // It should read the newly published records for its assigned ranges, starting from the committed offset!
+        // Since c1 did not consume the new messages yet (we broke out of the loop and c1 isn't fetching because we aren't calling next_record() on it? Wait, c1 is calling next_record() internally? No, the background task fetches and buffers in the flume channel.)
+        // But c2 should definitely not re-read the first 10 messages!
+        // So c1_records (buffered) + c2_records should be 5.
+        // Let's just assert that c2_records <= 5.
+        assert!(
+            c2_records <= 5,
+            "Second consumer should not reread the first 10 messages"
+        );
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -12,7 +12,7 @@ static NODES: &[NodeSpec] = &[("n1", 9091, 9191), ("n2", 9092, 9192), ("n3", 909
 fn consumer_group_assignment_and_offsets() {
     let mut sim = Builder::new()
         .tick_duration(Duration::from_millis(10))
-        .simulation_duration(Duration::from_secs(30))
+        .simulation_duration(Duration::from_secs(40))
         .build();
 
     host_cluster(&mut sim, NODES, |env| {
@@ -156,5 +156,219 @@ fn consumer_group_assignment_and_offsets() {
         Ok(())
     });
 
+    sim.run().unwrap();
+}
+#[test]
+fn consumer_group_scale_out_and_rebalance() {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(10))
+        .simulation_duration(Duration::from_secs(40))
+        .build();
+
+    host_cluster(&mut sim, NODES, |env| {
+        env.node_id_suffix = Some(String::new());
+        env.vnodes_per_node = 16;
+    });
+
+    sim.client("client", async move {
+        let client_addr: std::net::SocketAddr = format!("{}:9091", turmoil::lookup("n1")).parse().unwrap();
+        let client = Arc::new(Client::connect([client_addr]).unwrap());
+
+        let topic = format!("test_scale_out_{}", Uuid::new_v4());
+        client.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::Fixed }).await.unwrap();
+        let _ = client.create_topic("__eastguard_assignments", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+        let _ = client.create_topic("__eastguard_offsets", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let group_id = "scale-group".to_string();
+
+        let c1 = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+
+        for i in 0..10 {
+            producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
+        }
+
+        let mut c1_records = 0;
+        while c1_records < 10 {
+            match tokio::time::timeout(Duration::from_secs(5), c1.next_record()).await {
+                Ok(Ok(Some(_))) => c1_records += 1,
+                Ok(Ok(None)) => panic!("C1 channel closed prematurely!"),
+                Ok(Err(e)) => panic!("C1 error: {:?}", e),
+                Err(_) => panic!("Timeout waiting for C1 to consume record {}/10", c1_records),
+            }
+        }
+        assert_eq!(c1_records, 10, "C1 should process everything while alone");
+        
+        c1.commit().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let c2 = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        for i in 10..30 {
+            producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
+        }
+
+        let mut total_new_records = 0;
+        while total_new_records < 20 {
+            tokio::select! {
+                res = c1.next_record() => {
+                    match res {
+                        Ok(Some(_)) => total_new_records += 1,
+                        Ok(None) => panic!("C1 closed prematurely"),
+                        Err(e) => panic!("C1 error: {:?}", e),
+                    }
+                }
+                res = c2.next_record() => {
+                    match res {
+                        Ok(Some(_)) => total_new_records += 1,
+                        Ok(None) => panic!("C2 closed prematurely"),
+                        Err(e) => panic!("C2 error: {:?}", e),
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    panic!("Timeout waiting for scaled group to process. Handled {}/20", total_new_records);
+                }
+            }
+        }
+
+        assert_eq!(total_new_records, 20, "Total new messages should equal 20 exactly");
+        Ok(())
+    });
+    sim.run().unwrap();
+}
+#[test]
+fn consumer_group_failover() {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(10))
+        .simulation_duration(Duration::from_secs(40))
+        .build();
+
+    host_cluster(&mut sim, NODES, |env| {
+        env.node_id_suffix = Some(String::new());
+        env.vnodes_per_node = 16;
+    });
+
+    sim.client("client", async move {
+        let client_addr: std::net::SocketAddr = format!("{}:9091", turmoil::lookup("n1")).parse().unwrap();
+        
+        // FIX: Independent clients prevent the dropped Consumer from deadlocking the shared network router!
+        let client_admin = Arc::new(Client::connect([client_addr]).unwrap());
+        let client_prod = Arc::new(Client::connect([client_addr]).unwrap());
+        let client_c1 = Arc::new(Client::connect([client_addr]).unwrap());
+        let client_c2 = Arc::new(Client::connect([client_addr]).unwrap());
+
+        let topic = format!("test_failover_{}", Uuid::new_v4());
+        client_admin.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::Fixed }).await.unwrap();
+        let _ = client_admin.create_topic("__eastguard_assignments", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+        let _ = client_admin.create_topic("__eastguard_offsets", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+
+        let group_id = "failover-group".to_string();
+
+        let c1 = Consumer::new_with_group(client_c1.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+        let c2 = Consumer::new_with_group(client_c2.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some(group_id.clone())).await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let producer = Producer::new(client_prod.clone(), topic.clone(), ProducerConfig::default());
+        for i in 0..6 {
+            producer.send(format!("primer_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
+        }
+        
+        let mut primer_records = 0;
+        while primer_records < 6 {
+            tokio::select! {
+                res = c1.next_record() => { if let Ok(Some(_)) = res { primer_records += 1; } }
+                res = c2.next_record() => { if let Ok(Some(_)) = res { primer_records += 1; } }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    panic!("Timeout loading primer records");
+                }
+            }
+        }
+
+        c1.commit().await.unwrap();
+        c2.commit().await.unwrap();
+
+        // Simulate C2 crashing AND its network connection severing!
+        drop(c2);
+        drop(client_c2); 
+
+        // Wait for C2 to expire and C1 to mature the ranges
+        tokio::time::sleep(Duration::from_secs(10)).await; 
+
+        // Produce 15 more messages
+        for i in 0..15 {
+            // Because client_prod is separate, it is completely unblocked by C2's death!
+            producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
+        }
+
+        let mut c1_records = 0;
+        while c1_records < 15 {
+            match tokio::time::timeout(Duration::from_secs(5), c1.next_record()).await {
+                Ok(Ok(Some(_))) => c1_records += 1,
+                Ok(Ok(None)) => panic!("C1 channel closed prematurely!"),
+                Ok(Err(e)) => panic!("C1 error: {:?}", e),
+                Err(_) => panic!("Timeout waiting for C1. Processed {}/15 before hanging", c1_records),
+            }
+        }
+
+        assert_eq!(c1_records, 15, "C1 should have taken over C2's ranges and processed all new messages alone");
+        Ok(())
+    });
+    sim.run().unwrap();
+}
+
+
+#[test]
+fn consumer_group_independent_groups() {
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(10))
+        .simulation_duration(Duration::from_secs(40))
+        .build();
+
+    host_cluster(&mut sim, NODES, |env| {
+        env.node_id_suffix = Some(String::new());
+        env.vnodes_per_node = 16;
+    });
+
+    sim.client("client", async move {
+        let client_addr: std::net::SocketAddr = format!("{}:9091", turmoil::lookup("n1")).parse().unwrap();
+        let client = Arc::new(Client::connect([client_addr]).unwrap());
+
+        let topic = format!("test_independent_{}", Uuid::new_v4());
+        client.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::Fixed }).await.unwrap();
+        let _ = client.create_topic("__eastguard_assignments", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+        let _ = client.create_topic("__eastguard_offsets", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        for i in 0..10 {
+            producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let c_alpha = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-alpha".to_string())).await.unwrap();
+        let c_beta = Consumer::new_with_group(client.clone(), topic.clone(), KeyInterest::AllKeys, StartPolicy::Earliest, Some("group-beta".to_string())).await.unwrap();
+
+        let mut alpha_count = 0;
+        let mut beta_count = 0;
+
+        while alpha_count < 10 || beta_count < 10 {
+            tokio::select! {
+                res = c_alpha.next_record(), if alpha_count < 10 => {
+                    if let Ok(Some(_)) = res { alpha_count += 1; }
+                }
+                res = c_beta.next_record(), if beta_count < 10 => {
+                    if let Ok(Some(_)) = res { beta_count += 1; }
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    panic!("Timeout: Alpha processed {}, Beta processed {}", alpha_count, beta_count);
+                }
+            }
+        }
+
+        assert_eq!(alpha_count, 10, "Group Alpha should read all 10 messages");
+        assert_eq!(beta_count, 10, "Group Beta should read all 10 messages independently");
+        Ok(())
+    });
     sim.run().unwrap();
 }

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -378,3 +378,125 @@ fn consumer_group_independent_groups() {
     });
     sim.run().unwrap();
 }
+#[test]
+fn consumer_group_split_rebalance() {
+    use crate::control_plane::metadata::RangeId;
+    let mut sim = Builder::new()
+        .tick_duration(Duration::from_millis(10))
+        .simulation_duration(Duration::from_secs(60))
+        .build();
+
+    host_cluster(&mut sim, NODES, |env| {
+        env.node_id_suffix = Some(String::new());
+        env.vnodes_per_node = 16;
+        env.segment_size_limit_bytes = 1024; // Force size-based rolls but high enough to spare system topics
+    });
+
+    sim.client("client", async move {
+        let client_addr: std::net::SocketAddr = format!("{}:9091", turmoil::lookup("n1")).parse().unwrap();
+        let client = Arc::new(Client::connect([client_addr]).unwrap());
+
+        let topic = format!("test_split_rebalance_{}", Uuid::new_v4());
+        client.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 1, partition_strategy: PartitionStrategy::AutoSplit }).await.unwrap();
+        let _ = client.create_topic("__eastguard_assignments", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+        let _ = client.create_topic("__eastguard_offsets", StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::AutoSplit }).await;
+
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let group_id = "split-group".to_string();
+
+        let c1 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
+        let c2 = Consumer::new(client.clone(), topic.clone(), KeyInterest::AllKeys, ConsumerConfig { start_policy: StartPolicy::Earliest, group_id: Some(group_id.clone()), auto_commit_interval_ms: 1000 }).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Produce enough to trigger a roll (and eventually split)
+        // 3 segments are needed to trigger a split.
+        for i in 0..3 {
+            producer.send(b"k", vec![0u8; 1200]).await.unwrap();
+            // Wait for segment roll
+            let mut rolled = false;
+            for _ in 0..120 {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                if let Ok(detail) = client.resolve_topic(&topic).await {
+                    let r_opt = detail.ranges.iter().find(|r| r.range_id == RangeId(0));
+                    match r_opt {
+                        Some(r) => {
+                            if r.state == crate::control_plane::metadata::RangeState::Sealed {
+                                rolled = true;
+                                break;
+                            }
+                            if let Some(s) = &r.active_segment
+                                && s.segment_id >= (i + 1) as u64
+                            {
+                                rolled = true;
+                                break;
+                            }
+                        }
+                        None => {
+                            rolled = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if !rolled {
+                panic!("Timeout waiting for segment roll to {}", i + 1);
+            }
+        }
+
+        // Wait for split (ranges == 3)
+        let mut split = false;
+        for _ in 0..120 {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            if let Ok(detail) = client.resolve_topic(&topic).await && detail.ranges.len() == 3 {
+                split = true;
+                break;
+            
+            }
+        }
+        if !split {
+            panic!("Timeout waiting for split to 3 ranges");
+        }
+        
+        let detail = client.resolve_topic(&topic).await.unwrap();
+        assert_eq!(detail.ranges.len(), 3, "Topic must split into 3 ranges");
+
+        // Wait for rebalance (consumers to pick up the new children)
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        // Send messages to children
+        // Left child
+        for i in 0..5 {
+            producer.send(b"a", format!("left-{}", i).into_bytes()).await.unwrap();
+        }
+        // Right child
+        for i in 0..5 {
+            producer.send(b"\x90", format!("right-{}", i).into_bytes()).await.unwrap();
+        }
+
+        let mut c1_records = 0;
+        let mut c2_records = 0;
+        
+        let mut total_records = 0;
+        while total_records < 13 { // 3 parent + 5 left + 5 right
+            tokio::select! {
+                res = c1.next_record() => {
+                    if let Ok(Some(_)) = res { c1_records += 1; total_records += 1; }
+                }
+                res = c2.next_record() => {
+                    if let Ok(Some(_)) = res { c2_records += 1; total_records += 1; }
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    panic!("Timeout: c1={}, c2={}", c1_records, c2_records);
+                }
+            }
+        }
+
+        // Due to consistent hash ring assignment of only 3 ranges, there's a 25% chance
+        // one consumer gets all three ranges. As long as all 13 records are processed,
+        // the split/rebalance mechanics are working.
+        assert_eq!(c1_records + c2_records, 13, "All records must be processed");
+        println!("Test completed. C1: {}, C2: {}", c1_records, c2_records);
+        Ok(())
+    });
+    sim.run().unwrap();
+}

--- a/src/it/e2e/mod.rs
+++ b/src/it/e2e/mod.rs
@@ -1,5 +1,6 @@
 mod client_protocol;
 mod client_sdk;
+mod consumer_group_test;
 mod lifecycle;
 
 use crate::StartUp;


### PR DESCRIPTION
### Key Refactorings & Decoupling

1. Composition & Consumer Group Boundaries:
- Fully encapsulated group-specific state ( offsets ,  owned_ranges , and heartbeat tasks) into  ConsumerGroup .
- Tied  ConsumerGroup  1-to-1 with a topic, simplifying the client  .commit()  API to be argument-free.
  
2. Client Delegation:
- Moved all raw log boundary and offset fetching queries ( fetch_range_entry_ids  and  fetch_all_saved_offsets ) directly onto  Client .
 
3. Stateless, Lock-Free Rebalancer:
- Removed  RebalanceTracker ,  PeerTracker , and  GroupState .
- Rebalanced ranges using a stateless, lock-free diff over the concurrent  ArcSwap<Option<HashSet<RangeId>>>  ( owned_ranges ).
- Placed peer liveness counters ( last_seen_sequences  and  stale_ticks ) in local variables on the manager task's stack.
  
4. Cohesive Manager Loop State & Structuring:
- Grouped all manager state ( cursors ,  active_tasks , liveness maps, group configuration) into  CursorManagerState .
- Modularized the main loop into focused step functions:  provision_initial_tasks ,  handle_cursor_drained , and  handle_rebalance .
  
5. Compiler Auto-Trait Resolution ( Send  /  Sync ):
- Decoupled background task spawning from the constructor  Consumer::new(...)  using a synchronous helper  spawn_manager , allowing constructor and queries to be standard, clean  async fn s.
- Replaced raw task handles with  tokio::task::AbortHandle  (which are natively  Send + Sync ) to satisfy thread safety without locks or  unsafe .
  
6. Terminology Alignment:
- Formally aligned the code with protocol boundaries by separating offsets (logical consumer-committed checkpoints) from entry IDs (physical log indices in the storage engine).