### PR TITLE
opt: add fetch actor command

### DIFF
--- a/src/client/consumer/cursor_set.rs
+++ b/src/client/consumer/cursor_set.rs
@@ -47,9 +47,29 @@ impl RangeCursorSet {
         self.cursors.len()
     }
 
-    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.cursors.is_empty()
+    }
+
+    pub fn add_or_update(&mut self, cursor: RangeCursor) {
+        if let Some(c) = self
+            .cursors
+            .iter_mut()
+            .find(|c| c.range_id == cursor.range_id)
+        {
+            c.next_entry_id = cursor.next_entry_id;
+        } else {
+            self.cursors.push(cursor);
+        }
+        #[cfg(any(test, debug_assertions))]
+        self.assert_invariants();
+    }
+
+    pub fn remove(&mut self, range_id: RangeId) -> Option<RangeCursor> {
+        if let Some(idx) = self.cursors.iter().position(|c| c.range_id == range_id) {
+            return Some(self.cursors.remove(idx));
+        }
+        None
     }
 
     /// Apply a lineage transition after a range has been fully drained.
@@ -59,20 +79,17 @@ impl RangeCursorSet {
         range_id: RangeId,
         transition: RangeTransition,
     ) -> Box<[RangeCursor]> {
-        let idx = self
-            .cursors
-            .iter()
-            .position(|c| c.range_id == range_id)
-            .expect("apply_drained called for range not in cursor set");
+        let Some(drained) = self.remove(range_id) else {
+            return Box::new([]);
+        };
 
-        let drained = self.cursors.remove(idx);
-        let added = self.apply_transition(drained, transition);
-        self.cursors.extend(added.clone());
+        let new_cursors = self.apply_transition(drained, transition);
+        self.cursors.extend(new_cursors.clone());
 
         #[cfg(any(test, debug_assertions))]
         self.assert_invariants();
 
-        added
+        new_cursors
     }
 
     fn apply_transition(

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -23,18 +23,25 @@ enum RangeLookupResult {
         progress_signal: RangeProgressSignal,
     },
 }
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FetchActorCommand {
+    Stop,
+}
+
 /// The asynchronous fetch loop for a single active range cursor.
 pub(crate) async fn run_fetch_actor(
     range_id: RangeId,
     next_entry_id: u64,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+    stop_rx: flume::Receiver<FetchActorCommand>,
 ) {
     let mut actor = FetchActor {
         range_id,
         next_entry_id,
         ctx,
         record_tx,
+        stop_rx,
     };
     actor.run().await;
 }
@@ -44,17 +51,34 @@ struct FetchActor {
     next_entry_id: u64,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+    stop_rx: flume::Receiver<FetchActorCommand>,
 }
 
 impl FetchActor {
     async fn run(&mut self) {
+        let stop_rx = self.stop_rx.clone();
         loop {
-            match self.step().await {
-                Ok(true) => continue, // Keep looping
-                Ok(false) => return,  // Graceful shutdown (e.g., drained)
-                Err(e) => {
-                    let _ = self.record_tx.send(Err(e));
-                    return; // Fatal error shutdown
+            if self.record_tx.is_disconnected() {
+                return;
+            }
+
+            tokio::select! {
+                cmd = stop_rx.recv_async() => {
+                    match cmd {
+                        Ok(FetchActorCommand::Stop) | Err(_) => {
+                            return; // Graceful shutdown
+                        }
+                    }
+                }
+                res = self.step() => {
+                    match res {
+                        Ok(true) => continue, // Keep looping
+                        Ok(false) => return,  // Graceful shutdown (e.g., drained)
+                        Err(e) => {
+                            let _ = self.record_tx.send(Err(e));
+                            return; // Fatal error shutdown
+                        }
+                    }
                 }
             }
         }

--- a/src/client/consumer/fetch.rs
+++ b/src/client/consumer/fetch.rs
@@ -34,16 +34,15 @@ pub(crate) async fn run_fetch_actor(
     next_entry_id: u64,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-    stop_rx: flume::Receiver<FetchActorCommand>,
+    rx: flume::Receiver<FetchActorCommand>,
 ) {
     let mut actor = FetchActor {
         range_id,
         next_entry_id,
         ctx,
         record_tx,
-        stop_rx,
     };
-    actor.run().await;
+    actor.run(rx).await;
 }
 
 struct FetchActor {
@@ -51,19 +50,17 @@ struct FetchActor {
     next_entry_id: u64,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-    stop_rx: flume::Receiver<FetchActorCommand>,
 }
 
 impl FetchActor {
-    async fn run(&mut self) {
-        let stop_rx = self.stop_rx.clone();
+    async fn run(&mut self, rx: flume::Receiver<FetchActorCommand>) {
         loop {
             if self.record_tx.is_disconnected() {
                 return;
             }
 
             tokio::select! {
-                cmd = stop_rx.recv_async() => {
+                cmd = rx.recv_async() => {
                     match cmd {
                         Ok(FetchActorCommand::Stop) | Err(_) => {
                             return; // Graceful shutdown

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -1,16 +1,16 @@
-use super::RangeCursorSet;
-use crate::client::consumer::bootstrap::{KeyInterest, StartPolicy};
+use super::RangeCursor;
+use crate::client::consumer::bootstrap::StartPolicy;
 use crate::client::consumer::fetch::{FetchActorCommand, run_fetch_actor};
 use crate::client::consumer::group::ConsumerGroup;
-use crate::client::consumer::{ConsumerContext, ConsumerRecord};
+use crate::client::consumer::ownership::RangeOwnership;
+use crate::client::consumer::{ConsumerContext, ConsumerRecord, RangeCursorSet};
 use crate::client::{ClientError, ConsumerConfig};
-use crate::connections::protocol::RangeTransition;
+use crate::connections::protocol::{RangeDetail, RangeTransition};
 use crate::control_plane::metadata::RangeId;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::Interval;
 use uuid::Uuid;
 
 pub(crate) struct CursorDrained {
@@ -19,10 +19,8 @@ pub(crate) struct CursorDrained {
 }
 
 struct CursorManagerState {
-    /// Active partition range cursors and their next entry IDs to fetch.
-    cursors: RangeCursorSet,
-    /// Active background fetch actors (running tasks) keyed by their partition RangeId.
-    active_tasks: HashMap<RangeId, flume::Sender<FetchActorCommand>>,
+    /// Unified ownership of per-range cursors and their fetch actor senders.
+    ownership: RangeOwnership,
     /// The last observed heartbeat sequence number for each active group peer.
     last_seen_sequences: HashMap<Uuid, u64>,
     /// Consecutive rebalance ticks where a peer's heartbeat sequence number has not advanced.
@@ -41,8 +39,7 @@ impl CursorManagerState {
         start_policy: StartPolicy,
     ) -> Self {
         Self {
-            cursors,
-            active_tasks: HashMap::new(),
+            ownership: RangeOwnership::new(cursors),
             last_seen_sequences: HashMap::new(),
             stale_ticks: HashMap::new(),
             consumer_group,
@@ -51,7 +48,7 @@ impl CursorManagerState {
     }
 
     fn should_exit(&self) -> bool {
-        self.cursors.is_empty() && self.consumer_group.is_none()
+        self.ownership.is_empty() && self.consumer_group.is_none()
     }
 
     fn provision_initial_tasks(
@@ -59,14 +56,14 @@ impl CursorManagerState {
         ctx: &Arc<ConsumerContext>,
         record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) {
-        // If a consumer_group  is present, partition ownership is dynamic and determined entirely by the
+        // If a consumer_group is present, partition ownership is dynamic and determined entirely by the
         // group rebalancer. We return early to prevent the consumer from starting fetch tasks before
         // partitions are assigned to it.
         if self.consumer_group.is_some() {
             return;
         }
-        for cursor in self.cursors.cursors().to_vec() {
-            self.spawn_fetch_actor(
+        for cursor in self.ownership.cursors().to_vec() {
+            self.spawn_and_register(
                 cursor.range_id,
                 cursor.next_entry_id,
                 ctx.clone(),
@@ -81,11 +78,16 @@ impl CursorManagerState {
         ctx: &Arc<ConsumerContext>,
         record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) {
-        self.active_tasks.remove(&event.range_id);
-        let added = self.cursors.apply_drained(event.range_id, event.transition);
+        let Some(added) = self.ownership.drain(event.range_id, event.transition) else {
+            // This range was already revoked/stopped by a rebalance or shutdown.
+            return;
+        };
 
         for new_cursor in added.iter() {
-            self.spawn_fetch_actor(
+            if self.ownership.owns(&new_cursor.range_id) {
+                continue; // Skip if a fetch actor is already running
+            }
+            self.spawn_and_register(
                 new_cursor.range_id,
                 new_cursor.next_entry_id,
                 ctx.clone(),
@@ -144,7 +146,7 @@ impl CursorManagerState {
         // Perform rebalance inside ConsumerGroup
         let (to_drop, to_start) = group.rebalance(
             &ctx.all_ranges(),
-            self.active_tasks.keys().cloned().collect(),
+            self.ownership.owned_range_ids().cloned().collect(),
         );
 
         // Abort revoked tasks immediately and commit their offsets in the background
@@ -153,9 +155,7 @@ impl CursorManagerState {
             let group = group.clone();
             let ranges_to_commit = to_drop.clone();
             for range in to_drop {
-                if let Some(stop_tx) = self.active_tasks.remove(&range) {
-                    let _ = stop_tx.send(FetchActorCommand::Stop);
-                }
+                self.ownership.revoke(range);
             }
             tokio::spawn(async move {
                 let _ = group.revoke_ranges(&ranges_to_commit).await;
@@ -178,16 +178,38 @@ impl CursorManagerState {
         .map(|res| res.unwrap_or_default())
         .unwrap_or_default();
 
+        let metadata = ctx.metadata.load();
+
         for range in to_start {
             let resolved_entry_id = self
                 .resolve_start_entry_id(range, ctx, saved_offsets.get(&range).copied())
                 .await;
 
-            self.spawn_fetch_actor(range, resolved_entry_id, ctx.clone(), record_tx.clone());
+            if self.ownership.should_skip_start(
+                range,
+                &metadata.ranges,
+                &saved_offsets,
+                resolved_entry_id,
+            ) {
+                continue;
+            }
+
+            if let Some(r_meta) = metadata.ranges.iter().find(|r| r.range_id == range) {
+                self.spawn_and_acquire(
+                    range,
+                    resolved_entry_id,
+                    r_meta,
+                    ctx.clone(),
+                    record_tx.clone(),
+                );
+            }
         }
     }
 
-    fn spawn_fetch_actor(
+    /// Spawn a fetch actor and register its stop channel for a range whose
+    /// cursor already exists in the ownership set (independent consumer init
+    /// or post-drain transition).
+    fn spawn_and_register(
         &mut self,
         range_id: RangeId,
         entry_id: u64,
@@ -195,14 +217,29 @@ impl CursorManagerState {
         record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) {
         let (stop_tx, stop_rx) = flume::bounded(1);
-        tokio::spawn(run_fetch_actor(
+        self.ownership.register(range_id, stop_tx);
+        tokio::spawn(run_fetch_actor(range_id, entry_id, ctx, record_tx, stop_rx));
+    }
+
+    /// Create a cursor from range metadata, acquire ownership, and spawn
+    /// the fetch actor. Used by `handle_rebalance` for newly assigned ranges.
+    fn spawn_and_acquire(
+        &mut self,
+        range_id: RangeId,
+        entry_id: u64,
+        r_meta: &RangeDetail,
+        ctx: Arc<ConsumerContext>,
+        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
+    ) {
+        let cursor = RangeCursor::new(
             range_id,
             entry_id,
-            ctx.clone(),
-            record_tx.clone(),
-            stop_rx,
-        ));
-        self.active_tasks.insert(range_id, stop_tx);
+            r_meta.keyspace_start.clone(),
+            r_meta.keyspace_end.clone(),
+        );
+        let (stop_tx, stop_rx) = flume::bounded(1);
+        self.ownership.acquire(cursor, stop_tx);
+        tokio::spawn(run_fetch_actor(range_id, entry_id, ctx, record_tx, stop_rx));
     }
 
     /// Resolves the starting entry ID for a range cursor when it is dynamically started.
@@ -232,7 +269,12 @@ impl CursorManagerState {
         }
 
         // 3. Fallback to the local cursor's next entry ID.
-        if let Some(cursor) = self.cursors.cursors().iter().find(|c| c.range_id == range) {
+        if let Some(cursor) = self
+            .ownership
+            .cursors()
+            .iter()
+            .find(|c| c.range_id == range)
+        {
             return cursor.next_entry_id;
         }
 
@@ -241,9 +283,7 @@ impl CursorManagerState {
     }
 
     async fn abort_all(&mut self) {
-        for (_, stop_tx) in self.active_tasks.drain() {
-            let _ = stop_tx.send(FetchActorCommand::Stop);
-        }
+        self.ownership.revoke_all();
         if let Some(group) = &self.consumer_group {
             let _ = tokio::time::timeout(Duration::from_secs(1), group.commit()).await;
         }
@@ -304,7 +344,7 @@ pub(crate) async fn run_cursor_manager(
                 if startup_grace_ticks > 0 {
                     startup_grace_ticks -= 1;
                 } else {
-                    if state.active_tasks.is_empty() {
+                    if state.ownership.is_empty() {
                         let _ = ctx.refresh_metadata().await;
                     }
                     state.handle_rebalance(&ctx, &record_tx).await;

--- a/src/client/consumer/manager.rs
+++ b/src/client/consumer/manager.rs
@@ -1,6 +1,6 @@
 use super::RangeCursorSet;
 use crate::client::consumer::bootstrap::{KeyInterest, StartPolicy};
-use crate::client::consumer::fetch::run_fetch_actor;
+use crate::client::consumer::fetch::{FetchActorCommand, run_fetch_actor};
 use crate::client::consumer::group::ConsumerGroup;
 use crate::client::consumer::{ConsumerContext, ConsumerRecord};
 use crate::client::{ClientError, ConsumerConfig};
@@ -10,7 +10,6 @@ use crate::control_plane::metadata::RangeId;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::task::JoinHandle;
 use tokio::time::Interval;
 use uuid::Uuid;
 
@@ -23,7 +22,7 @@ struct CursorManagerState {
     /// Active partition range cursors and their next entry IDs to fetch.
     cursors: RangeCursorSet,
     /// Active background fetch actors (running tasks) keyed by their partition RangeId.
-    active_tasks: HashMap<RangeId, JoinHandle<()>>,
+    active_tasks: HashMap<RangeId, flume::Sender<FetchActorCommand>>,
     /// The last observed heartbeat sequence number for each active group peer.
     last_seen_sequences: HashMap<Uuid, u64>,
     /// Consecutive rebalance ticks where a peer's heartbeat sequence number has not advanced.
@@ -152,14 +151,14 @@ impl CursorManagerState {
         // to prevent blocking the main cursor manager loop.
         if !to_drop.is_empty() {
             let group = group.clone();
-
-            for range in &to_drop {
-                if let Some(handle) = self.active_tasks.remove(range) {
-                    handle.abort();
+            let ranges_to_commit = to_drop.clone();
+            for range in to_drop {
+                if let Some(stop_tx) = self.active_tasks.remove(&range) {
+                    let _ = stop_tx.send(FetchActorCommand::Stop);
                 }
             }
             tokio::spawn(async move {
-                let _ = group.revoke_ranges(&to_drop).await;
+                let _ = group.revoke_ranges(&ranges_to_commit).await;
             });
         }
 
@@ -195,13 +194,15 @@ impl CursorManagerState {
         ctx: Arc<ConsumerContext>,
         record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) {
-        let handle = tokio::spawn(run_fetch_actor(
+        let (stop_tx, stop_rx) = flume::bounded(1);
+        tokio::spawn(run_fetch_actor(
             range_id,
             entry_id,
             ctx.clone(),
             record_tx.clone(),
+            stop_rx,
         ));
-        self.active_tasks.insert(range_id, handle);
+        self.active_tasks.insert(range_id, stop_tx);
     }
 
     /// Resolves the starting entry ID for a range cursor when it is dynamically started.
@@ -240,8 +241,8 @@ impl CursorManagerState {
     }
 
     async fn abort_all(&mut self) {
-        for (_, handle) in self.active_tasks.drain() {
-            handle.abort();
+        for (_, stop_tx) in self.active_tasks.drain() {
+            let _ = stop_tx.send(FetchActorCommand::Stop);
         }
         if let Some(group) = &self.consumer_group {
             let _ = tokio::time::timeout(Duration::from_secs(1), group.commit()).await;

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod cursor_set;
 mod fetch;
 pub(crate) mod group;
 pub(crate) mod manager;
+pub(crate) mod ownership;
 pub(crate) mod parked_merges;
 mod record;
 pub use bootstrap::{KeyInterest, StartPolicy};
@@ -71,6 +72,9 @@ impl Consumer {
             )?);
             group.bootstrap().await?;
             consumer_group = Some(group);
+            // If in a consumer group, initialize with empty cursors;
+            // assignments will be dynamically resolved and started by the rebalancer.
+            cursors = RangeCursorSet::new(Vec::new());
         }
 
         if matches!(config.start_policy, StartPolicy::Latest) {

--- a/src/client/consumer/ownership.rs
+++ b/src/client/consumer/ownership.rs
@@ -1,0 +1,209 @@
+use super::cursor::RangeCursor;
+use super::cursor_set::RangeCursorSet;
+use crate::client::consumer::fetch::FetchActorCommand;
+use crate::connections::protocol::{RangeDetail, RangeTransition};
+use crate::control_plane::metadata::{RangeId, RangeState};
+
+use std::collections::HashMap;
+
+/// Unified ownership of per-range state: the consumer's cursor set and the
+/// matching stop channels for active fetch actors.
+///
+/// Every mutation (acquire / revoke / drain) keeps the two in sync so that
+/// callers cannot accidentally have a cursor without an actor or vice-versa.
+pub(crate) struct RangeOwnership {
+    cursors: RangeCursorSet,
+    senders: HashMap<RangeId, flume::Sender<FetchActorCommand>>,
+}
+
+impl RangeOwnership {
+    /// Construct from a pre-built cursor set (pre-populated for independent
+    /// consumers, empty for group consumers). Stop channels start empty and
+    /// are populated via [`register`] or [`acquire`].
+    pub fn new(cursors: RangeCursorSet) -> Self {
+        Self {
+            cursors,
+            senders: HashMap::new(),
+        }
+    }
+
+    /// Acquire ownership of a new range: add cursor to the set and register
+    /// its stop channel atomically.
+    /// Used when the rebalancer assigns a range to this consumer.
+    pub fn acquire(&mut self, cursor: RangeCursor, stop_tx: flume::Sender<FetchActorCommand>) {
+        self.senders.insert(cursor.range_id, stop_tx);
+        self.cursors.add_or_update(cursor);
+    }
+
+    /// Register a stop channel for a range whose cursor already exists.
+    /// Used during independent consumer initialization (cursors are
+    /// pre-populated at bootstrap) and after [`drain`] (cursors are added
+    /// by `apply_drained`).
+    pub fn register(&mut self, range_id: RangeId, stop_tx: flume::Sender<FetchActorCommand>) {
+        debug_assert!(
+            self.cursors
+                .cursors()
+                .iter()
+                .any(|c| c.range_id == range_id),
+            "register called for range {range_id:?} not in cursor set"
+        );
+        self.senders.insert(range_id, stop_tx);
+    }
+
+    /// Revoke ownership: send Stop, remove cursor and stop channel.
+    pub fn revoke(&mut self, range_id: RangeId) {
+        if let Some(stop_tx) = self.senders.remove(&range_id) {
+            let _ = stop_tx.send(FetchActorCommand::Stop);
+        }
+        self.cursors.remove(range_id);
+    }
+
+    /// Handle a drained range's lineage transition.
+    /// Returns `None` if the range was already revoked (late drain event).
+    /// Returns `Some(new_cursors)` — cursors that were added to the set by
+    /// `apply_drained` and now need fetch actors spawned + [`register`]ed.
+    pub fn drain(
+        &mut self,
+        range_id: RangeId,
+        transition: RangeTransition,
+    ) -> Option<Box<[RangeCursor]>> {
+        // If not owned, it was already revoked — late drain event, safe to ignore.
+        self.senders.remove(&range_id)?;
+        Some(self.cursors.apply_drained(range_id, transition))
+    }
+
+    /// Revoke all owned ranges. Used at shutdown.
+    pub fn revoke_all(&mut self) {
+        for (_, stop_tx) in self.senders.drain() {
+            let _ = stop_tx.send(FetchActorCommand::Stop);
+        }
+    }
+
+    pub fn owns(&self, range_id: &RangeId) -> bool {
+        self.senders.contains_key(range_id)
+    }
+
+    pub fn owned_range_ids(&self) -> impl Iterator<Item = &RangeId> {
+        self.senders.keys()
+    }
+
+    pub fn cursors(&self) -> &[RangeCursor] {
+        self.cursors.cursors()
+    }
+
+    pub fn cursors_mut(&mut self) -> &mut [RangeCursor] {
+        self.cursors.cursors_mut()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cursors.is_empty()
+    }
+
+    /// Returns true if this range should NOT be started. Consolidates:
+    /// - Active descendant check (children already being fetched)
+    /// - Undrained parent check (parent not yet fully consumed)
+    /// - Sealed-and-consumed check (range already fully consumed)
+    pub fn should_skip_start(
+        &self,
+        range_id: RangeId,
+        ranges: &[RangeDetail],
+        saved_offsets: &HashMap<RangeId, u64>,
+        resolved_entry_id: u64,
+    ) -> bool {
+        self.has_active_descendant(range_id, ranges)
+            || self.has_undrained_parent(range_id, ranges, saved_offsets)
+            || ranges
+                .iter()
+                .find(|r| r.range_id == range_id)
+                .is_some_and(|r| {
+                    r.state == RangeState::Sealed && resolved_entry_id > r.end_entry_id()
+                })
+    }
+
+    /// Returns true if any descendant (split child or merge target) of the
+    /// given range is currently owned or has a live cursor.
+    pub fn has_active_descendant(&self, range_id: RangeId, ranges: &[RangeDetail]) -> bool {
+        let Some(r_meta) = ranges.iter().find(|r| r.range_id == range_id) else {
+            return false;
+        };
+
+        if let Some(children) = r_meta.split_into {
+            if self.owns(&children.0) || self.owns(&children.1) {
+                return true;
+            }
+            if self
+                .cursors
+                .cursors()
+                .iter()
+                .any(|c| c.range_id == children.0 || c.range_id == children.1)
+            {
+                return true;
+            }
+            if self.has_active_descendant(children.0, ranges)
+                || self.has_active_descendant(children.1, ranges)
+            {
+                return true;
+            }
+        }
+
+        if let Some(child) = r_meta.merged_into {
+            if self.owns(&child) {
+                return true;
+            }
+            if self.cursors.cursors().iter().any(|c| c.range_id == child) {
+                return true;
+            }
+            if self.has_active_descendant(child, ranges) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns true if any ancestor (split parent or merge source) of the
+    /// given range still needs to be drained before this range can start.
+    pub fn has_undrained_parent(
+        &self,
+        range_id: RangeId,
+        ranges: &[RangeDetail],
+        saved_offsets: &HashMap<RangeId, u64>,
+    ) -> bool {
+        for p in ranges.iter() {
+            let is_parent = p
+                .split_into
+                .is_some_and(|children| children.0 == range_id || children.1 == range_id)
+                || p.merged_into.is_some_and(|child| child == range_id);
+
+            if !is_parent {
+                continue;
+            }
+
+            // Parent still has an active fetch actor — not yet drained.
+            if self.owns(&p.range_id) {
+                return true;
+            }
+
+            // Parent is still active (not sealed) — can't have drained.
+            if p.state == RangeState::Active {
+                return true;
+            }
+
+            // Parent is sealed but consumer hasn't consumed past its end.
+            if p.state == RangeState::Sealed {
+                let parent_resolved = saved_offsets.get(&p.range_id).map(|o| o + 1).unwrap_or(0);
+
+                if parent_resolved <= p.end_entry_id() {
+                    return true;
+                }
+            }
+
+            // Walk further up the lineage tree.
+            if self.has_undrained_parent(p.range_id, ranges, saved_offsets) {
+                return true;
+            }
+        }
+
+        false
+    }
+}


### PR DESCRIPTION
### Changes

The new command-channel implementation is a significant upgrade over raw task aborts for three key reasons:

1. Cooperative/Safe Shutdown: Brute-force  JoinHandle::abort()  terminates a task abruptly at its next yield point. This can cause problems if the task is aborted mid-decompressing, mid-lookups, or during a cursor state transition. By leveraging stop signal in a cooperative multiplex logic, the task exits cleanly at a defined boundary.
  
2. True Actor Pattern Boundary: The fetch loop now behaves as a proper async actor with a structured mailbox. It decouples the cursor manager from the implementation details of the fetch actor task.

3. Clean Extensibility: If we need to add runtime controls (like backpressure or seeking) in the future, we can simply add variants to the  command enum without changing task types or manager fields.

### Fix
The change revealed that latent bug:  rebalance logic blindly restarted sealed parent ranges whose children were already live. Before our change, this silently spawned a duplicate fetch actor. After, the invariant panicked, the turmoil task died, and the consumer's  `next_record()`  busy-looped on a disconnected channel → hang.
