### PR TITLE
optimization : remove bottlenecks in produce/consume flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "crc32fast",
  "dashmap",
  "flume",
+ "futures",
  "libc",
  "lz4_flex",
  "murmur3",
@@ -401,6 +402,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +441,23 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -435,8 +478,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ shlex = "2.0.1"
 serde_yaml = "0.9.34"
 serde = "1"
 serde_json = "1"
+futures = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -125,16 +125,15 @@ impl FetchActor {
                             ClientError::UnexpectedResponse
                         })?;
 
-                    for (i, rec) in records.iter().enumerate() {
+                    for (i, rec) in records.into_iter().enumerate() {
                         let consumer_rec = ConsumerRecord {
                             topic: self.ctx.topic.clone(),
                             range_id: self.range_id,
                             offset: entry.entry_id + i as u64,
-                            key: rec.key.clone(),
-                            value: rec.value.clone(),
+                            key: rec.key,
+                            value: rec.value,
                         };
 
-                        // TODO commit offset management?
                         if self.record_tx.send(Ok(consumer_rec)).is_err() {
                             return Ok(false); // Disconnected
                         }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -20,6 +20,14 @@ pub struct HeartbeatPayload {
     pub consumer_id: [u8; 16],
     pub sequence_number: u64, // Repurposed from timestamp to be a deterministic counter
 }
+impl HeartbeatPayload {
+    fn stop_signal(consumer_id: &[u8; 16]) -> Self {
+        HeartbeatPayload {
+            consumer_id: *consumer_id,
+            sequence_number: 0, // indicates leaving
+        }
+    }
+}
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 pub struct OffsetCommitPayload {
@@ -62,9 +70,7 @@ pub struct ConsumerGroup {
     pub owned_ranges: ArcSwap<HashSet<RangeId>>,
     pub offsets: DashMap<RangeId, OffsetTracker>,
 
-    // Hold the handles so we can kill them on drop
-    hb_sender_handle: tokio::task::AbortHandle,
-    hb_receiver_handle: tokio::task::AbortHandle,
+    _hb_stop_tx: flume::Sender<()>,
 }
 
 impl ConsumerGroup {
@@ -72,24 +78,28 @@ impl ConsumerGroup {
         let consumer_id = Uuid::new_v4();
         let active_peers = Arc::new(DashMap::new());
 
-        let hb_sender_handle = tokio::spawn(group_heartbeat_sender(
+        let (hb_stop_tx, hb_stop_rx) = flume::bounded(0);
+
+        let routing_key = format!("hb:{}", group_id.clone());
+        tokio::spawn(group_heartbeat_sender(
             consumer_id,
             client.clone(),
-            format!("hb:{}", group_id.clone()),
-        ))
-        .abort_handle();
+            routing_key.clone(),
+            hb_stop_rx.clone(),
+        ));
+
         let offset_producer = Producer::new(
             client.clone(),
             SYSTEM_TOPIC_OFFSETS.to_string(),
             ProducerConfig::default(),
         );
 
-        let hb_receiver_handle = tokio::spawn(heartbeat_receiver(
+        tokio::spawn(heartbeat_receiver(
             client.clone(),
             active_peers.clone(),
-            format!("hb:{}", group_id),
-        ))
-        .abort_handle();
+            routing_key,
+            hb_stop_rx,
+        ));
 
         Ok(Self {
             group_id,
@@ -100,8 +110,7 @@ impl ConsumerGroup {
             active_peers,
             owned_ranges: ArcSwap::from_pointee(HashSet::new()),
             offsets: DashMap::new(),
-            hb_sender_handle,
-            hb_receiver_handle,
+            _hb_stop_tx: hb_stop_tx,
         })
     }
 
@@ -281,7 +290,12 @@ impl ConsumerGroup {
     }
 }
 
-async fn group_heartbeat_sender(consumer_id: Uuid, hb_client: Arc<Client>, routing_key: String) {
+async fn group_heartbeat_sender(
+    consumer_id: Uuid,
+    hb_client: Arc<Client>,
+    routing_key: String,
+    stop_rx: flume::Receiver<()>,
+) {
     let producer = Producer::new(
         hb_client,
         SYSTEM_TOPIC_ASSIGNMENTS.to_string(),
@@ -299,7 +313,17 @@ async fn group_heartbeat_sender(consumer_id: Uuid, hb_client: Arc<Client>, routi
         if let Ok(data) = borsh::to_vec(&payload) {
             let _ = producer.send(routing_key.as_bytes(), data).await;
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        tokio::select! {
+            _ = stop_rx.recv_async() => { // Matches any Result (Ok or Err!)
+                // Gracefully publish a leave tombstone signal before exiting
+                if let Ok(data) = borsh::to_vec(&HeartbeatPayload::stop_signal(consumer_id.as_bytes())) {
+                    let _ = producer.send(routing_key.as_bytes(), data).await;
+                }
+                break;
+            }
+            _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+        }
     }
 }
 
@@ -307,6 +331,7 @@ async fn heartbeat_receiver(
     client: Arc<Client>,
     active_peers: Arc<DashMap<Uuid, u64>>,
     heartbeat_key: String,
+    stop_rx: flume::Receiver<()>,
 ) {
     let mut end_key = heartbeat_key.as_bytes().to_vec();
     end_key.push(0u8);
@@ -326,26 +351,35 @@ async fn heartbeat_receiver(
         return;
     };
 
-    while let Ok(Some(record)) = consumer.next_record().await {
-        if record.key_match(heartbeat_key.as_bytes().iter())
-            && let Ok(payload) = HeartbeatPayload::try_from_slice(&record.value)
-            && let Ok(cid) = Uuid::from_slice(&payload.consumer_id)
-        {
-            // Store the highest sequence number seen
-            if let Some(mut current) = active_peers.get_mut(&cid) {
-                if payload.sequence_number > *current {
-                    *current = payload.sequence_number;
+    loop {
+        tokio::select! {
+            _ = stop_rx.recv_async() => {
+                break;
+            }
+            res = consumer.next_record() => {
+
+                let Ok(Some(record)) = res else {
+                    break;
+                };
+                if record.key_match(heartbeat_key.as_bytes().iter())
+                    && let Ok(payload) = HeartbeatPayload::try_from_slice(&record.value)
+                    && let Ok(cid) = Uuid::from_slice(&payload.consumer_id)
+                {
+                    if payload.sequence_number == 0 {
+                        // Peer is leaving gracefully; remove immediately
+                        active_peers.remove(&cid);
+                    } else {
+                        // Store the highest sequence number seen
+                        if let Some(mut current) = active_peers.get_mut(&cid) {
+                            if payload.sequence_number > *current {
+                                *current = payload.sequence_number;
+                            }
+                        } else {
+                            active_peers.insert(cid, payload.sequence_number);
+                        }
+                    }
                 }
-            } else {
-                active_peers.insert(cid, payload.sequence_number);
             }
         }
-    }
-}
-
-impl Drop for ConsumerGroup {
-    fn drop(&mut self) {
-        self.hb_sender_handle.abort();
-        self.hb_receiver_handle.abort();
     }
 }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -116,12 +116,25 @@ impl ConsumerGroup {
             partition_strategy: PartitionStrategy::AutoSplit,
         };
 
-        // Attempt to create system topics. Ignore errors if they already exist.
-        let _ = self
+        if self
             .client
-            .create_topic(SYSTEM_TOPIC_ASSIGNMENTS, policy.clone())
-            .await;
-        let _ = self.client.create_topic(SYSTEM_TOPIC_OFFSETS, policy).await;
+            .resolve_topic(SYSTEM_TOPIC_ASSIGNMENTS)
+            .await
+            .is_err()
+        {
+            let _ = self
+                .client
+                .create_topic(SYSTEM_TOPIC_ASSIGNMENTS, policy.clone())
+                .await;
+        }
+        if self
+            .client
+            .resolve_topic(SYSTEM_TOPIC_OFFSETS)
+            .await
+            .is_err()
+        {
+            let _ = self.client.create_topic(SYSTEM_TOPIC_OFFSETS, policy).await;
+        }
 
         Ok(())
     }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -172,9 +172,12 @@ impl ConsumerGroup {
     }
 
     async fn write_offset_commits(&self, commits: Vec<(RangeId, u64)>) -> Result<(), ClientError> {
-        for (range_id, offset) in commits {
-            let payload = OffsetCommitPayload { range_id, offset };
-            if let Ok(data) = borsh::to_vec(&payload)
+        if commits.is_empty() {
+            return Ok(());
+        }
+
+        let futures = commits.into_iter().map(|(range_id, offset)| async move {
+            if let Ok(data) = borsh::to_vec(&OffsetCommitPayload { range_id, offset })
                 && self
                     .offset_producer
                     .send(self.routing_key().as_bytes(), data)
@@ -184,7 +187,9 @@ impl ConsumerGroup {
             {
                 entry.committed = Some(offset);
             }
-        }
+        });
+
+        futures::future::join_all(futures).await;
         Ok(())
     }
 

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -148,15 +148,19 @@ impl CursorManagerState {
             self.active_tasks.keys().cloned().collect(),
         );
 
-        // Commit offsets for revoked tasks BEFORE dropping them
+        // Abort revoked tasks immediately and commit their offsets in the background
+        // to prevent blocking the main cursor manager loop.
         if !to_drop.is_empty() {
-            let _ = group.revoke_ranges(&to_drop).await;
-        }
+            let group = group.clone();
 
-        for range in to_drop {
-            if let Some(handle) = self.active_tasks.remove(&range) {
-                handle.abort();
+            for range in &to_drop {
+                if let Some(handle) = self.active_tasks.remove(range) {
+                    handle.abort();
+                }
             }
+            tokio::spawn(async move {
+                let _ = group.revoke_ranges(&to_drop).await;
+            });
         }
 
         if to_start.is_empty() {

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -112,6 +112,12 @@ impl CursorManagerState {
             .map(|kv| (*kv.key(), *kv.value()))
             .collect();
 
+        // Garbage collect tracking maps for any peers that left or were removed
+        self.last_seen_sequences
+            .retain(|k, _| group.active_peers.contains_key(k));
+        self.stale_ticks
+            .retain(|k, _| group.active_peers.contains_key(k));
+
         for (peer_id, current_seq) in peers_copy {
             let last_seq = self
                 .last_seen_sequences
@@ -229,9 +235,12 @@ impl CursorManagerState {
         0
     }
 
-    fn abort_all(&mut self) {
+    async fn abort_all(&mut self) {
         for (_, handle) in self.active_tasks.drain() {
             handle.abort();
+        }
+        if let Some(group) = &self.consumer_group {
+            let _ = tokio::time::timeout(Duration::from_secs(1), group.commit()).await;
         }
     }
 }
@@ -262,10 +271,6 @@ pub(crate) async fn run_cursor_manager(
 
     loop {
         if record_tx.is_disconnected() {
-            // Perform a final commit on graceful shutdown.
-            if let Some(group) = &state.consumer_group {
-                let _ = tokio::time::timeout(Duration::from_secs(1), group.commit()).await;
-            }
             break;
         }
 
@@ -279,7 +284,7 @@ pub(crate) async fn run_cursor_manager(
                 state.handle_cursor_drained(event, &ctx, &record_tx);
 
                 if state.should_exit() {
-                    break;
+                     break;
                 }
             }
 
@@ -303,5 +308,5 @@ pub(crate) async fn run_cursor_manager(
         }
     }
 
-    state.abort_all();
+    state.abort_all().await;
 }

--- a/src/client/producer/buffers.rs
+++ b/src/client/producer/buffers.rs
@@ -23,9 +23,6 @@ pub struct RangeBuffer {
 }
 impl RangeBuffer {
     fn push(&mut self, pending: PendingRecord) {
-        if self.records.is_empty() {
-            self.current_batch_seq = self.current_batch_seq.wrapping_add(1);
-        }
         // Estimate serialized size: key_len (4B) + value_len (4B) + content bytes
         let record_bytes = 8 + pending.record.key.len() + pending.record.value.len();
         self.current_bytes += record_bytes;
@@ -39,7 +36,9 @@ impl RangeBuffer {
         self.current_bytes >= config.max_batch_bytes
             || self.records.len() >= config.max_batch_records
     }
+
     fn flush(&mut self) -> Vec<PendingRecord> {
+        self.current_batch_seq = self.current_batch_seq.wrapping_add(1);
         let records_to_flush = std::mem::take(&mut self.records);
         self.current_bytes = 0;
         self.spawned_linger = false;
@@ -106,10 +105,18 @@ impl ProducerBuffers {
         if buf.records.is_empty() {
             return None;
         }
-        let records = std::mem::take(&mut buf.records);
-        buf.current_bytes = 0;
-        buf.spawned_linger = false;
-        buf.first_added_at = None;
-        Some(records)
+        Some(buf.flush())
+    }
+
+    /// Take and clear all buffered records unconditionally across all partitions.
+    /// Increment the batch sequence to invalidate any pending linger tasks.
+    pub fn take_all(&self) -> Vec<(RangeId, Vec<PendingRecord>)> {
+        let mut all_records = Vec::with_capacity(self.inner.len());
+        for mut entry in self.inner.iter_mut() {
+            if !entry.records.is_empty() {
+                all_records.push((*entry.key(), entry.flush()));
+            }
+        }
+        all_records
     }
 }

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -118,6 +118,18 @@ impl Producer {
         }
     }
 
+    /// Flush all currently buffered records across all partitions and wait for their completion.
+    pub async fn flush(&self) {
+        let batches = self.inner.buffers.take_all();
+        if batches.is_empty() {
+            return;
+        }
+        let futures = batches
+            .into_iter()
+            .map(|(_, records)| self.flush_records(records));
+        futures::future::join_all(futures).await;
+    }
+
     /// Serialize, compress, and publish a batch of records.
     async fn flush_records(&self, pending_records: Vec<PendingRecord>) {
         if pending_records.is_empty() {

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -74,6 +74,11 @@ impl ClientController {
                 Ok((request_id, request)) => {
                     let writer_tx = writer_tx.clone();
                     let controller = self.clone();
+                    // Spawn a task per request to process them concurrently. This prevents
+                    // Head-of-Line (HOL) blocking on the multiplexed connection: slow requests
+                    // (e.g. disk reads or consensus proposals) won't block fast hot-cache reads
+                    // from other concurrent client threads. Strict partition-level ordering for
+                    // sequential clients remains intact because they await responses sequentially.
                     tokio::spawn(async move {
                         let response = controller.dispatch(request).await;
                         if writer_tx.send((request_id, response)).await.is_err() {

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -72,10 +72,14 @@ impl ClientController {
             // TODO idempotency based on request id (or separate idempotence key)
             match reader.read_request::<ClientRequest>().await {
                 Ok((request_id, request)) => {
-                    let response = self.dispatch(request).await;
-                    if writer_tx.send((request_id, response)).await.is_err() {
-                        tracing::debug!("client writer closed");
-                    }
+                    let writer_tx = writer_tx.clone();
+                    let controller = self.clone();
+                    tokio::spawn(async move {
+                        let response = controller.dispatch(request).await;
+                        if writer_tx.send((request_id, response)).await.is_err() {
+                            tracing::debug!("client writer closed");
+                        }
+                    });
                 }
                 Err(e) => {
                     tracing::debug!("client connection closed: {e}");

--- a/src/data_plane/states/replication.rs
+++ b/src/data_plane/states/replication.rs
@@ -60,13 +60,6 @@ impl ReplicationState {
             .push(reply);
     }
 
-    pub(crate) fn drain_pending_replies(
-        &mut self,
-        segment_key: &SegmentKey,
-    ) -> Vec<oneshot::Sender<ProduceAck>> {
-        self.pending_replies.remove(segment_key).unwrap_or_default()
-    }
-
     /// Pop the oldest waiting reply for a segment (FIFO). The no-follower commit
     /// path publishes one entry per produce in order, so popping one reply per
     /// published entry pairs each producer with its exact committed `entry_id`.
@@ -114,7 +107,10 @@ impl ReplicationState {
         &mut self,
         pending_repl: &PendingReplicationBatch,
     ) -> Option<u64> {
-        let replies = self.drain_pending_replies(&pending_repl.segment_key);
+        let mut replies = Vec::new();
+        if let Some(reply) = self.pop_pending_reply(&pending_repl.segment_key) {
+            replies.push(reply);
+        }
         let pending_acks = pending_repl.followers.iter().cloned().collect();
         let is_first = self.push_in_flight(
             pending_repl.segment_key,
@@ -278,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn begin_replication_drains_pending_replies() {
+    fn begin_replication_pops_single_reply() {
         let mut state = ReplicationState::default();
         let sk = key(0);
         let (tx1, _) = tokio::sync::oneshot::channel();
@@ -290,7 +286,10 @@ mod tests {
         let repl = pending_repl(sk, vec![node("f1")], 0);
         state.begin_replication(&repl);
 
-        assert!(state.drain_pending_replies(&sk).is_empty());
+        assert_eq!(
+            state.pending_replies.get(&sk).map(|v| v.len()).unwrap_or(0),
+            1
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Addressed 5 bottlenecks and improvement points identified:

- Server-Side Parallel Request Dispatch (_**spawns task per client request**_).
-Concurrent Offset Commits & Async Revocation (uses  join_all  for offset commits, offloads rebalance revocation to a background task).
- Optimized Fetch Actor Key/Value Cloning (iterates by value taking ownership of data).
- Producer Graceful Shutdown / Flush API ( Producer::flush() ).
- Graceful Leave Protocol for Consumer Groups (heartbeat task tombstone sequence  0  exit).