### PR TITLE
refact : global type safety by replacing u64 primitive with `EntryId`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
 [alias]
 t = "nextest run"
 lint = "clippy --all-targets --all-features -- -D warnings"
+
+
+[env]
+CC="/opt/homebrew/opt/llvm/bin/clang"
+CXX="/opt/homebrew/opt/llvm/bin/clang++"
+CXXFLAGS="-nostdinc++ -isystem /opt/homebrew/opt/llvm/include/c++/v1"
+LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib"
+LIBCLANG_PATH="/opt/homebrew/opt/llvm/lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ murmur3 = "0.5"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 thiserror = "2.0.18"
-rocksdb = "0.24.0"
+rocksdb = { version = "0.24.0"}
 dashmap = "6.2.1"
 
 crc32fast = "1.4"

--- a/diagrams/data-plane/d1_storage_engine.md
+++ b/diagrams/data-plane/d1_storage_engine.md
@@ -326,7 +326,7 @@ impl SegmentRingBuffer {
 struct CachedEntry {
     data: EntryPayload,        // opaque blob from producer — broker never parses
     record_count: u32,         // number of records in this entry
-    entry_id: u64,             // broker-assigned, per-segment monotonic
+    entry_id: EntryId,         // broker-assigned, per-segment monotonic
     lsn: u64,                  // WAL LSN for checkpoint tracking
 }
 ```
@@ -357,8 +357,8 @@ struct SegmentTracker {
     segment_file_path: PathBuf,
     role: SegmentRole,                   // Leader | Follower (D2)
     replica_set: Vec<NodeId>,            // [leader, follower, ...] (D2)
-    committed_entry_id: u64,             // last committed entry_id (D2)
-    next_entry_id: u64,                  // next entry_id to assign on publish
+    committed_entry_id: EntryId,         // last committed entry_id (D2)
+    next_entry_id: EntryId,              // next entry_id to assign on publish
     staged_entries: Vec<StagedEntry>,    // accumulated entries awaiting flush
 }
 
@@ -550,14 +550,14 @@ Fixed-size thread pool (e.g., 4 threads). Cold reads are initiated by many indep
 ```rust
 struct ColdReadRequest {
     segment_key: SegmentKey,
-    start_entry_id: u64,
+    start_entry_id: EntryId,
     max_bytes: u64,
     respond_tx: oneshot::Sender<ColdReadResult>,
 }
 
 struct ColdReadResult {
     entries: Vec<EntryPayload>,
-    next_entry_id: u64,
+    next_entry_id: EntryId,
 }
 ```
 

--- a/diagrams/data-plane/d2_segment_replication.md
+++ b/diagrams/data-plane/d2_segment_replication.md
@@ -191,7 +191,7 @@ struct ReplicationState {
 struct PendingBatch {
     replies: Vec<oneshot::Sender<ProduceAck>>,
     pending_acks: HashSet<NodeId>,
-    entry_id: u64,
+    entry_id: EntryId,
 }
 ```
 

--- a/src/client/consumer/cursor.rs
+++ b/src/client/consumer/cursor.rs
@@ -406,7 +406,7 @@ mod tests {
     use super::*;
     use super::*;
     use crate::connections::protocol::{RangeDetail, SegmentDetail, TopicState};
-    use crate::control_plane::metadata::{RangeId, RangeState, SegmentId};
+    use crate::control_plane::metadata::{RangeId, RangeState, SegmentId, TopicId};
 
     fn cursor(range_id: RangeId, next_offset: u64, start: &[u8], end: &[u8]) -> RangeCursor {
         RangeCursor::new(range_id, next_offset, start.to_vec(), end.to_vec())
@@ -456,7 +456,7 @@ mod tests {
 
     fn topic(ranges: Vec<RangeDetail>) -> TopicDetail {
         TopicDetail {
-            topic_id: 0,
+            topic_id: TopicId(0),
             name: "t".into(),
             state: TopicState::Active,
             ranges: ranges.into_boxed_slice(),

--- a/src/client/consumer/cursor.rs
+++ b/src/client/consumer/cursor.rs
@@ -12,6 +12,7 @@
 use crate::client::TopicDetail;
 use crate::connections::protocol::RangeDetail;
 use crate::connections::protocol::RangeTransition;
+use crate::control_plane::metadata::EntryId;
 use crate::control_plane::metadata::{RangeId, RangeState};
 use crate::test_traits::TAssertInvariant;
 use std::collections::HashSet;
@@ -243,7 +244,7 @@ impl RangeCursorSet {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RangeCursor {
     pub range_id: RangeId,
-    pub next_entry_id: u64,
+    pub next_entry_id: EntryId,
     pub keyspace_start: Vec<u8>,
     pub keyspace_end: Vec<u8>,
 }
@@ -251,7 +252,7 @@ pub struct RangeCursor {
 impl RangeCursor {
     pub fn new(
         range_id: RangeId,
-        next_entry_id: u64,
+        next_entry_id: EntryId,
         keyspace_start: Vec<u8>,
         keyspace_end: Vec<u8>,
     ) -> Self {
@@ -269,10 +270,10 @@ impl RangeCursor {
             .filter(|r| r.state == RangeState::Active)
             .filter(|r| interest.matches(r))
             .map(|r| {
-                let start_offset = r.active_segment.as_ref().map_or(0, |s| *s.start_entry_id);
+                let start_entry = r.active_segment.as_ref().map_or(0, |s| *s.start_entry_id);
                 RangeCursor::new(
                     r.range_id,
-                    start_offset,
+                    EntryId(start_entry),
                     r.keyspace_start.clone(),
                     r.keyspace_end.clone(),
                 )
@@ -301,7 +302,7 @@ impl RangeCursor {
             .map(|r| {
                 RangeCursor::new(
                     r.range_id,
-                    r.first_segment_start_offset().map_or(0, |id| *id),
+                    r.first_segment_start_offset().map_or(EntryId(0), |id| id),
                     r.keyspace_start.clone(),
                     r.keyspace_end.clone(),
                 )
@@ -317,13 +318,13 @@ impl RangeCursor {
     ) -> [RangeCursor; 2] {
         let left = RangeCursor::new(
             RangeId(*left_range_id),
-            0,
+            EntryId::default(),
             self.keyspace_start.clone(),
             split_point.clone(),
         );
         let right = RangeCursor::new(
             RangeId(*right_range_id),
-            0,
+            EntryId::default(),
             split_point.clone(),
             self.keyspace_end.clone(),
         );
@@ -336,7 +337,7 @@ impl RangeCursor {
     fn into_merged_cursor(self, merged_id: RangeId) -> Self {
         Self {
             range_id: merged_id,
-            next_entry_id: 0,
+            next_entry_id: EntryId::default(),
             ..self
         }
     }
@@ -408,8 +409,8 @@ mod tests {
     use crate::connections::protocol::{RangeDetail, SegmentDetail, TopicState};
     use crate::control_plane::metadata::{RangeId, RangeState, SegmentId, TopicId};
 
-    fn cursor(range_id: RangeId, next_offset: u64, start: &[u8], end: &[u8]) -> RangeCursor {
-        RangeCursor::new(range_id, next_offset, start.to_vec(), end.to_vec())
+    fn cursor(range_id: RangeId, next_entry_id: EntryId, start: &[u8], end: &[u8]) -> RangeCursor {
+        RangeCursor::new(range_id, next_entry_id, start.to_vec(), end.to_vec())
     }
 
     fn split_transition(l: RangeId, r: RangeId, split_point: &[u8]) -> RangeTransition {
@@ -574,12 +575,12 @@ mod tests {
     /// keyspaces around the split point, both at offset 0.
     #[test]
     fn split_replaces_parent_with_two_children() {
-        let mut set = RangeCursorSet::new(vec![cursor(RangeId(0), 1001, b"a", b"c")]);
+        let mut set = RangeCursorSet::new(vec![cursor(RangeId(0), 1001.into(), b"a", b"c")]);
         let added = set.apply_drained(RangeId(0), split_transition(RangeId(1), RangeId(2), b"b"));
 
         assert_eq!(added.len(), 2);
-        assert_eq!(added[0], cursor(RangeId(1), 0, b"a", b"b"));
-        assert_eq!(added[1], cursor(RangeId(2), 0, b"b", b"c"));
+        assert_eq!(added[0], cursor(RangeId(1), EntryId::default(), b"a", b"b"));
+        assert_eq!(added[1], cursor(RangeId(2), EntryId::default(), b"b", b"c"));
 
         assert_eq!(set.len(), 2);
     }
@@ -591,8 +592,8 @@ mod tests {
     #[test]
     fn merge_first_parent_defers_m_when_sibling_tracked() {
         let mut set = RangeCursorSet::new(vec![
-            cursor(RangeId(1), 0, b"a", b"b"),
-            cursor(RangeId(2), 0, b"b", b"c"),
+            cursor(RangeId(1), EntryId::default(), b"a", b"b"),
+            cursor(RangeId(2), EntryId::default(), b"b", b"c"),
         ]);
         let added = set.apply_drained(
             RangeId(1),
@@ -614,8 +615,8 @@ mod tests {
     #[test]
     fn merge_second_parent_activates_m_with_union_keyspace() {
         let mut set = RangeCursorSet::new(vec![
-            cursor(RangeId(1), 0, b"a", b"b"),
-            cursor(RangeId(2), 0, b"b", b"c"),
+            cursor(RangeId(1), EntryId::default(), b"a", b"b"),
+            cursor(RangeId(2), EntryId::default(), b"b", b"c"),
         ]);
         set.apply_drained(
             RangeId(1),
@@ -628,7 +629,7 @@ mod tests {
         );
 
         assert_eq!(added.len(), 1);
-        assert_eq!(added[0], cursor(RangeId(3), 0, b"a", b"c"));
+        assert_eq!(added[0], cursor(RangeId(3), EntryId::default(), b"a", b"c"));
 
         // Only M remains, spanning both pre-merge keyspaces.
         assert_eq!(set.len(), 1);
@@ -641,14 +642,14 @@ mod tests {
     /// waits on, P2" case.
     #[test]
     fn single_parent_consumer_follows_into_m_without_tracking_sibling() {
-        let mut set = RangeCursorSet::new(vec![cursor(RangeId(1), 0, b"a", b"b")]);
+        let mut set = RangeCursorSet::new(vec![cursor(RangeId(1), EntryId::default(), b"a", b"b")]);
         let added = set.apply_drained(
             RangeId(1),
             merge_transition(RangeId(3), [RangeId(1), RangeId(2)]),
         );
 
         assert_eq!(added.len(), 1);
-        assert_eq!(added[0], cursor(RangeId(3), 0, b"a", b"b"));
+        assert_eq!(added[0], cursor(RangeId(3), EntryId::default(), b"a", b"b"));
 
         assert_eq!(set.len(), 1);
         assert_eq!(set.get(RangeId(3)).unwrap().range_id, RangeId(3));
@@ -658,8 +659,8 @@ mod tests {
     #[should_panic(expected = "duplicate range_id")]
     fn duplicate_range_id_panics_invariants() {
         RangeCursorSet::new(vec![
-            cursor(RangeId(1), 0, b"a", b"b"),
-            cursor(RangeId(1), 0, b"c", b"d"),
+            cursor(RangeId(1), EntryId::default(), b"a", b"b"),
+            cursor(RangeId(1), EntryId::default(), b"c", b"d"),
         ]);
     }
 
@@ -667,8 +668,8 @@ mod tests {
     #[should_panic(expected = "overlapping keyspaces")]
     fn overlapping_keyspaces_panic_invariants() {
         RangeCursorSet::new(vec![
-            cursor(RangeId(1), 0, b"a", b"c"),
-            cursor(RangeId(2), 0, b"b", b"d"),
+            cursor(RangeId(1), EntryId::default(), b"a", b"c"),
+            cursor(RangeId(2), EntryId::default(), b"b", b"d"),
         ]);
     }
 }

--- a/src/client/consumer/cursor.rs
+++ b/src/client/consumer/cursor.rs
@@ -269,7 +269,7 @@ impl RangeCursor {
             .filter(|r| r.state == RangeState::Active)
             .filter(|r| interest.matches(r))
             .map(|r| {
-                let start_offset = r.active_segment.as_ref().map_or(0, |s| s.start_entry_id);
+                let start_offset = r.active_segment.as_ref().map_or(0, |s| *s.start_entry_id);
                 RangeCursor::new(
                     r.range_id,
                     start_offset,
@@ -301,7 +301,7 @@ impl RangeCursor {
             .map(|r| {
                 RangeCursor::new(
                     r.range_id,
-                    r.first_segment_start_offset().unwrap_or(0),
+                    r.first_segment_start_offset().map_or(0, |id| *id),
                     r.keyspace_start.clone(),
                     r.keyspace_end.clone(),
                 )
@@ -406,7 +406,7 @@ mod tests {
     use super::*;
     use super::*;
     use crate::connections::protocol::{RangeDetail, SegmentDetail, TopicState};
-    use crate::control_plane::metadata::{RangeId, RangeState};
+    use crate::control_plane::metadata::{RangeId, RangeState, SegmentId};
 
     fn cursor(range_id: RangeId, next_offset: u64, start: &[u8], end: &[u8]) -> RangeCursor {
         RangeCursor::new(range_id, next_offset, start.to_vec(), end.to_vec())
@@ -442,8 +442,8 @@ mod tests {
             keyspace_end: end.to_vec(),
             state,
             active_segment: state.eq(&RangeState::Active).then(|| SegmentDetail {
-                segment_id: 0,
-                start_entry_id: 0,
+                segment_id: SegmentId(0),
+                start_entry_id: 0.into(),
                 end_entry_id: None,
                 replica_set: vec![],
             }),

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -13,7 +13,7 @@ use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientResponse, DataPlaneResponse, FetchByIdRequest,
     RangeOffsetRequest, SegmentDetail, TopicDetail,
 };
-use crate::control_plane::metadata::{RangeId, RangeState};
+use crate::control_plane::metadata::{EntryId, RangeId, RangeState};
 
 pub(crate) mod cursor;
 pub(crate) mod group;
@@ -93,7 +93,8 @@ impl Consumer {
 
         if matches!(config.start_policy, StartPolicy::Latest) {
             for cursor in cursors.iter_mut() {
-                let has_saved_offset = consumer_group.is_some() && cursor.next_entry_id > 0;
+                let has_saved_offset =
+                    consumer_group.is_some() && cursor.next_entry_id > EntryId::default();
                 if !has_saved_offset
                     && let Ok((_, committed_entry_id)) =
                         client.fetch_range_entry_ids(&topic, cursor.range_id).await

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -3,9 +3,11 @@ use dashmap::DashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::client::consumer::range_fetcher::ConsumerContext;
 use crate::client::consumer::group::{ConsumerGroup, OffsetCommitPayload, SYSTEM_TOPIC_OFFSETS};
-use crate::client::consumer::topic_fetch_manager::{CursorDrained, run_topic_fetch_manager};
+use crate::client::consumer::range_fetcher::ConsumerContext;
+use crate::client::consumer::topic_fetch_manager::{
+    RangeDrained, TopicFetchManagerState, run_topic_fetch_manager,
+};
 use crate::client::{Client, ClientError, Producer, ProducerConfig};
 use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientResponse, DataPlaneResponse, FetchByIdRequest,
@@ -40,6 +42,7 @@ impl ConsumerRecord {
 
 #[derive(Debug, Clone)]
 pub struct ConsumerConfig {
+    /// The policy (Earliest/Latest) used to start consumption on newly assigned ranges.
     pub start_policy: StartPolicy,
     pub group_id: Option<String>,
     pub auto_commit_interval_ms: u64,
@@ -58,7 +61,7 @@ impl ConsumerConfig {
 #[derive(Clone)]
 pub struct Consumer {
     ctx: Arc<ConsumerContext>,
-    record_rx: flume::Receiver<Result<ConsumerRecord, ClientError>>,
+    consumer_rx: flume::Receiver<Result<ConsumerRecord, ClientError>>,
     group: Option<Arc<ConsumerGroup>>,
 }
 
@@ -100,7 +103,7 @@ impl Consumer {
             }
         }
 
-        let (record_tx, record_rx) = flume::unbounded();
+        let (record_tx, consumer_rx) = flume::unbounded();
         let (cursor_tx, cursor_rx) = flume::bounded(100);
 
         let ctx = Arc::new(ConsumerContext {
@@ -111,37 +114,28 @@ impl Consumer {
             cursor_tx,
         });
 
-        Self::spawn_manager(
-            cursors,
-            cursor_rx,
-            &ctx,
-            record_tx,
-            consumer_group.clone(),
-            config,
-        );
+        let topic_fetch_manager =
+            TopicFetchManagerState::new(cursors, consumer_group.clone(), config, record_tx);
+        if !topic_fetch_manager.should_exit() {
+            Self::spawn_manager(topic_fetch_manager, cursor_rx, &ctx);
+        }
 
         Ok(Self {
             ctx,
-            record_rx,
+            consumer_rx,
             group: consumer_group,
         })
     }
 
     fn spawn_manager(
-        cursors: RangeCursorSet,
-        cursor_rx: flume::Receiver<CursorDrained>,
+        topic_fetch_manager: TopicFetchManagerState,
+        drain_event_rx: flume::Receiver<RangeDrained>,
         ctx: &Arc<ConsumerContext>,
-        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-        consumer_group: Option<Arc<ConsumerGroup>>,
-        config: ConsumerConfig,
     ) {
         tokio::spawn(run_topic_fetch_manager(
-            cursors,
-            cursor_rx,
+            topic_fetch_manager,
+            drain_event_rx,
             Arc::downgrade(ctx),
-            record_tx,
-            consumer_group,
-            config,
         ));
     }
 
@@ -158,7 +152,7 @@ impl Consumer {
     /// cursors remain).
     pub async fn next_record(&self) -> Result<Option<ConsumerRecord>, ClientError> {
         loop {
-            let Ok(res) = self.record_rx.recv_async().await else {
+            let Ok(res) = self.consumer_rx.recv_async().await else {
                 return Ok(None);
             };
 

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -16,7 +16,7 @@ use crate::control_plane::metadata::{EntryId, RangeId, RangeState, TopicId};
 enum RangeLookupResult {
     Found(SegmentDetail),
     FellBehind {
-        first_start: u64,
+        first_start: EntryId,
     },
     NeedRefresh,
     RangeSealedAndDrained {
@@ -30,7 +30,7 @@ pub(crate) enum RangeFetchActorCommand {
 
 pub(crate) struct RangeFetchActor {
     range_id: RangeId,
-    next_entry_id: u64,
+    next_entry_id: EntryId,
     ctx: Arc<ConsumerContext>,
     record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
 }
@@ -38,7 +38,7 @@ pub(crate) struct RangeFetchActor {
 impl RangeFetchActor {
     pub(crate) fn new(
         range_id: RangeId,
-        next_entry_id: u64,
+        next_entry_id: EntryId,
         ctx: Arc<ConsumerContext>,
         record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) -> Self {
@@ -176,7 +176,7 @@ impl RangeFetchActor {
                     return Ok(false);
                 }
 
-                self.next_entry_id = *next_entry_id;
+                self.next_entry_id = next_entry_id;
                 Ok(true)
             }
             DataPlaneResponse::EntryIdOutOfRange => {
@@ -221,7 +221,7 @@ impl ConsumerContext {
         &self,
         segment: &SegmentDetail,
         range_id: RangeId,
-        offset: u64,
+        entry_id: EntryId,
     ) -> Result<Served, ClientError> {
         let addr = segment
             .pick_replica()
@@ -229,7 +229,7 @@ impl ConsumerContext {
         let req = FetchByIdRequest {
             topic_id: self.topic_id,
             range_id,
-            entry_id: EntryId(offset),
+            entry_id,
             max_bytes: 1024 * 1024,
         };
         self.client
@@ -269,22 +269,22 @@ impl ConsumerContext {
     }
 
     /// Pure synchronous metadata lookup to isolate the non-Send arc_swap::Guard.
-    fn lookup_range(&self, range_id: RangeId, next_entry_id: u64) -> RangeLookupResult {
+    fn lookup_range(&self, range_id: RangeId, next_entry_id: EntryId) -> RangeLookupResult {
         let meta = self.metadata.load();
         let Some(r) = meta.ranges.iter().find(|r| r.range_id == range_id) else {
             return RangeLookupResult::NeedRefresh;
         };
 
         // Try to find the segment directly
-        if let Some(segment) = r.find_segment_for_offset(EntryId(next_entry_id)) {
+        if let Some(segment) = r.find_segment_for_offset(next_entry_id) {
             return RangeLookupResult::Found(segment.clone());
         }
 
         // If sealed, check if we've drained it completely
         if r.state != RangeState::Active {
-            let range_end_offset = r.end_entry_id();
+            let range_end_entry = r.end_entry_id();
 
-            if next_entry_id > *range_end_offset {
+            if next_entry_id > range_end_entry {
                 if let Some(progress_signal) = compute_progress_signal(&meta, r) {
                     return RangeLookupResult::RangeSealedAndDrained { progress_signal };
                 } else {
@@ -295,11 +295,11 @@ impl ConsumerContext {
 
         // (Common Fallback) Check if we fell behind the oldest available data,
         // otherwise signal that a metadata refresh is needed to discover the new segment
-        if let Some(first_start) = r.first_segment_start_offset()
-            && next_entry_id < *first_start
+        if let Some(start_entry) = r.first_segment_start_offset()
+            && next_entry_id < start_entry
         {
             return RangeLookupResult::FellBehind {
-                first_start: *first_start,
+                first_start: start_entry,
             };
         }
 

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use arc_swap::ArcSwap;
 
 use super::ConsumerRecord;
-use crate::client::consumer::topic_fetch_manager::CursorDrained;
+use crate::client::consumer::topic_fetch_manager::RangeDrained;
 use crate::client::redirect::Served;
 use crate::client::{Client, ClientError, CompressionCodec};
 use crate::connections::protocol::{
@@ -98,7 +98,7 @@ impl RangeFetchActor {
             }
             RangeLookupResult::RangeSealedAndDrained { progress_signal } => {
                 if let RangeProgressSignal::Sealed { transition, .. } = progress_signal {
-                    let _ = self.ctx.cursor_tx.send(CursorDrained {
+                    let _ = self.ctx.cursor_tx.send(RangeDrained {
                         range_id: self.range_id,
                         transition,
                     });
@@ -169,7 +169,7 @@ impl RangeFetchActor {
                 } = progress_signal
                     && next_entry_id > end_entry_id
                 {
-                    let _ = self.ctx.cursor_tx.send(CursorDrained {
+                    let _ = self.ctx.cursor_tx.send(RangeDrained {
                         range_id: self.range_id,
                         transition,
                     });
@@ -212,7 +212,7 @@ pub(crate) struct ConsumerContext {
     pub(crate) topic: String,
     pub(crate) topic_id: u64,
     pub(crate) metadata: ArcSwap<TopicDetail>,
-    pub(crate) cursor_tx: flume::Sender<CursorDrained>,
+    pub(crate) cursor_tx: flume::Sender<RangeDrained>,
 }
 
 impl ConsumerContext {

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -11,7 +11,7 @@ use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientResponse, DataPlaneResponse, FetchByIdRequest, RangeDetail,
     RangeOffsetRequest, RangeProgressSignal, RangeTransition, SegmentDetail, TopicDetail,
 };
-use crate::control_plane::metadata::{RangeId, RangeState};
+use crate::control_plane::metadata::{EntryId, RangeId, RangeState};
 
 enum RangeLookupResult {
     Found(SegmentDetail),
@@ -146,7 +146,7 @@ impl RangeFetchActor {
                         let consumer_rec = ConsumerRecord {
                             topic: self.ctx.topic.clone(),
                             range_id: self.range_id,
-                            offset: entry.entry_id + i as u64,
+                            offset: *entry.entry_id + i as u64,
                             key: rec.key,
                             value: rec.value,
                         };
@@ -176,7 +176,7 @@ impl RangeFetchActor {
                     return Ok(false);
                 }
 
-                self.next_entry_id = next_entry_id;
+                self.next_entry_id = *next_entry_id;
                 Ok(true)
             }
             DataPlaneResponse::EntryIdOutOfRange => {
@@ -229,7 +229,7 @@ impl ConsumerContext {
         let req = FetchByIdRequest {
             topic_id: self.topic_id,
             range_id,
-            entry_id: offset,
+            entry_id: EntryId(offset),
             max_bytes: 1024 * 1024,
         };
         self.client
@@ -276,7 +276,7 @@ impl ConsumerContext {
         };
 
         // Try to find the segment directly
-        if let Some(segment) = r.find_segment_for_offset(next_entry_id) {
+        if let Some(segment) = r.find_segment_for_offset(EntryId(next_entry_id)) {
             return RangeLookupResult::Found(segment.clone());
         }
 
@@ -284,7 +284,7 @@ impl ConsumerContext {
         if r.state != RangeState::Active {
             let range_end_offset = r.end_entry_id();
 
-            if next_entry_id > range_end_offset {
+            if next_entry_id > *range_end_offset {
                 if let Some(progress_signal) = compute_progress_signal(&meta, r) {
                     return RangeLookupResult::RangeSealedAndDrained { progress_signal };
                 } else {
@@ -296,9 +296,9 @@ impl ConsumerContext {
         // (Common Fallback) Check if we fell behind the oldest available data,
         // otherwise signal that a metadata refresh is needed to discover the new segment
         if let Some(first_start) = r.first_segment_start_offset()
-            && next_entry_id < first_start
+            && next_entry_id < *first_start
         {
-            return RangeLookupResult::FellBehind { first_start };
+            return RangeLookupResult::FellBehind { first_start: *first_start };
         }
 
         RangeLookupResult::NeedRefresh

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -11,7 +11,7 @@ use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientResponse, DataPlaneResponse, FetchByIdRequest, RangeDetail,
     RangeOffsetRequest, RangeProgressSignal, RangeTransition, SegmentDetail, TopicDetail,
 };
-use crate::control_plane::metadata::{EntryId, RangeId, RangeState};
+use crate::control_plane::metadata::{EntryId, RangeId, RangeState, TopicId};
 
 enum RangeLookupResult {
     Found(SegmentDetail),
@@ -210,7 +210,7 @@ impl RangeFetchActor {
 pub(crate) struct ConsumerContext {
     pub(crate) client: Arc<Client>,
     pub(crate) topic: String,
-    pub(crate) topic_id: u64,
+    pub(crate) topic_id: TopicId,
     pub(crate) metadata: ArcSwap<TopicDetail>,
     pub(crate) cursor_tx: flume::Sender<RangeDrained>,
 }
@@ -298,7 +298,9 @@ impl ConsumerContext {
         if let Some(first_start) = r.first_segment_start_offset()
             && next_entry_id < *first_start
         {
-            return RangeLookupResult::FellBehind { first_start: *first_start };
+            return RangeLookupResult::FellBehind {
+                first_start: *first_start,
+            };
         }
 
         RangeLookupResult::NeedRefresh

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -1,8 +1,8 @@
 use super::RangeCursor;
 
 use crate::client::consumer::cursor::StartPolicy;
-use crate::client::consumer::range_fetcher::{RangeFetchActor, RangeFetchActorCommand};
 use crate::client::consumer::group::ConsumerGroup;
+use crate::client::consumer::range_fetcher::{RangeFetchActor, RangeFetchActorCommand};
 use crate::client::consumer::{ConsumerContext, ConsumerRecord, RangeCursorSet};
 use crate::client::{ClientError, ConsumerConfig};
 use crate::connections::protocol::{RangeDetail, RangeTransition};
@@ -15,44 +15,48 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-pub(crate) struct CursorDrained {
+pub(crate) struct RangeDrained {
     pub range_id: RangeId,
     pub transition: RangeTransition,
 }
 
-struct TopicFetchManagerState {
+pub(crate) struct TopicFetchManagerState {
     cursors: RangeCursorSet,
     senders: HashMap<RangeId, flume::Sender<RangeFetchActorCommand>>,
 
     /// The optional shared consumer group context for dynamic partition rebalancing.
     consumer_group: Option<Arc<ConsumerGroup>>,
-    /// The policy (Earliest/Latest) used to start consumption on newly assigned ranges.
-    start_policy: StartPolicy,
+    config: ConsumerConfig,
+    record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
 }
 
 impl TopicFetchManagerState {
-    fn new(
+    pub(crate) fn new(
         cursors: RangeCursorSet,
         consumer_group: Option<Arc<ConsumerGroup>>,
-        start_policy: StartPolicy,
+        config: ConsumerConfig,
+        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
     ) -> Self {
         Self {
             cursors,
             senders: HashMap::new(),
             consumer_group,
-            start_policy,
+            config,
+            record_tx,
         }
     }
+    fn auto_commit_interval_ms(&self) -> u64 {
+        self.config.auto_commit_interval_ms
+    }
+    fn start_policy(&self) -> &StartPolicy {
+        &self.config.start_policy
+    }
 
-    fn should_exit(&self) -> bool {
+    pub(crate) fn should_exit(&self) -> bool {
         self.cursors.is_empty() && self.consumer_group.is_none()
     }
 
-    fn provision_initial_tasks(
-        &mut self,
-        ctx: &Arc<ConsumerContext>,
-        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
-    ) {
+    fn provision_initial_tasks(&mut self, ctx: &Arc<ConsumerContext>) {
         // If a consumer_group is present, partition ownership is dynamic and determined entirely by the
         // group rebalancer. We return early to prevent the consumer from starting fetch tasks before
         // partitions are assigned to it.
@@ -60,16 +64,11 @@ impl TopicFetchManagerState {
             return;
         }
         for cursor in self.cursors.iter().cloned().collect::<Vec<_>>() {
-            self.spawn_and_register(cursor, ctx.clone(), record_tx.clone());
+            self.spawn_and_register(cursor, ctx.clone());
         }
     }
 
-    fn handle_cursor_drained(
-        &mut self,
-        event: CursorDrained,
-        ctx: &Arc<ConsumerContext>,
-        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
-    ) {
+    fn handle_cursor_drained(&mut self, event: RangeDrained, ctx: &Arc<ConsumerContext>) {
         // If not owned, it was already revoked — late drain event, safe to ignore.
         if self.senders.remove(&event.range_id).is_none() {
             return;
@@ -77,15 +76,11 @@ impl TopicFetchManagerState {
         let added = self.cursors.apply_drained(event.range_id, event.transition);
 
         for new_cursor in added {
-            self.spawn_and_register(new_cursor, ctx.clone(), record_tx.clone());
+            self.spawn_and_register(new_cursor, ctx.clone());
         }
     }
 
-    async fn handle_rebalance(
-        &mut self,
-        ctx: &Arc<ConsumerContext>,
-        record_tx: &flume::Sender<Result<ConsumerRecord, ClientError>>,
-    ) {
+    async fn handle_rebalance(&mut self, ctx: &Arc<ConsumerContext>) {
         let Some(group) = &self.consumer_group else {
             return;
         };
@@ -147,7 +142,6 @@ impl TopicFetchManagerState {
                         r_meta.keyspace_end.clone(),
                     ),
                     ctx.clone(),
-                    record_tx.clone(),
                 );
             }
         }
@@ -155,17 +149,17 @@ impl TopicFetchManagerState {
 
     /// Spawn a fetch actor, register its stop channel, and update/add the cursor
     /// in the cursor set.
-    fn spawn_and_register(
-        &mut self,
-        cursor: RangeCursor,
-        ctx: Arc<ConsumerContext>,
-        record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-    ) {
+    fn spawn_and_register(&mut self, cursor: RangeCursor, ctx: Arc<ConsumerContext>) {
         if self.senders.contains_key(&cursor.range_id) {
             return;
         }
         let (stop_tx, stop_rx) = flume::bounded(1);
-        let actor = RangeFetchActor::new(cursor.range_id, cursor.next_entry_id, ctx, record_tx);
+        let actor = RangeFetchActor::new(
+            cursor.range_id,
+            cursor.next_entry_id,
+            ctx,
+            self.record_tx.clone(),
+        );
         tokio::spawn(actor.run(stop_rx));
         self.senders.insert(cursor.range_id, stop_tx);
         self.cursors.add_or_update(cursor);
@@ -190,7 +184,7 @@ impl TopicFetchManagerState {
 
         // 2. Fetch the latest boundary from the replica if the start policy is Latest.
         // Note: fetch_range_entry_ids returns (start_entry_id, committed_entry_id).
-        if matches!(self.start_policy, StartPolicy::Latest)
+        if matches!(self.start_policy(), StartPolicy::Latest)
             && let Ok((_, committed_entry_id)) =
                 ctx.client.fetch_range_entry_ids(&ctx.topic, range).await
         {
@@ -320,31 +314,23 @@ impl TopicFetchManagerState {
 }
 
 pub(crate) async fn run_topic_fetch_manager(
-    cursors: RangeCursorSet,
-    rx: flume::Receiver<CursorDrained>,
+    mut state: TopicFetchManagerState,
+    drain_event_rx: flume::Receiver<RangeDrained>,
     weak_ctx: std::sync::Weak<ConsumerContext>,
-    record_tx: flume::Sender<Result<ConsumerRecord, ClientError>>,
-    consumer_group: Option<Arc<ConsumerGroup>>,
-    config: ConsumerConfig,
 ) {
-    let mut state = TopicFetchManagerState::new(cursors, consumer_group, config.start_policy);
-    if state.should_exit() {
-        return;
-    }
-
     if let Some(ctx) = weak_ctx.upgrade() {
-        state.provision_initial_tasks(&ctx, &record_tx);
+        state.provision_initial_tasks(&ctx);
     }
 
     let mut rebalance_interval = tokio::time::interval(Duration::from_secs(1));
     let mut commit_interval =
-        tokio::time::interval(Duration::from_millis(config.auto_commit_interval_ms));
+        tokio::time::interval(Duration::from_millis(state.auto_commit_interval_ms()));
 
     // Waiting exactly 2 tickets(~2secs) before the first rebalance.
     let mut startup_grace_ticks = if state.consumer_group.is_some() { 2 } else { 0 };
 
     loop {
-        if record_tx.is_disconnected() {
+        if state.record_tx.is_disconnected() {
             break;
         }
 
@@ -353,10 +339,10 @@ pub(crate) async fn run_topic_fetch_manager(
         };
 
         tokio::select! {
-            res = rx.recv_async() => {
+            // CursorDrained Event arrived! meaning that fetch actor figured that the range is sealed
+            res = drain_event_rx.recv_async() => {
                 let Ok(event) = res else { break };
-                // CursorDrained Event arrived! meaning that fetch actor figured that the range is sealed
-                state.handle_cursor_drained(event, &ctx, &record_tx);
+                state.handle_cursor_drained(event, &ctx);
 
                 if state.should_exit() {
                      break;
@@ -377,7 +363,7 @@ pub(crate) async fn run_topic_fetch_manager(
                     if state.cursors.is_empty() {
                         let _ = ctx.refresh_metadata().await;
                     }
-                    state.handle_rebalance(&ctx, &record_tx).await;
+                    state.handle_rebalance(&ctx).await;
                 }
             }
         }

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -226,7 +226,7 @@ impl TopicFetchManagerState {
                 .iter()
                 .find(|r| r.range_id == range_id)
                 .is_some_and(|r| {
-                    r.state == RangeState::Sealed && resolved_entry_id > r.end_entry_id()
+                    r.state == RangeState::Sealed && resolved_entry_id > *r.end_entry_id()
                 })
     }
 
@@ -298,7 +298,7 @@ impl TopicFetchManagerState {
             if p.state == RangeState::Sealed {
                 let parent_resolved = saved_offsets.get(&p.range_id).map(|o| o + 1).unwrap_or(0);
 
-                if parent_resolved <= p.end_entry_id() {
+                if parent_resolved <= *p.end_entry_id() {
                     return true;
                 }
             }

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -6,7 +6,7 @@ use crate::client::consumer::range_fetcher::{RangeFetchActor, RangeFetchActorCom
 use crate::client::consumer::{ConsumerContext, ConsumerRecord, RangeCursorSet};
 use crate::client::{ClientError, ConsumerConfig};
 use crate::connections::protocol::{RangeDetail, RangeTransition};
-use crate::control_plane::metadata::{RangeId, RangeState};
+use crate::control_plane::metadata::{EntryId, RangeId, RangeState};
 
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
@@ -175,11 +175,15 @@ impl TopicFetchManagerState {
         range: RangeId,
         ctx: &Arc<ConsumerContext>,
         committed_offset: Option<u64>,
-    ) -> u64 {
-        // 1. Prefer explicitly saved offsets. If a consumer committed offset `N`,
-        // the next record to fetch starts at entry ID `N + 1`.
+    ) -> EntryId {
+        // 1. Prefer explicitly saved offsets. The committed offset is a
+        // record-level checkpoint. Because one entry can contain multiple
+        // records, `offset + 1` may still fall inside the same entry the
+        // consumer already consumed — not the start of the next entry.
+        // The fetch path re-delivers the containing entry; the consumer
+        // skips already-processed records.
         if let Some(offset) = committed_offset {
-            return offset + 1;
+            return EntryId(offset + 1);
         }
 
         // 2. Fetch the latest boundary from the replica if the start policy is Latest.
@@ -197,7 +201,7 @@ impl TopicFetchManagerState {
         }
 
         // 4. Default start entry ID is 0
-        0
+        EntryId::default()
     }
 
     async fn abort_all(&mut self) {
@@ -218,7 +222,7 @@ impl TopicFetchManagerState {
         range_id: RangeId,
         ranges: &[RangeDetail],
         saved_offsets: &HashMap<RangeId, u64>,
-        resolved_entry_id: u64,
+        resolved_entry_id: EntryId,
     ) -> bool {
         self.has_active_descendant(range_id, ranges)
             || self.has_undrained_parent(range_id, ranges, saved_offsets)
@@ -226,7 +230,7 @@ impl TopicFetchManagerState {
                 .iter()
                 .find(|r| r.range_id == range_id)
                 .is_some_and(|r| {
-                    r.state == RangeState::Sealed && resolved_entry_id > *r.end_entry_id()
+                    r.state == RangeState::Sealed && resolved_entry_id > r.end_entry_id()
                 })
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -127,7 +127,7 @@ impl Client {
             return Err(ClientError::UnexpectedResponse);
         };
 
-        Ok((start_entry_id, committed_entry_id))
+        Ok((*start_entry_id, *committed_entry_id))
     }
 
     pub async fn fetch_all_saved_offsets(

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,7 @@ pub use producer::{BufferConfig, Producer, ProducerConfig};
 use crate::client::consumer::group::OffsetCommitPayload;
 use crate::client::consumer::group::SYSTEM_TOPIC_OFFSETS;
 use crate::connections::protocol::{ClientResponse, DataPlaneResponse, RangeOffsetRequest};
-use crate::control_plane::metadata::RangeId;
+use crate::control_plane::metadata::{EntryId, RangeId};
 use borsh::BorshDeserialize;
 
 pub use redirect::RetryPolicy;
@@ -98,7 +98,7 @@ impl Client {
         &self,
         topic: &str,
         range_id: RangeId,
-    ) -> Result<(u64, u64), ClientError> {
+    ) -> Result<(EntryId, EntryId), ClientError> {
         let detail = self.resolve_topic(topic).await?;
         let addr = detail
             .ranges
@@ -127,7 +127,7 @@ impl Client {
             return Err(ClientError::UnexpectedResponse);
         };
 
-        Ok((*start_entry_id, *committed_entry_id))
+        Ok((start_entry_id, committed_entry_id))
     }
 
     pub async fn fetch_all_saved_offsets(

--- a/src/client/produce.rs
+++ b/src/client/produce.rs
@@ -44,7 +44,7 @@ impl Client {
             self.cache.invalidate(topic);
         }
         match served.response {
-            ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) => Ok(entry_id),
+            ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) => Ok(*entry_id),
             _ => Err(ClientError::UnexpectedResponse),
         }
     }

--- a/src/client/produce.rs
+++ b/src/client/produce.rs
@@ -7,6 +7,7 @@ use crate::client::error::ClientError;
 use crate::connections::protocol::{
     ClientDataPlaneRequest, ClientRequest, ClientResponse, DataPlaneResponse, ProduceRequest,
 };
+use crate::control_plane::metadata::EntryId;
 
 impl Client {
     /// Produce one entry under `routing_key`, returning the committed `entry_id`.
@@ -18,7 +19,7 @@ impl Client {
         routing_key: &[u8],
         data: Vec<u8>,
         record_count: u32,
-    ) -> Result<u64, ClientError> {
+    ) -> Result<EntryId, ClientError> {
         // Describe once to seed the cache (gives the first hop).
         if self.cache.get(topic).is_none() {
             self.resolve_topic(topic).await?;
@@ -44,7 +45,7 @@ impl Client {
             self.cache.invalidate(topic);
         }
         match served.response {
-            ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) => Ok(*entry_id),
+            ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) => Ok(entry_id),
             _ => Err(ClientError::UnexpectedResponse),
         }
     }

--- a/src/client/producer/buffers.rs
+++ b/src/client/producer/buffers.rs
@@ -1,7 +1,7 @@
 use super::ProducerRecord;
-use crate::client::error::ClientError;
 use crate::client::producer::config::BufferConfig;
 use crate::control_plane::metadata::RangeId;
+use crate::{client::error::ClientError, control_plane::metadata::EntryId};
 
 use dashmap::DashMap;
 use std::time::{Duration, Instant};
@@ -51,7 +51,7 @@ pub struct PendingRecord {
     pub record: ProducerRecord,
     pub producer_id: Uuid,
     pub sequence_number: u32,
-    pub tx: oneshot::Sender<Result<u64, ClientError>>,
+    pub tx: oneshot::Sender<Result<EntryId, ClientError>>,
 }
 
 /// The action to be taken after pushing a record to the buffer.

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -3,7 +3,7 @@ mod config;
 pub(crate) mod record;
 use crate::client::error::ClientError;
 use crate::client::{Client, CompressionCodec};
-use crate::control_plane::metadata::RangeId;
+use crate::control_plane::metadata::{EntryId, RangeId};
 use buffers::{PendingRecord, ProducerBuffers, PushResult};
 pub use config::{BufferConfig, ProducerConfig};
 use record::ProducerRecord;
@@ -58,7 +58,7 @@ impl Producer {
     }
 
     /// Produce a single record. Returns the committed entry ID once the batch flushes.
-    pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<u64, ClientError> {
+    pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
         let topic = &self.inner.topic;
         let client = &self.inner.client;
 

--- a/src/client/redirect.rs
+++ b/src/client/redirect.rs
@@ -343,7 +343,7 @@ mod tests {
         );
         assert_eq!(
             classify(&ClientResponse::DataPlane(DataPlaneResponse::Produced {
-                entry_id: 7
+                entry_id: 7.into()
             })),
             "done"
         );

--- a/src/client/routing.rs
+++ b/src/client/routing.rs
@@ -3,7 +3,7 @@
 //! per-request check corrects a stale entry with a redirect (`redirect.rs`), so the
 //! cache only ever costs an extra hop, never a wrong target.
 use crate::connections::protocol::{RangeDetail, TopicDetail};
-use crate::control_plane::metadata::RangeId;
+use crate::control_plane::metadata::{RangeId, TopicId};
 use arc_swap::ArcSwap;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 /// Per-topic routing snapshot. Built once from a `DescribeTopic` response and
 /// replaced wholesale on refresh.
 pub(crate) struct TopicRouting {
-    pub topic_id: u64,
+    pub topic_id: TopicId,
     ranges: Box<[RangeRoute]>,
 }
 

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -11,7 +11,7 @@ use crate::control_plane::{
         actor::{ShardRouting, SwimSender},
     },
     metadata::{
-        RangeId, TopicId,
+        EntryId, RangeId, TopicId,
         command::{CreateTopic, DeleteTopic, MetadataCommand},
         strategy::StoragePolicy,
     },
@@ -359,7 +359,7 @@ impl ClientController {
         let query = Fetch {
             topic_id: meta.id,
             range_id: RangeId(req.range_id),
-            entry_id: req.entry_id,
+            entry_id: EntryId(req.entry_id),
             max_bytes: req.max_bytes,
             progress_signal,
             reply: reply_tx,
@@ -604,7 +604,7 @@ mod tests {
         tokio::spawn(async move {
             while let Ok(msg) = rx.recv_async().await {
                 if let DataPlaneMessage::Command(DataPlaneCommand::Produce(p)) = msg {
-                    let _ = p.reply.send(ProduceAck::Ok { entry_id: 7 });
+                    let _ = p.reply.send(ProduceAck::Ok { entry_id: 7.into() });
                 }
             }
         });
@@ -747,7 +747,7 @@ mod tests {
         let ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) = resp else {
             panic!("expected Produced, got {resp:?}");
         };
-        assert_eq!(entry_id, 7);
+        assert_eq!(entry_id, 7.into());
     }
 
     /// A control-plane write on a non-member node returns the structural redirect
@@ -808,11 +808,10 @@ mod tests {
             .dispatch(ClientRequest::ControlPlane(
                 ControlPlaneRequest::CreateTopic {
                     name: "t1".into(),
-                    storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
+                    storage_policy: StoragePolicy {
                         retention_ms: Some(3_600_000),
                         replication_factor: 1,
-                        partition_strategy:
-                            crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
+                        partition_strategy: PartitionStrategy::AutoSplit,
                     },
                 },
             ))
@@ -833,24 +832,19 @@ mod tests {
                 let _ = reply.send(None);
             }
         });
-        let resp = ClientController::new(
-            node_id("self"),
-            swim,
-            raft_sender_with(|_| {}),
-            dp_stub(),
-        )
-        .dispatch(ClientRequest::ControlPlane(
-            ControlPlaneRequest::CreateTopic {
-                name: "t1".into(),
-                storage_policy: crate::control_plane::metadata::strategy::StoragePolicy {
-                    retention_ms: Some(3_600_000),
-                    replication_factor: 1,
-                    partition_strategy:
-                        crate::control_plane::metadata::strategy::PartitionStrategy::AutoSplit,
-                },
-            },
-        ))
-        .await;
+        let resp =
+            ClientController::new(node_id("self"), swim, raft_sender_with(|_| {}), dp_stub())
+                .dispatch(ClientRequest::ControlPlane(
+                    ControlPlaneRequest::CreateTopic {
+                        name: "t1".into(),
+                        storage_policy: StoragePolicy {
+                            retention_ms: Some(3_600_000),
+                            replication_factor: 1,
+                            partition_strategy: PartitionStrategy::AutoSplit,
+                        },
+                    },
+                ))
+                .await;
         assert!(
             matches!(
                 resp,

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -11,7 +11,6 @@ use crate::control_plane::{
         actor::{ShardRouting, SwimSender},
     },
     metadata::{
-        EntryId, RangeId, TopicId,
         command::{CreateTopic, DeleteTopic, MetadataCommand},
         strategy::StoragePolicy,
     },
@@ -347,7 +346,7 @@ impl ClientController {
         let Some(meta) = self.raft_sender.get_topic_metadata(req.topic_name).await else {
             return Ok(DataPlaneResponse::TopicNotFound.into());
         };
-        let Some(range) = meta.ranges.get(&RangeId(req.range_id)) else {
+        let Some(range) = meta.ranges.get(&req.range_id) else {
             return Ok(DataPlaneResponse::TopicNotFound.into());
         };
         if !keyspace_bound_matches_range(&req.keyspace_bound, range) {
@@ -358,8 +357,8 @@ impl ClientController {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         let query = Fetch {
             topic_id: meta.id,
-            range_id: RangeId(req.range_id),
-            entry_id: EntryId(req.entry_id),
+            range_id: req.range_id,
+            entry_id: req.entry_id,
             max_bytes: req.max_bytes,
             progress_signal,
             reply: reply_tx,
@@ -381,8 +380,8 @@ impl ClientController {
     /// retries another replica.
     async fn handle_fetch_by_id(&self, req: FetchByIdRequest) -> anyhow::Result<ClientResponse> {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-        let query = DataPlaneQuery::Fetch(Fetch {
-            topic_id: TopicId(req.topic_id),
+        let query = Fetch {
+            topic_id: req.topic_id,
             range_id: req.range_id,
             entry_id: req.entry_id,
             max_bytes: req.max_bytes,
@@ -390,7 +389,7 @@ impl ClientController {
             // so the response's progress signal isn't authoritative here.
             progress_signal: RangeProgressSignal::Active,
             reply: reply_tx,
-        });
+        };
         if self.data_plane_tx.send_async(query).await.is_err() {
             return Ok(DataPlaneResponse::InternalError("data plane closed".into()).into());
         }
@@ -478,7 +477,7 @@ impl ClientController {
             .get_shard_info(key)
             .await?
             .map(|(group, leader)| ShardDetail {
-                shard_group_id: group.id.0,
+                shard_group_id: group.id,
                 leader_node_id: leader.as_ref().map(|e| e.leader_node_id.to_string()),
                 leader_addr: leader.map(|e| e.leader_addr.client_addr()),
                 member_node_ids: group.members.iter().map(|n| n.to_string()).collect(),
@@ -486,10 +485,13 @@ impl ClientController {
         Ok(ClientResponse::Admin(AdminResponse::ShardInfo { detail }))
     }
 
-    async fn handle_get_shard_leader(&self, shard_group_id: u64) -> anyhow::Result<ClientResponse> {
+    async fn handle_get_shard_leader(
+        &self,
+        shard_group_id: ShardGroupId,
+    ) -> anyhow::Result<ClientResponse> {
         let leader = self
             .raft_sender
-            .get_leader(ShardGroupId(shard_group_id))
+            .get_leader(shard_group_id)
             .await
             .map(|n| n.to_string());
         Ok(ClientResponse::Admin(AdminResponse::ShardLeader { leader }))
@@ -1044,7 +1046,7 @@ mod tests {
         let ClientResponse::Admin(AdminResponse::ShardInfo { detail: Some(d) }) = resp else {
             panic!("expected ShardInfo with detail, got {resp:?}");
         };
-        assert_eq!(d.shard_group_id, 42);
+        assert_eq!(*d.shard_group_id, 42);
         assert_eq!(d.leader_node_id.as_deref(), Some("n1"));
         assert_eq!(d.leader_addr, Some(addr(8081)));
         assert_eq!(d.member_node_ids[0], "node-1");
@@ -1083,7 +1085,7 @@ mod tests {
         let resp =
             ClientController::new(node_id("self"), swim_sender_with(|_| {}), raft, dp_stub())
                 .dispatch(ClientRequest::Admin(AdminRequest::GetShardLeader {
-                    shard_group_id: 42,
+                    shard_group_id: ShardGroupId(42),
                 }))
                 .await;
         let ClientResponse::Admin(AdminResponse::ShardLeader { leader }) = resp else {

--- a/src/connections/protocol/admin.rs
+++ b/src/connections/protocol/admin.rs
@@ -6,13 +6,15 @@ use std::net::SocketAddr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
+use crate::control_plane::membership::ShardGroupId;
+
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub enum AdminRequest {
     DescribeCluster,
     ListHostedTopicsWithStats,
     // Internal/debug queries — also used by integration test helpers.
     GetShardInfo { key: Vec<u8> },
-    GetShardLeader { shard_group_id: u64 },
+    GetShardLeader { shard_group_id: ShardGroupId },
 }
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -34,7 +36,7 @@ pub enum AdminResponse {
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct ShardDetail {
-    pub shard_group_id: u64,
+    pub shard_group_id: ShardGroupId,
     pub leader_node_id: Option<String>,
     pub leader_addr: Option<SocketAddr>,
     pub member_node_ids: Box<[String]>,

--- a/src/connections/protocol/control_plane.rs
+++ b/src/connections/protocol/control_plane.rs
@@ -22,8 +22,8 @@ use crate::control_plane::NodeId;
 use crate::control_plane::metadata::strategy::StoragePolicy;
 
 use crate::control_plane::metadata::{
-    EntryId, RangeId, RangeMeta, RangeState, SegmentId, SegmentMeta, SegmentMetaState, TopicMeta,
-    TopicState as MetaTopicState,
+    EntryId, RangeId, RangeMeta, RangeState, SegmentId, SegmentMeta, SegmentMetaState, TopicId,
+    TopicMeta, TopicState as MetaTopicState,
 };
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -88,7 +88,7 @@ pub enum TopicState {
 pub struct TopicDetail {
     /// Resolved id, so a consumer can fetch by id directly from a holding replica
     /// (no name re-resolution on the data node). See `FetchByIdRequest`.
-    pub topic_id: u64,
+    pub topic_id: TopicId,
     pub name: String,
     pub state: TopicState,
     pub ranges: Box<[RangeDetail]>,
@@ -108,7 +108,7 @@ impl TopicDetail {
             .map(|range| RangeDetail::from_meta(range, addresses))
             .collect();
         TopicDetail {
-            topic_id: meta.id.0,
+            topic_id: meta.id,
             name: meta.name,
             state: match meta.state {
                 MetaTopicState::Active => TopicState::Active,

--- a/src/connections/protocol/control_plane.rs
+++ b/src/connections/protocol/control_plane.rs
@@ -22,7 +22,7 @@ use crate::control_plane::NodeId;
 use crate::control_plane::metadata::strategy::StoragePolicy;
 
 use crate::control_plane::metadata::{
-    RangeId, RangeMeta, RangeState, SegmentMeta, SegmentMetaState, TopicMeta,
+    EntryId, RangeId, RangeMeta, RangeState, SegmentId, SegmentMeta, SegmentMetaState, TopicMeta,
     TopicState as MetaTopicState,
 };
 
@@ -149,13 +149,13 @@ pub struct RangeDetail {
 }
 
 impl RangeDetail {
-    pub(crate) fn end_entry_id(&self) -> u64 {
+    pub(crate) fn end_entry_id(&self) -> EntryId {
         self.sealed_segments
             .last()
             .and_then(|s| s.end_entry_id)
-            .unwrap_or(0)
+            .unwrap_or(EntryId::MIN)
     }
-    pub(crate) fn from_meta(range: RangeMeta, addresses: &HashMap<NodeId, SocketAddr>) -> Self {
+    fn from_meta(range: RangeMeta, addresses: &HashMap<NodeId, SocketAddr>) -> Self {
         let active_segment = range
             .active_segment
             .and_then(|id| range.segments.get(&id))
@@ -181,7 +181,7 @@ impl RangeDetail {
     }
 
     /// Find the segment in this range that covers the specified `entry_id`.
-    pub fn find_segment_for_offset(&self, entry_id: u64) -> Option<&SegmentDetail> {
+    pub fn find_segment_for_offset(&self, entry_id: EntryId) -> Option<&SegmentDetail> {
         // Check if it is in the active segment
         if let Some(seg) = &self.active_segment
             && entry_id >= seg.start_entry_id
@@ -203,7 +203,7 @@ impl RangeDetail {
     }
 
     /// Get the start offset of the very first segment in the range (either sealed or active).
-    pub fn first_segment_start_offset(&self) -> Option<u64> {
+    pub fn first_segment_start_offset(&self) -> Option<EntryId> {
         if let Some(seg) = self.sealed_segments.first() {
             Some(seg.start_entry_id)
         } else {
@@ -217,15 +217,15 @@ impl RangeDetail {
 /// separate address-resolution round trip.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SegmentDetail {
-    pub segment_id: u64,
-    pub start_entry_id: u64,
+    pub segment_id: SegmentId,
+    pub start_entry_id: EntryId,
     /// `None` while the segment is still active (the write head).
-    pub end_entry_id: Option<u64>,
+    pub end_entry_id: Option<EntryId>,
     pub replica_set: Vec<NodeAddressInfo>,
 }
 
 impl SegmentDetail {
-    pub(crate) fn from_meta(seg: &SegmentMeta, addresses: &HashMap<NodeId, SocketAddr>) -> Self {
+    fn from_meta(seg: &SegmentMeta, addresses: &HashMap<NodeId, SocketAddr>) -> Self {
         let replica_set = seg
             .replica_set
             .iter()
@@ -237,7 +237,7 @@ impl SegmentDetail {
             })
             .collect();
         SegmentDetail {
-            segment_id: seg.segment_id.0,
+            segment_id: seg.segment_id,
             start_entry_id: seg.start_entry_id,
             end_entry_id: seg.end_entry_id,
             replica_set,

--- a/src/connections/protocol/data_plane.rs
+++ b/src/connections/protocol/data_plane.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::{
-    control_plane::metadata::{EntryId, RangeId, RangeMeta, RangeState, TopicMeta},
+    control_plane::metadata::{EntryId, RangeId, RangeMeta, RangeState, TopicId, TopicMeta},
     data_plane::messages::query::{FetchResult, ListOffsetsResult},
     impl_from_variant,
 };
@@ -52,8 +52,8 @@ pub struct ProduceRequest {
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct FetchRequest {
     pub topic_name: String,
-    pub range_id: u64,
-    pub entry_id: u64,
+    pub range_id: RangeId,
+    pub entry_id: EntryId,
     /// Position within the entry to start from; 0 means the first record.
     pub record_index: u32,
     pub max_bytes: u32,
@@ -69,7 +69,7 @@ pub struct FetchRequest {
 /// resolution; the server never proxies.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct FetchByIdRequest {
-    pub topic_id: u64,
+    pub topic_id: TopicId,
     pub range_id: RangeId,
     pub entry_id: EntryId,
     pub max_bytes: u32,

--- a/src/connections/protocol/data_plane.rs
+++ b/src/connections/protocol/data_plane.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::{
-    control_plane::metadata::{RangeId, RangeMeta, RangeState, TopicMeta},
+    control_plane::metadata::{EntryId, RangeId, RangeMeta, RangeState, TopicMeta},
     data_plane::messages::query::{FetchResult, ListOffsetsResult},
     impl_from_variant,
 };
@@ -71,7 +71,7 @@ pub struct FetchRequest {
 pub struct FetchByIdRequest {
     pub topic_id: u64,
     pub range_id: RangeId,
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub max_bytes: u32,
 }
 
@@ -85,12 +85,12 @@ pub struct RangeOffsetRequest {
 pub enum DataPlaneResponse {
     // Produce
     Produced {
-        entry_id: u64,
+        entry_id: EntryId,
     },
     // Fetch
     Fetched {
         entries: Box<[Entry]>,
-        next_entry_id: u64,
+        next_entry_id: EntryId,
         progress_signal: RangeProgressSignal,
     },
     EntryIdOutOfRange,
@@ -98,8 +98,8 @@ pub enum DataPlaneResponse {
     KeyspaceBoundNarrowed,
 
     RangeOffset {
-        start_entry_id: u64,
-        committed_entry_id: u64,
+        start_entry_id: EntryId,
+        committed_entry_id: EntryId,
     },
     // `NotWriteLeader` is the segment's data-replica write leader (`replica_set[0]`),
     // distinct from the metadata Raft leader (`ControlPlaneResponse::NotRaftLeader`).
@@ -184,7 +184,7 @@ pub struct KeyspaceBound {
 /// parse records from it using `record_count`.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct Entry {
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub data: Vec<u8>,
     pub record_count: u32,
 }
@@ -198,7 +198,7 @@ pub struct Entry {
 pub enum RangeProgressSignal {
     Active,
     Sealed {
-        end_entry_id: u64,
+        end_entry_id: EntryId,
         transition: RangeTransition,
     },
 }

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -10,7 +10,7 @@ use crate::control_plane::consensus::raft::{compute_replacement_replica_set, now
 use crate::control_plane::consensus::seal_recovery::{SealEndRecovery, SealEndStep};
 use crate::control_plane::membership::{ShardGroup, ShardGroupId, TopologyReader};
 use crate::control_plane::metadata::command::RollSegment;
-use crate::control_plane::metadata::{TopicId, TopicMeta, TopicStats};
+use crate::control_plane::metadata::{EntryId, TopicId, TopicMeta, TopicStats};
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::{
     CatchUpAck, SealBoundaryQuery, SealBoundaryReport, SegmentAssignmentAck,
@@ -583,7 +583,7 @@ impl MultiRaft {
         &mut self,
         group_id: ShardGroupId,
         segment_key: SegmentKey,
-        end: Option<u64>,
+        end: Option<EntryId>,
         recency_leader: Option<NodeId>,
     ) {
         let Some(raft) = self.groups.get_mut(&group_id) else {
@@ -898,6 +898,7 @@ mod tests {
     use super::*;
 
     use crate::control_plane::consensus::raft::storage::RaftPersistentState;
+    use crate::control_plane::consensus::seal_recovery;
     use crate::impls::metadata_storage::MetadataStorage;
     use crate::schedulers::ticker_message::TimerCommand;
     use std::collections::BTreeSet;
@@ -1877,12 +1878,12 @@ mod tests {
         store.handle_seal_boundary_report(SealBoundaryReport {
             segment_key: seg0,
             from: node("y"),
-            durable_end: Some(50),
+            durable_end: Some(EntryId(50)),
         });
         store.handle_seal_boundary_report(SealBoundaryReport {
             segment_key: seg0,
             from: node("z"),
-            durable_end: Some(40),
+            durable_end: Some(EntryId(40)),
         });
         store.flush();
 
@@ -1891,7 +1892,7 @@ mod tests {
         assert_eq!(rolls[0].segment_key, seg0);
         assert_eq!(
             rolls[0].end_entry_id,
-            Some(40),
+            Some(EntryId(40)),
             "seal at the min of survivor durable extents"
         );
         assert_eq!(
@@ -1919,7 +1920,7 @@ mod tests {
 
         // No reports ever arrive: each death-driven reconcile re-drives the
         // gather; after the attempt budget it falls back to an unknown-end roll.
-        for _ in 0..(crate::control_plane::consensus::seal_recovery::GATHER_ATTEMPTS + 2) {
+        for _ in 0..(seal_recovery::GATHER_ATTEMPTS + 2) {
             store.handle_node_death(node("x"));
         }
         store.flush();

--- a/src/control_plane/consensus/raft/catch_up.rs
+++ b/src/control_plane/consensus/raft/catch_up.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::control_plane::NodeId;
 use crate::control_plane::membership::ShardGroupId;
+use crate::control_plane::metadata::EntryId;
 use crate::control_plane::metadata::event::SegmentReassigned;
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::CatchUpAssignment;
@@ -18,8 +19,8 @@ use crate::data_plane::transport::command::DataTransportCommand;
 /// `replica_set` is the full set (the assignment carries it so the receiver
 /// picks its own source).
 struct CatchUpRepair {
-    start_entry_id: u64,
-    sealed_end: u64,
+    start_entry_id: EntryId,
+    sealed_end: EntryId,
     replica_set: Vec<NodeId>,
     pending: HashSet<NodeId>,
 }
@@ -51,8 +52,8 @@ impl CatchUpRepairs {
     pub(crate) fn track_sealed(
         &mut self,
         segment_key: SegmentKey,
-        start_entry_id: u64,
-        sealed_end: u64,
+        start_entry_id: EntryId,
+        sealed_end: EntryId,
         replica_set: Vec<NodeId>,
     ) {
         let pending = replica_set.iter().cloned().collect();
@@ -124,8 +125,8 @@ mod tests {
     fn reassigned(members: &[&str], sealed_end: Option<u64>) -> SegmentReassigned {
         SegmentReassigned {
             segment_key: seg(),
-            start_entry_id: 0,
-            sealed_end,
+            start_entry_id: 0.into(),
+            sealed_end: sealed_end.map(EntryId),
             new_replica_set: members.iter().map(|n| node(n)).collect(),
         }
     }
@@ -167,7 +168,7 @@ mod tests {
             panic!("expected CatchUpAssignment");
         };
         assert_eq!(a.shard_group_id, ShardGroupId(7));
-        assert_eq!(a.sealed_end_entry_id, 100);
+        assert_eq!(a.sealed_end_entry_id, EntryId(100));
         assert_eq!(a.replica_set.len(), 3);
     }
 

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -13,8 +13,8 @@ use crate::control_plane::metadata::command::DeleteSegments;
 use crate::control_plane::metadata::event::ApplyResult;
 use crate::control_plane::metadata::state_machine::MetadataStateMachine;
 use crate::control_plane::metadata::{
-    MetadataCommand, RangeId, ReassignSegment, ReplicaSet, RollSegment, SegmentId, TopicId,
-    TopicMeta, TopicStats,
+    EntryId, MetadataCommand, RangeId, ReassignSegment, ReplicaSet, RollSegment, SegmentId,
+    TopicId, TopicMeta, TopicStats,
 };
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::{CatchUpAck, SegmentAssignment, SegmentAssignmentAck};
@@ -216,7 +216,7 @@ impl Raft {
     /// Every active segment's assignment tuple `(key, replica_set, start_offset)`.
     /// The leader's confirmation-gated assignment sweep (`MultiRaft::build_redrive_cmds`)
     /// turns these into `SegmentAssignment` re-drives for unconfirmed segments.
-    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, EntryId)]> {
         self.state_machine.active_segment_assignments()
     }
 
@@ -713,7 +713,7 @@ impl Raft {
         leader_dead && (dead == 1)
     }
 
-    pub(crate) fn has_topic(&self, topic_id: &crate::control_plane::metadata::TopicId) -> bool {
+    pub(crate) fn has_topic(&self, topic_id: &TopicId) -> bool {
         self.state_machine.get_topic(topic_id).is_some()
     }
 
@@ -3808,7 +3808,7 @@ mod tests {
                 segment_key: seg0,
                 sealed_at: 2000,
                 new_replica_set: vec![node("node-1")],
-                end_entry_id: Some(100),
+                end_entry_id: Some(100.into()),
             })
             .into(),
         )
@@ -3882,7 +3882,7 @@ mod tests {
                 segment_key: seg0,
                 sealed_at: 2000,
                 new_replica_set: sealed_set,
-                end_entry_id: Some(100),
+                end_entry_id: Some(100.into()),
             })
             .into(),
         )
@@ -4011,7 +4011,7 @@ mod tests {
                 segment_key: seg0,
                 sealed_at: 2000,
                 new_replica_set: vec![node("node-1")],
-                end_entry_id: Some(100),
+                end_entry_id: Some(100.into()),
             })
             .into(),
         )
@@ -4067,8 +4067,8 @@ mod tests {
         for (_, a) in &redrives {
             assert_eq!(a.segment_key, seg0);
             assert_eq!(a.shard_group_id, TEST_SHARD);
-            assert_eq!(a.start_entry_id, 0);
-            assert_eq!(a.sealed_end_entry_id, 100);
+            assert_eq!(a.start_entry_id, 0.into());
+            assert_eq!(a.sealed_end_entry_id, 100.into());
             assert_eq!(a.replica_set, members);
         }
     }
@@ -4097,7 +4097,7 @@ mod tests {
         let redrives = drain_catch_up_redrives(&mut raft);
         for (_, a) in &redrives {
             assert_eq!(a.segment_key, seg0);
-            assert_eq!(a.sealed_end_entry_id, 100);
+            assert_eq!(a.sealed_end_entry_id, 100.into());
         }
         let mut targets: Vec<NodeId> = redrives.iter().map(|(t, _)| t.clone()).collect();
         targets.sort();

--- a/src/control_plane/consensus/seal_recovery.rs
+++ b/src/control_plane/consensus/seal_recovery.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, HashSet};
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::raft::state::LeaderlessSegments;
 use crate::control_plane::membership::ShardGroupId;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 
 /// How many drive passes a gather waits for every survivor to report before
@@ -33,7 +34,7 @@ pub(crate) enum SealEndStep {
     Seal {
         shard_group_id: ShardGroupId,
         segment_key: SegmentKey,
-        end: Option<u64>,
+        end: Option<EntryId>,
         leader: Option<NodeId>,
     },
 }
@@ -45,7 +46,7 @@ struct SealEndGather {
     /// Survivors we await, in replica-set order.
     nodes: Vec<NodeId>,
     /// Durable extents reported so far (`None` = the survivor holds nothing).
-    reports: HashMap<NodeId, Option<u64>>,
+    reports: HashMap<NodeId, Option<EntryId>>,
     /// Re-drive budget; the roll falls back to an unknown end when it hits 0.
     attempts_left: u32,
     /// True once the roll is proposed — the gather then waits (ignoring late
@@ -68,7 +69,7 @@ impl SealEndGather {
         self.nodes.contains(node)
     }
 
-    fn record(&mut self, from: NodeId, durable_end: Option<u64>) {
+    fn record(&mut self, from: NodeId, durable_end: Option<EntryId>) {
         self.reports.insert(from, durable_end);
     }
 
@@ -89,14 +90,14 @@ impl SealEndGather {
     /// highest offset present on *every* survivor, hence committed (commit
     /// requires all-replica ack). `None` if any survivor holds nothing (nothing
     /// was committed) or none reported.
-    fn recovered_end(&self) -> Option<u64> {
+    fn recovered_end(&self) -> Option<EntryId> {
         if self.reports.is_empty() {
             return None;
         }
         let mut min = None;
         for extent in self.reports.values() {
             let extent = (*extent)?; // a survivor holding nothing ⇒ nothing committed
-            min = Some(min.map_or(extent, |m: u64| m.min(extent)));
+            min = Some(min.map_or(extent, |m: EntryId| m.min(extent)));
         }
         min
     }
@@ -105,7 +106,7 @@ impl SealEndGather {
     /// `NodeId` for determinism — to lead the rolled segment. `None` when no
     /// survivor reported any data.
     fn recency_leader(&self) -> Option<NodeId> {
-        let mut ranked: Vec<(u64, &NodeId)> = self
+        let mut ranked: Vec<(EntryId, &NodeId)> = self
             .reports
             .iter()
             .filter_map(|(node, extent)| extent.map(|e| (e, node)))
@@ -193,7 +194,7 @@ impl SealEndRecovery {
         &mut self,
         segment_key: SegmentKey,
         from: NodeId,
-        durable_end: Option<u64>,
+        durable_end: Option<EntryId>,
     ) -> Option<SealEndStep> {
         let g = self.gathers.get_mut(&segment_key)?;
         if g.proposed || !g.awaits(&from) {
@@ -255,7 +256,7 @@ impl SealEndRecovery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+    use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 
     fn node(id: &str) -> NodeId {
         NodeId::new(id)
@@ -265,7 +266,7 @@ mod tests {
         let nodes = reports.iter().map(|(n, _)| node(n)).collect();
         let mut g = SealEndGather::new(ShardGroupId(0), nodes);
         for (n, end) in reports {
-            g.record(node(n), *end);
+            g.record(node(n), end.map(EntryId));
         }
         g
     }
@@ -274,7 +275,7 @@ mod tests {
     fn recovered_end_is_min_of_survivor_extents() {
         assert_eq!(
             gather_with(&[("y", Some(50)), ("z", Some(40))]).recovered_end(),
-            Some(40)
+            Some(EntryId(40))
         );
     }
 
@@ -336,16 +337,16 @@ mod tests {
         let mut recovery = SealEndRecovery::default();
         recovery.advance(ShardGroupId(1), vec![(seg, vec![node("y"), node("z")])]);
 
-        assert!(recovery.record(seg, node("y"), Some(50)).is_none()); // partial
+        assert!(recovery.record(seg, node("y"), Some(EntryId(50))).is_none()); // partial
         let step = recovery
-            .record(seg, node("z"), Some(40))
+            .record(seg, node("z"), Some(EntryId(40)))
             .expect("completes");
         assert!(matches!(
             step,
-            SealEndStep::Seal { end: Some(40), leader: Some(l), .. } if l == node("y")
+            SealEndStep::Seal { end: Some(EntryId(40)), leader: Some(l), .. } if l == node("y")
         ));
         // A late/duplicate report after the roll is proposed is ignored.
-        assert!(recovery.record(seg, node("y"), Some(99)).is_none());
+        assert!(recovery.record(seg, node("y"), Some(EntryId(99))).is_none());
     }
 
     #[test]

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -67,6 +67,7 @@ impl RaftTransportActor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::control_plane::consensus::actor::MultiRaftActor;
     use crate::control_plane::consensus::messages::{RaftRpc, RequestVote, WireRaftMessage};
     use crate::control_plane::membership::ShardGroupId;
     use crate::net::OwnedWriteHalf;
@@ -174,8 +175,7 @@ mod tests {
             .build();
 
         sim.host("acceptor", || async {
-            let (raft_tx, _raft_rx) =
-                crate::control_plane::consensus::actor::MultiRaftActor::channel(16);
+            let (raft_tx, _raft_rx) = MultiRaftActor::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
             let (dial_tx, _dial_rx) = tokio::sync::mpsc::channel(8);
             let mut state = RaftRpcDispatcher::new(NodeId::new("node-b"), dial_tx);
@@ -212,8 +212,7 @@ mod tests {
             .build();
 
         sim.host("node-b", || async {
-            let (raft_tx, _raft_rx) =
-                crate::control_plane::consensus::actor::MultiRaftActor::channel(16);
+            let (raft_tx, _raft_rx) = MultiRaftActor::channel(16);
             let listener = TcpListener::bind("0.0.0.0:9000").await?;
             let dummy_listener = TcpListener::bind("0.0.0.0:9001").await?;
             let (dial_tx, _dial_rx) = tokio::sync::mpsc::channel(8);

--- a/src/control_plane/membership/tests.rs
+++ b/src/control_plane/membership/tests.rs
@@ -7,7 +7,7 @@ use crate::control_plane::membership::actor::SwimActor;
 use crate::control_plane::membership::peer_discovery::JoinConfig;
 use crate::control_plane::membership::swim::Swim;
 use crate::control_plane::membership::{
-    DIRECT_ACK_TIMEOUT_TICKS, OutboundPacket, QueryCommand, SwimActorCommand, SwimCommand,
+    self, DIRECT_ACK_TIMEOUT_TICKS, OutboundPacket, QueryCommand, SwimActorCommand, SwimCommand,
     SwimHeader, SwimPacket, SwimTimer, Topology, TopologyConfig,
 };
 use crate::control_plane::{NodeAddress, NodeId, SwimNode, SwimNodeState};
@@ -165,8 +165,7 @@ async fn setup_with_config(port: u32, join_config: JoinConfig) -> TestHarness {
 
     // Topology publish/read channel — this harness has no reader-side
     // consumer, but SwimActor still needs the writer half to publish into.
-    let (topology_pub, _topology_reader) =
-        crate::control_plane::membership::topology_channel(swim.topology.clone());
+    let (topology_pub, _topology_reader) = membership::topology_channel(swim.topology.clone());
 
     let ticker_tx = spawn_scheduling_actor(
         tx_in.clone(),

--- a/src/control_plane/metadata/command.rs
+++ b/src/control_plane/metadata/command.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate::{
     control_plane::{
         NodeId,
-        metadata::{RangeId, SegmentId, TopicId, strategy::StoragePolicy},
+        metadata::{EntryId, RangeId, SegmentId, TopicId, strategy::StoragePolicy},
     },
     data_plane::SegmentKey,
     impl_from_variant,
@@ -25,7 +25,7 @@ pub struct RollSegment {
     /// None for SWIM-death-triggered seals — the coordinator doesn't know
     /// the actual committed offset. Corrected later via `correct_end_offset`
     /// or D5 sealed segment repair.
-    pub end_entry_id: Option<u64>,
+    pub end_entry_id: Option<EntryId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]

--- a/src/control_plane/metadata/event.rs
+++ b/src/control_plane/metadata/event.rs
@@ -1,7 +1,7 @@
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::multi_raft::SealContext;
 use crate::control_plane::membership::ShardGroupId;
-use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::{
     CatchUpAssignment, DeleteSegments, SealResponse, SegmentAssignment, SegmentSealed,
@@ -22,7 +22,7 @@ impl TopicCreated {
                 segment_key: self.segment_key,
                 shard_group_id,
                 replica_set: self.replica_set,
-                start_entry_id: 0,
+                start_entry_id: EntryId::MIN,
             },
         )
     }
@@ -32,7 +32,7 @@ impl TopicCreated {
 pub struct SegmentRolled {
     pub new_segment_key: SegmentKey,
     pub new_replica_set: Vec<NodeId>,
-    pub end_entry_id: Option<u64>,
+    pub end_entry_id: Option<EntryId>,
 }
 
 impl SegmentRolled {
@@ -41,7 +41,7 @@ impl SegmentRolled {
         ctx: Option<SealContext>,
         shard_group_id: ShardGroupId,
     ) -> Vec<DataTransportCommand> {
-        let start = self.end_entry_id.map_or(0, |id| id + 1);
+        let start = self.end_entry_id.map_or(EntryId::MIN, |id| id + 1);
         let mut v = vec![DataTransportCommand::send_to_targets(
             vec![self.new_replica_set[0].clone()],
             SegmentAssignment {
@@ -69,11 +69,11 @@ impl SegmentRolled {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentReassigned {
     pub segment_key: SegmentKey,
-    pub start_entry_id: u64,
+    pub start_entry_id: EntryId,
     /// Committed end = the catch-up target. `None` only for a segment whose end
     /// was never established; those aren't selected for reassignment, so the
     /// dispatch just emits nothing.
-    pub sealed_end: Option<u64>,
+    pub sealed_end: Option<EntryId>,
     pub new_replica_set: Vec<NodeId>,
 }
 
@@ -120,7 +120,7 @@ impl RangeSplit {
                         segment_key: SegmentKey::new(self.topic_id, range_id, segment_id),
                         shard_group_id,
                         replica_set,
-                        start_entry_id: 0,
+                        start_entry_id: EntryId::MIN,
                     },
                 )
             })
@@ -158,7 +158,7 @@ impl RangeMerged {
                 segment_key: self.segment_key,
                 shard_group_id,
                 replica_set: self.replica_set,
-                start_entry_id: 0,
+                start_entry_id: EntryId::MIN,
             },
         )
     }
@@ -193,7 +193,7 @@ impl SegmentsDeleted {
 pub struct SegmentSealCorrected {
     pub segment_key: SegmentKey,
     pub replica_set: Vec<NodeId>,
-    pub committed_entry_id: Option<u64>,
+    pub committed_entry_id: Option<EntryId>,
 }
 
 impl SegmentSealCorrected {

--- a/src/control_plane/metadata/mod.rs
+++ b/src/control_plane/metadata/mod.rs
@@ -36,7 +36,7 @@ pub struct SegmentId(pub(crate) u64);
 
 smart_pointer!(SegmentId, u64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Ser, Deser)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Ser, Deser)]
 pub struct EntryId(pub u64);
 
 smart_pointer!(EntryId, u64);

--- a/src/control_plane/metadata/mod.rs
+++ b/src/control_plane/metadata/mod.rs
@@ -4,25 +4,21 @@ pub mod constants;
 pub mod error;
 pub(crate) mod event;
 pub(crate) mod range;
-#[allow(dead_code)]
+
 pub(crate) mod state_machine;
 pub mod strategy;
 pub(crate) mod topic;
 
 pub(crate) use range::{RangeMeta, RangeState};
 pub(crate) use topic::{TopicMeta, TopicState, TopicStats};
-#[allow(dead_code)]
+
 pub(crate) mod segment;
 
 use borsh::{BorshDeserialize as Deser, BorshSerialize as Ser};
-#[allow(unused_imports)]
+
 pub(crate) use command::*;
-#[allow(unused_imports)]
-pub(crate) use event::*;
-#[allow(unused_imports)]
+
 pub(crate) use segment::*;
-#[allow(unused_imports)]
-pub(crate) use state_machine::*;
 
 use crate::smart_pointer;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Ser, Deser)]
@@ -39,3 +35,127 @@ smart_pointer!(RangeId, u64);
 pub struct SegmentId(pub(crate) u64);
 
 smart_pointer!(SegmentId, u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Ser, Deser)]
+pub struct EntryId(pub u64);
+
+smart_pointer!(EntryId, u64);
+
+impl EntryId {
+    pub const MIN: EntryId = EntryId(0);
+    pub const MAX: EntryId = EntryId(u64::MAX);
+
+    pub fn saturating_sub(self, rhs: u64) -> Self {
+        EntryId(self.0.saturating_sub(rhs))
+    }
+
+    pub fn saturating_add(self, rhs: u64) -> Self {
+        EntryId(self.0.saturating_add(rhs))
+    }
+}
+
+impl std::fmt::Display for EntryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for EntryId {
+    fn from(val: u64) -> Self {
+        EntryId(val)
+    }
+}
+
+impl From<EntryId> for u64 {
+    fn from(val: EntryId) -> Self {
+        val.0
+    }
+}
+
+impl std::ops::Add<u64> for EntryId {
+    type Output = Self;
+    fn add(self, rhs: u64) -> Self::Output {
+        EntryId(self.0 + rhs)
+    }
+}
+
+impl std::ops::Add<usize> for EntryId {
+    type Output = Self;
+    fn add(self, rhs: usize) -> Self::Output {
+        EntryId(self.0 + rhs as u64)
+    }
+}
+
+impl std::ops::Add<EntryId> for EntryId {
+    type Output = Self;
+    fn add(self, rhs: EntryId) -> Self::Output {
+        EntryId(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::AddAssign<u64> for EntryId {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs;
+    }
+}
+
+impl std::ops::AddAssign<usize> for EntryId {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0 += rhs as u64;
+    }
+}
+
+impl std::ops::Sub<u64> for EntryId {
+    type Output = Self;
+    fn sub(self, rhs: u64) -> Self::Output {
+        EntryId(self.0 - rhs)
+    }
+}
+
+impl std::ops::Sub<usize> for EntryId {
+    type Output = Self;
+    fn sub(self, rhs: usize) -> Self::Output {
+        EntryId(self.0 - rhs as u64)
+    }
+}
+
+impl std::ops::Sub<EntryId> for EntryId {
+    type Output = Self;
+    fn sub(self, rhs: EntryId) -> Self::Output {
+        EntryId(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::SubAssign<u64> for EntryId {
+    fn sub_assign(&mut self, rhs: u64) {
+        self.0 -= rhs;
+    }
+}
+
+impl std::ops::SubAssign<usize> for EntryId {
+    fn sub_assign(&mut self, rhs: usize) {
+        self.0 -= rhs as u64;
+    }
+}
+
+impl std::ops::Add<i32> for EntryId {
+    type Output = Self;
+    fn add(self, rhs: i32) -> Self::Output {
+        if rhs >= 0 {
+            EntryId(self.0 + rhs as u64)
+        } else {
+            EntryId(self.0 - (-rhs) as u64)
+        }
+    }
+}
+
+impl std::ops::Sub<i32> for EntryId {
+    type Output = Self;
+    fn sub(self, rhs: i32) -> Self::Output {
+        if rhs >= 0 {
+            EntryId(self.0 - rhs as u64)
+        } else {
+            EntryId(self.0 + (-rhs) as u64)
+        }
+    }
+}

--- a/src/control_plane/metadata/range.rs
+++ b/src/control_plane/metadata/range.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use std::collections::{HashMap, VecDeque};
 
 use crate::control_plane::metadata::{
-    RangeId, ReplicaSet, SegmentId, SegmentMeta, SegmentMetaState, SplitRange,
+    EntryId, RangeId, ReplicaSet, SegmentId, SegmentMeta, SegmentMetaState, SplitRange,
     command::{MetadataCommand, RollSegment},
     error::MetadataError,
 };
@@ -24,7 +24,7 @@ pub struct RangeMeta {
     pub active_segment: Option<SegmentId>,
     pub segments: HashMap<SegmentId, SegmentMeta>,
     pub next_segment_id: u64,
-    pub next_offset: u64,
+    pub next_offset: EntryId,
     pub split_into: Option<[RangeId; 2]>,
     pub merged_into: Option<RangeId>,
     pub merged_from: Option<[RangeId; 2]>,
@@ -40,7 +40,7 @@ impl RangeMeta {
         created_at: u64,
     ) -> Self {
         let segment_id = SegmentId(0);
-        let segment = SegmentMeta::new(segment_id, replica_set, 0, created_at);
+        let segment = SegmentMeta::new(segment_id, replica_set, EntryId::MIN, created_at);
 
         RangeMeta {
             range_id,
@@ -50,7 +50,7 @@ impl RangeMeta {
             active_segment: Some(segment_id),
             segments: HashMap::from([(segment_id, segment)]),
             next_segment_id: 1,
-            next_offset: 0,
+            next_offset: EntryId::MIN,
             split_into: None,
             merged_into: None,
             merged_from: None,
@@ -113,7 +113,7 @@ impl RangeMeta {
     pub(crate) fn correct_end_offset(
         &mut self,
         segment_id: SegmentId,
-        end_entry_id: u64,
+        end_entry_id: EntryId,
     ) -> Option<ReplicaSet> {
         let seg = self.segments.get_mut(&segment_id)?;
 
@@ -162,7 +162,7 @@ impl RangeMeta {
             .ok_or(MetadataError::SegmentNotFound)?;
         segment.seal(cmd.end_entry_id, cmd.sealed_at)?;
 
-        let start_offset = cmd.end_entry_id.map_or(0, |id| id + 1);
+        let start_offset = cmd.end_entry_id.map_or(EntryId::MIN, |id| id + 1);
         let new_segment_id = SegmentId(self.next_segment_id);
         let new_segment = SegmentMeta::new(
             new_segment_id,

--- a/src/control_plane/metadata/segment.rs
+++ b/src/control_plane/metadata/segment.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::control_plane::{
     NodeId,
-    metadata::{SegmentId, error::MetadataError},
+    metadata::{EntryId, SegmentId, error::MetadataError},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -19,8 +19,8 @@ pub struct SegmentMeta {
     pub state: SegmentMetaState,
     pub replica_set: ReplicaSet,
     pub size_bytes: u64,
-    pub start_entry_id: u64,
-    pub end_entry_id: Option<u64>,
+    pub start_entry_id: EntryId,
+    pub end_entry_id: Option<EntryId>,
     pub created_at: u64,
     pub sealed_at: Option<u64>,
 }
@@ -29,7 +29,7 @@ impl SegmentMeta {
     pub(crate) fn new(
         segment_id: SegmentId,
         replica_set: ReplicaSet,
-        start_entry_id: u64,
+        start_entry_id: EntryId,
         created_at: u64,
     ) -> Self {
         SegmentMeta {
@@ -45,7 +45,7 @@ impl SegmentMeta {
     }
     pub(crate) fn seal(
         &mut self,
-        end_entry_id: Option<u64>,
+        end_entry_id: Option<EntryId>,
         sealed_at: u64,
     ) -> Result<(), MetadataError> {
         if self.state != SegmentMetaState::Active {

--- a/src/control_plane/metadata/state_machine.rs
+++ b/src/control_plane/metadata/state_machine.rs
@@ -3,7 +3,8 @@ use super::event::*;
 use super::segment::*;
 use super::topic::{TopicMeta, TopicState, TopicStats};
 use crate::control_plane::NodeId;
-use crate::control_plane::metadata::{RangeId, SegmentId, TopicId, error::MetadataError};
+use crate::control_plane::membership::ShardGroupId;
+use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId, error::MetadataError};
 use crate::data_plane::SegmentKey;
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
@@ -18,7 +19,7 @@ pub struct MetadataStateMachine {
 }
 
 impl MetadataStateMachine {
-    pub(crate) fn new(shard_group_id: crate::control_plane::membership::ShardGroupId) -> Self {
+    pub(crate) fn new(shard_group_id: ShardGroupId) -> Self {
         MetadataStateMachine {
             topics: HashMap::new(),
             topic_name_index: HashMap::new(),
@@ -41,7 +42,8 @@ impl MetadataStateMachine {
         self.topic_name_index.keys().cloned().collect()
     }
 
-    pub(crate) fn topic_count(&self) -> usize {
+    #[cfg(test)]
+    pub fn topic_count(&self) -> usize {
         self.topics.len()
     }
 
@@ -65,7 +67,7 @@ impl MetadataStateMachine {
 
     /// Every active segment across all topics with its replica set and start
     /// offset, for the leader's periodic assignment re-drive.
-    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, EntryId)]> {
         self.topics
             .values()
             .flat_map(|t| t.active_segment_assignments())
@@ -412,7 +414,7 @@ mod tests {
             segment_key: SegmentKey::new(topic_id, RangeId(0), segment_id),
             sealed_at,
             new_replica_set: replica_set(),
-            end_entry_id: Some(end_entry_id),
+            end_entry_id: Some(EntryId(end_entry_id)),
         }));
         assert!(matches!(result.unwrap(), ApplyResult::SegmentRolled(_)));
     }
@@ -734,10 +736,10 @@ mod tests {
 
         let topic = sm.get_topic(&id).unwrap();
         let range = &topic.ranges[&RangeId(0)];
-        assert_eq!(range.next_offset, 0);
+        assert_eq!(range.next_offset, EntryId(0));
 
         let seg = &range.segments[&SegmentId(0)];
-        assert_eq!(seg.start_entry_id, 0);
+        assert_eq!(seg.start_entry_id, EntryId(0));
         assert_eq!(seg.end_entry_id, None);
     }
 
@@ -1346,23 +1348,23 @@ mod tests {
             segment_key: SegmentKey::new(tid, RangeId(0), SegmentId(0)),
             sealed_at: 2000,
             new_replica_set: replica_set(),
-            end_entry_id: Some(42000),
+            end_entry_id: Some(EntryId(42000)),
         }));
 
         let result = result.unwrap();
         assert!(matches!(
             result,
             ApplyResult::SegmentRolled(SegmentRolled {
-                end_entry_id: Some(42000),
+                end_entry_id: Some(EntryId(42000)),
                 ..
             })
         ));
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
         let sealed = &range.segments[&SegmentId(0)];
-        assert_eq!(sealed.end_entry_id, Some(42000));
+        assert_eq!(sealed.end_entry_id, Some(EntryId(42000)));
         let new_seg = &range.segments[&SegmentId(1)];
-        assert_eq!(new_seg.start_entry_id, 42001);
+        assert_eq!(new_seg.start_entry_id, EntryId(42001));
     }
 
     // --- D3: end-offset correction ---
@@ -1390,13 +1392,16 @@ mod tests {
             segment_key: SegmentKey::new(tid, RangeId(0), SegmentId(0)),
             sealed_at: 2500,
             new_replica_set: replica_set(),
-            end_entry_id: Some(42000),
+            end_entry_id: Some(EntryId(42000)),
         }));
         assert!(result.is_ok());
 
         let range = &sm.get_topic(&tid).unwrap().ranges[&RangeId(0)];
-        assert_eq!(range.segments[&SegmentId(0)].end_entry_id, Some(42000));
-        assert_eq!(range.segments[&SegmentId(1)].start_entry_id, 42001);
+        assert_eq!(
+            range.segments[&SegmentId(0)].end_entry_id,
+            Some(EntryId(42000))
+        );
+        assert_eq!(range.segments[&SegmentId(1)].start_entry_id, EntryId(42001));
     }
 
     #[test]
@@ -1409,7 +1414,7 @@ mod tests {
             segment_key: SegmentKey::new(tid, RangeId(0), SegmentId(0)),
             sealed_at: 2000,
             new_replica_set: replica_set(),
-            end_entry_id: Some(1000),
+            end_entry_id: Some(EntryId(1000)),
         }));
 
         // Duplicate roll is rejected (end_offset already set)
@@ -1417,7 +1422,7 @@ mod tests {
             segment_key: SegmentKey::new(tid, RangeId(0), SegmentId(0)),
             sealed_at: 2500,
             new_replica_set: replica_set(),
-            end_entry_id: Some(42000),
+            end_entry_id: Some(EntryId(42000)),
         }));
         assert_eq!(result, Ok(ApplyResult::Noop));
     }

--- a/src/control_plane/metadata/topic.rs
+++ b/src/control_plane/metadata/topic.rs
@@ -122,7 +122,7 @@ impl TopicMeta {
     /// the leader's periodic assignment re-drive. Returns `(key, replica_set,
     /// start_offset)` so a re-driven `SegmentAssignment` can recreate a segment
     /// that missed its one-shot delivery with the correct starting offset.
-    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, u64)]> {
+    pub(crate) fn active_segment_assignments(&self) -> Box<[(SegmentKey, ReplicaSet, EntryId)]> {
         if self.state != TopicState::Active {
             return Box::new([]);
         }
@@ -215,7 +215,7 @@ impl TopicMeta {
     /// Every known-end sealed segment, with the data a `CatchUpAssignment` needs.
     /// The takeover reseed (raft-actor.md #9) tracks these so a repair in flight
     /// when leadership changed isn't stranded.
-    pub(crate) fn known_end_sealed_segments(&self) -> Vec<(SegmentKey, u64, u64, ReplicaSet)> {
+    pub(crate) fn known_end_sealed_segments(&self) -> Vec<(SegmentKey, EntryId, EntryId, ReplicaSet)> {
         let mut out = Vec::new();
         for range in self.ranges.values() {
             for seg in range.segments.values() {

--- a/src/data_plane/cold_read.rs
+++ b/src/data_plane/cold_read.rs
@@ -12,6 +12,7 @@ use super::states::segment::cache::CachedEntry;
 use super::wal::{WalRecord, WalRecordType};
 use crate::connections::protocol::RangeProgressSignal;
 use crate::control_plane::NodeId;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::messages::command::CatchUpReadComplete;
 use crate::data_plane::messages::query::FetchResult;
 
@@ -31,10 +32,10 @@ pub(crate) struct ColdReadRequest {
     pub(crate) segment_key: SegmentKey,
     pub(crate) segment_file_path: PathBuf,
     /// First entry id wanted (inclusive).
-    pub(crate) start_entry_offset: u64,
+    pub(crate) start_entry_offset: EntryId,
     /// Last entry id stored in this sealed segment (inclusive). Reads never
     /// cross past this even if the file has a trailing partial write.
-    pub(crate) end_entry_id: u64,
+    pub(crate) end_entry_id: EntryId,
     pub(crate) max_bytes: u64,
     pub(crate) reply: ColdReadReply,
 }
@@ -54,8 +55,8 @@ pub(crate) struct CatchUpReadReply {
     pub(crate) requester: NodeId,
     /// Echoed into `CatchUpReadComplete` so the worker can re-arm the next read
     /// and decide when the sealed end is reached.
-    pub(crate) start_offset: u64,
-    pub(crate) sealed_end: u64,
+    pub(crate) start_offset: EntryId,
+    pub(crate) sealed_end: EntryId,
     pub(crate) mailbox: DataPlaneSender,
 }
 
@@ -63,7 +64,7 @@ pub(crate) struct CatchUpReadReply {
 /// and per-entry `record_count` (restored from the on-disk `WalRecord`).
 pub(crate) struct ColdReadRecords {
     entries: Vec<Arc<CachedEntry>>,
-    next_offset: u64,
+    next_offset: EntryId,
 }
 
 pub(crate) struct ColdReadPool;
@@ -183,7 +184,7 @@ impl ColdReadPool {
         sparse_index: &dyn SparseIndex,
     ) -> Result<ColdReadRecords, ColdReadError> {
         let (anchor_id, byte_position) =
-            sparse_index.seek_index(req.segment_key, req.start_entry_offset);
+            sparse_index.seek_index(req.segment_key, *req.start_entry_offset);
 
         let file = File::open(&req.segment_file_path).map_err(ColdReadError::FileOpen)?;
         let file_len = file.metadata()?.len();
@@ -192,7 +193,7 @@ impl ColdReadPool {
         reader.seek(SeekFrom::Start(byte_position))?;
 
         let mut entries: Vec<Arc<CachedEntry>> = Vec::new();
-        let mut current_offset = anchor_id;
+        let mut current_offset = EntryId(anchor_id);
         let mut next_offset = req.start_entry_offset;
         let mut bytes_read = 0u64;
 
@@ -220,7 +221,7 @@ impl ColdReadPool {
                 WalRecordType::BatchEnd => continue,
                 WalRecordType::Data => {
                     let entry_id = current_offset;
-                    current_offset += 1;
+                    current_offset += 1u64;
 
                     if entry_id < req.start_entry_offset {
                         continue;
@@ -237,7 +238,7 @@ impl ColdReadPool {
                     }
 
                     bytes_read += payload_len;
-                    next_offset = entry_id + 1;
+                    next_offset = entry_id + 1u64;
                     entries.push(Arc::new(CachedEntry {
                         data: record.payload.into(),
                         record_count: record.record_count,
@@ -345,8 +346,8 @@ mod tests {
         ColdReadRequest {
             segment_key: key(),
             segment_file_path: path,
-            start_entry_offset: start_offset,
-            end_entry_id,
+            start_entry_offset: EntryId(start_offset),
+            end_entry_id: EntryId(end_entry_id),
             max_bytes,
             reply: ColdReadReply::Consumer {
                 reply,
@@ -375,9 +376,9 @@ mod tests {
         let out = ColdReadPool::process_request(&req, &idx).unwrap();
 
         assert_eq!(out.entries.len(), 1);
-        assert_eq!(out.entries[0].entry_id, 4);
+        assert_eq!(out.entries[0].entry_id, EntryId(4));
         assert_eq!(out.entries[0].data.to_vec(), b"e4".to_vec());
-        assert_eq!(out.next_offset, 5);
+        assert_eq!(out.next_offset, EntryId(5));
     }
 
     #[test]
@@ -391,11 +392,11 @@ mod tests {
         let out = ColdReadPool::process_request(&req, &idx).unwrap();
 
         assert_eq!(out.entries.len(), 3, "BatchEnd must not end the stream");
-        assert_eq!(out.next_offset, 3);
+        assert_eq!(out.next_offset, EntryId(3));
         let got: Vec<(u64, u32, Vec<u8>)> = out
             .entries
             .iter()
-            .map(|e| (e.entry_id, e.record_count, e.data.to_vec()))
+            .map(|e| (*e.entry_id, e.record_count, e.data.to_vec()))
             .collect();
         assert_eq!(
             got,
@@ -418,8 +419,8 @@ mod tests {
         let out = ColdReadPool::process_request(&req, &idx).unwrap();
 
         assert_eq!(out.entries.len(), 1, "always include at least one entry");
-        assert_eq!(out.entries[0].entry_id, 0);
-        assert_eq!(out.next_offset, 1);
+        assert_eq!(out.entries[0].entry_id, EntryId(0));
+        assert_eq!(out.next_offset, EntryId(1));
     }
 
     #[test]
@@ -433,8 +434,8 @@ mod tests {
         let out = ColdReadPool::process_request(&req, &idx).unwrap();
 
         assert_eq!(out.entries.len(), 2);
-        assert_eq!(out.entries.last().unwrap().entry_id, 1);
-        assert_eq!(out.next_offset, 2);
+        assert_eq!(out.entries.last().unwrap().entry_id, EntryId(1));
+        assert_eq!(out.next_offset, EntryId(2));
     }
 
     #[test]
@@ -450,9 +451,9 @@ mod tests {
         let got: Vec<(u64, u32)> = out
             .entries
             .iter()
-            .map(|e| (e.entry_id, e.record_count))
+            .map(|e| (*e.entry_id, e.record_count))
             .collect();
         assert_eq!(got, vec![(1, 2), (2, 3)]);
-        assert_eq!(out.next_offset, 3);
+        assert_eq!(out.next_offset, EntryId(3));
     }
 }

--- a/src/data_plane/messages/command.rs
+++ b/src/data_plane/messages/command.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot;
 use crate::{
     control_plane::NodeId,
     control_plane::membership::ShardGroupId,
-    control_plane::metadata::SegmentId,
+    control_plane::metadata::{EntryId, SegmentId},
     data_plane::states::segment::cache::CachedEntry,
     data_plane::{EntryPayload, SegmentKey, timer::DataPlaneTimeoutCallback},
 };
@@ -49,7 +49,7 @@ pub struct SegmentAssignment {
     pub segment_key: SegmentKey,
     pub shard_group_id: ShardGroupId,
     pub replica_set: Vec<NodeId>,
-    pub start_entry_id: u64,
+    pub start_entry_id: EntryId,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -65,20 +65,20 @@ pub struct ReplicaAppend {
     pub replica_set: Vec<NodeId>,
     pub data: EntryPayload,
     pub record_count: u32,
-    pub entry_id: u64,
+    pub entry_id: EntryId,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct ReplicaAck {
     pub segment_key: SegmentKey,
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub from: NodeId,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct CommitAdvance {
     pub segment_key: SegmentKey,
-    pub committed_entry_id: u64,
+    pub committed_entry_id: EntryId,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -86,7 +86,7 @@ pub struct SealRequest {
     pub from: NodeId,
     pub segment_key: SegmentKey,
     pub failed_nodes: Vec<NodeId>,
-    pub end_entry_id: u64,
+    pub end_entry_id: EntryId,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -99,7 +99,7 @@ pub struct SealResponse {
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SegmentSealed {
     pub segment_key: SegmentKey,
-    pub committed_entry_id: Option<u64>,
+    pub committed_entry_id: Option<EntryId>,
 }
 
 // Catch-up: re-replicate a sealed segment to a newly assigned replica.
@@ -121,8 +121,8 @@ pub struct CatchUpAssignment {
     pub segment_key: SegmentKey,
     /// Echoed into the `CatchUpAck` so the reply reaches this group's coordinator.
     pub shard_group_id: ShardGroupId,
-    pub start_entry_id: u64,
-    pub sealed_end_entry_id: u64,
+    pub start_entry_id: EntryId,
+    pub sealed_end_entry_id: EntryId,
     pub replica_set: Vec<NodeId>,
 }
 
@@ -133,7 +133,7 @@ pub struct CatchUpRequest {
     pub from: NodeId,
     /// Highest entry id the requester already holds locally; the source streams
     /// `(local_end, sealed_end]`. `None` means nothing is held.
-    pub local_end: Option<u64>,
+    pub local_end: Option<EntryId>,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -144,7 +144,7 @@ pub struct CatchUpChunk {
 }
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct CatchUpEntry {
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub data: EntryPayload,
     pub record_count: u32,
 }
@@ -198,7 +198,7 @@ pub struct SealBoundaryQuery {
 pub struct SealBoundaryReport {
     pub segment_key: SegmentKey,
     pub from: NodeId,
-    pub durable_end: Option<u64>,
+    pub durable_end: Option<EntryId>,
 }
 
 /// Retention (D7): the coordinator tells replicas to reclaim sealed segments —
@@ -259,7 +259,7 @@ pub enum ProduceAck {
     /// with one request in flight at a time (the common case); under pipelining
     /// it is the segment's committed highwater at ack time (an upper bound).
     Ok {
-        entry_id: u64,
+        entry_id: EntryId,
     },
     Err(String),
 }
@@ -274,10 +274,10 @@ pub struct CheckpointComplete {
 pub struct CatchUpReadComplete {
     pub requester: NodeId,
     pub segment_key: SegmentKey,
-    pub start_offset: u64,
-    pub sealed_end: u64,
+    pub start_offset: EntryId,
+    pub sealed_end: EntryId,
     pub entries: Vec<Arc<CachedEntry>>,
-    pub next_offset: u64,
+    pub next_offset: EntryId,
 }
 
 impl_from_variant!(

--- a/src/data_plane/messages/pending.rs
+++ b/src/data_plane/messages/pending.rs
@@ -4,6 +4,7 @@ use tokio::sync::oneshot;
 use crate::channels::BatchSender;
 use crate::control_plane::consensus::actor::MutlRaftSender;
 use crate::control_plane::consensus::messages::MultiRaftActorCommand;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 use crate::data_plane::checkpoint::{CheckpointJob, CheckpointTask};
 use crate::data_plane::messages::command::ProduceAck;
@@ -26,7 +27,7 @@ pub(crate) struct DataPlaneOutputs {
     pub(crate) coordinator_cmds: Vec<MultiRaftActorCommand>,
     /// `(entry_id, reply)` — the committed offset is paired with each waiting
     /// producer so the `ProduceAck::Ok` carries it back to the client.
-    pub(crate) produce_replies: Vec<(u64, oneshot::Sender<ProduceAck>)>,
+    pub(crate) produce_replies: Vec<(EntryId, oneshot::Sender<ProduceAck>)>,
 }
 
 impl DataPlaneOutputs {

--- a/src/data_plane/messages/query.rs
+++ b/src/data_plane/messages/query.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 
 use crate::connections::protocol::RangeProgressSignal;
-use crate::control_plane::metadata::{RangeId, TopicId};
+use crate::control_plane::metadata::{EntryId, RangeId, TopicId};
 use crate::data_plane::states::segment::cache::CachedEntry;
 use crate::impl_from_variant;
 
@@ -28,7 +28,7 @@ impl_from_variant!(DataPlaneQuery, Fetch, ListOffsets);
 pub struct Fetch {
     pub topic_id: TopicId,
     pub range_id: RangeId,
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub max_bytes: u32,
     /// Pre-computed by the broker from the topic's metadata snapshot. The data
     /// plane echoes it back on the response so the consumer sees the seal
@@ -50,7 +50,7 @@ pub enum FetchResult {
     /// `lsn` field rides along through the channel but isn't on the wire.
     Records {
         entries: Vec<Arc<CachedEntry>>,
-        next_entry_id: u64,
+        next_entry_id: EntryId,
         progress_signal: RangeProgressSignal,
     },
     /// `entry_id` was past the last committed offset on this node (e.g. caller
@@ -74,8 +74,8 @@ pub struct ListOffsets {
 
 pub enum ListOffsetsResult {
     RangeOffsets {
-        start_entry_id: u64,
-        committed_entry_id: u64,
+        start_entry_id: EntryId,
+        committed_entry_id: EntryId,
     },
     SegmentNotLocal,
     #[allow(dead_code)] // reserved for future failure modes

--- a/src/data_plane/mod.rs
+++ b/src/data_plane/mod.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::Bytes;
 use std::path::{Path, PathBuf};
 
-use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 use crate::smart_pointer;
 
 pub(crate) mod actor;
@@ -65,15 +65,15 @@ impl SegmentKey {
     }
 
     /// Path to this segment's file. The filename encodes the segment's
-    /// `start_offset` (its first entry id) so the file is self-describing for
+    /// `start_entry` (its first entry id) so the file is self-describing for
     /// crash recovery — discovery derives the base entry id from the name
-    /// alone, no metadata lookup. `start_offset` is immutable, so the name is
+    /// alone, no metadata lookup. `start_entry` is immutable, so the name is
     /// stable for the segment's life (no rename on seal).
-    pub fn file_path(&self, data_dir: &Path, start_offset: u64) -> PathBuf {
+    pub fn file_path(&self, data_dir: &Path, start_entry: impl Into<EntryId>) -> PathBuf {
         data_dir
             .join(self.topic_id.to_string())
             .join(self.range_id.to_string())
-            .join(format!("{}-{}.seg", *self.segment_id, start_offset))
+            .join(format!("{}-{}.seg", *self.segment_id, *start_entry.into()))
     }
 
     pub fn with_segment_id(&self, segment_id: SegmentId) -> Self {

--- a/src/data_plane/recovery/index_rebuild.rs
+++ b/src/data_plane/recovery/index_rebuild.rs
@@ -78,7 +78,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+    use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
     use crate::data_plane::sparse_index::{INDEX_INTERVAL_ENTRIES, SparseIndex};
 
     fn key() -> SegmentKey {
@@ -117,7 +117,7 @@ mod tests {
             .collect();
         // Byte offset where the id-n batch starts (batches vary in size).
         let pos_n: u64 = batches[..n as usize].iter().map(|b| b.len() as u64).sum();
-        let path = key().file_path(dir.path(), 0);
+        let path = key().file_path(dir.path(), EntryId(0));
         write_segment(&path, &batches.concat());
 
         let entries = rebuild_sparse_entries(&path, key()).unwrap();

--- a/src/data_plane/recovery/mod.rs
+++ b/src/data_plane/recovery/mod.rs
@@ -129,7 +129,10 @@ impl Durable {
             let Some(start_offset) = self.recovered.start_entry_id(&key) else {
                 continue;
             };
-            let path = key.file_path(&self.data_dir, start_offset);
+            let path = key.file_path(
+                &self.data_dir,
+                crate::control_plane::metadata::EntryId(start_offset),
+            );
             index.put_batch(rebuild_sparse_entries(&path, key)?)?;
         }
 
@@ -151,7 +154,7 @@ mod tests {
 
     use super::segment_scan::scan_segment_file;
     use super::*;
-    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+    use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
     use crate::data_plane::SegmentKey;
     use crate::data_plane::wal::{WalRecord, WalStorage, WalWriter};
 
@@ -170,7 +173,7 @@ mod tests {
     /// exactly as the live produce path (`tracker.rs`) stages it.
     fn wal_data(key: SegmentKey, entry_id: u64, record_count: u32, payload: &str) -> WalRecord {
         let wal_payload =
-            RoutingHeader::new(key, entry_id, record_count).build_wal_payload(payload.as_bytes());
+            RoutingHeader::new(key, EntryId(entry_id), record_count).build_wal_payload(payload.as_bytes());
         WalRecord::data(wal_payload, record_count)
     }
 
@@ -185,7 +188,7 @@ mod tests {
     }
 
     fn write_segment(data_dir: &Path, key: SegmentKey, start_offset: u64, bytes: &[u8]) {
-        let path = key.file_path(data_dir, start_offset);
+        let path = key.file_path(data_dir, EntryId(start_offset));
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, bytes).unwrap();
     }
@@ -203,7 +206,7 @@ mod tests {
     }
 
     fn last_id(data_dir: &Path, key: SegmentKey, start_offset: u64) -> Option<u64> {
-        scan_segment_file(&key.file_path(data_dir, start_offset))
+        scan_segment_file(&key.file_path(data_dir, EntryId(start_offset)))
             .unwrap()
             .last_entry_id
     }
@@ -264,13 +267,13 @@ mod tests {
 
         let (_db_dir, db) = open_db();
         run(data_dir.clone(), &db).unwrap();
-        let after_first = fs::read(a.file_path(&data_dir, 0)).unwrap();
+        let after_first = fs::read(a.file_path(&data_dir, EntryId(0))).unwrap();
 
         // Commit 13 deletes the WAL after the first run, so the second run finds
         // an empty WAL dir and rebuilds the inventory from the segment files
         // alone — still byte-identical, still cursor 2.
         let output = run(data_dir.clone(), &db).unwrap();
-        assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), after_first);
+        assert_eq!(fs::read(a.file_path(&data_dir, EntryId(0))).unwrap(), after_first);
         assert_eq!(output.inventory.get(&a), Some(2));
     }
 
@@ -332,14 +335,14 @@ mod tests {
         );
         // The survivor re-presents entry 1 — already on disk, so it dedups.
         write_wal(&data_dir, 2, &wal_batch(&[wal_data(a, 1, 1, "a1")]));
-        let before = fs::read(a.file_path(&data_dir, 0)).unwrap();
+        let before = fs::read(a.file_path(&data_dir, EntryId(0))).unwrap();
 
         let (_db_dir, db) = open_db();
         let output = run(data_dir.clone(), &db).unwrap();
 
         // Zero appends (the survivor dedups), the segment is byte-identical, and
         // the already-deleted half's data was safe in the segment all along.
-        assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), before);
+        assert_eq!(fs::read(a.file_path(&data_dir, EntryId(0))).unwrap(), before);
         assert_eq!(output.inventory.get(&a), Some(1));
         assert!(fs::read_dir(data_dir.join("wal")).unwrap().next().is_none());
     }
@@ -370,7 +373,7 @@ mod tests {
         // every id — in particular the interior anchor resolves, instead of
         // collapsing to the byte-0 fallback that would mislabel a cold read.
         let (_full_dir, full) = open_db();
-        full.put_batch(rebuild_sparse_entries(&a.file_path(&data_dir, 0), a).unwrap())
+        full.put_batch(rebuild_sparse_entries(&a.file_path(&data_dir, EntryId(0)), a).unwrap())
             .unwrap();
         for id in 0..=n + 2 {
             assert_eq!(db.seek_index(a, id), full.seek_index(a, id));
@@ -391,7 +394,7 @@ mod tests {
         let mut wal = WalWriter::new(data_dir.to_path_buf()).unwrap();
         for batch in batches {
             for &(key, entry_id, payload) in *batch {
-                let wp = RoutingHeader::new(key, entry_id, 1).build_wal_payload(payload.as_bytes());
+                let wp = RoutingHeader::new(key, EntryId(entry_id), 1).build_wal_payload(payload.as_bytes());
                 WalRecord::data(wp, 1).encode_to(wal.buf()).unwrap();
             }
             WalRecord::batch_end().encode_to(wal.buf()).unwrap();

--- a/src/data_plane/recovery/orphan.rs
+++ b/src/data_plane/recovery/orphan.rs
@@ -37,7 +37,7 @@ impl OrphanCandidate {
     /// is cluster-confirmed and last. Returns the key so the caller can drop its inventory
     /// entry. Idempotent: an already-absent file is success.
     pub(crate) fn delete(&self, data_dir: &Path) -> io::Result<SegmentKey> {
-        let path = self.segment_key.file_path(data_dir, self.start_offset);
+        let path = self.segment_key.file_path(data_dir, crate::control_plane::metadata::EntryId(self.start_offset));
         match std::fs::remove_file(&path) {
             Ok(()) => Ok(self.segment_key),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(self.segment_key),

--- a/src/data_plane/recovery/replay.rs
+++ b/src/data_plane/recovery/replay.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use bytes::Bytes;
 
 use super::segment_scan::{Decision, RecoveredSegments};
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 use crate::data_plane::segment_writer::SegmentAppender;
 use crate::data_plane::states::segment::record::RoutingHeader;
@@ -58,11 +59,11 @@ impl ReplayWriter {
             return Ok(Decision::Skip);
         }
         let key = header.segment_key();
-        self.writer_for(key, header.entry_id)?.append_entry(
+        self.writer_for(key, *header.entry_id)?.append_entry(
             header.entry_id,
             WalRecord::data(Bytes::copy_from_slice(entry_data), header.record_count),
         )?;
-        self.recovered.advance(key, header.entry_id);
+        self.recovered.advance(key, *header.entry_id);
         Ok(Decision::Append)
     }
 
@@ -90,7 +91,7 @@ impl ReplayWriter {
                 .start_entry_id(&key)
                 .unwrap_or(first_entry_id);
             let valid_len = self.recovered.valid_len(&key);
-            let path = key.file_path(&self.data_dir, start_offset);
+            let path = key.file_path(&self.data_dir, EntryId(start_offset));
             self.writers.insert(
                 key,
                 SegmentAppender::open_truncating(key, &path, valid_len)?,
@@ -110,7 +111,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+    use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
     use crate::data_plane::recovery::segment_scan::scan_segment_file;
     use crate::data_plane::wal::WalRecord;
 
@@ -141,18 +142,18 @@ mod tests {
 
         let mut w = ReplayWriter::new(data_dir.clone(), RecoveredSegments::default());
         assert_eq!(
-            w.replay(&RoutingHeader::new(key(), 0, 1), b"alpha")
+            w.replay(&RoutingHeader::new(key(), EntryId(0), 1), b"alpha")
                 .unwrap(),
             Decision::Append
         );
         assert_eq!(
-            w.replay(&RoutingHeader::new(key(), 1, 1), b"beta").unwrap(),
+            w.replay(&RoutingHeader::new(key(), EntryId(1), 1), b"beta").unwrap(),
             Decision::Append
         );
         w.finish().unwrap();
 
         // Named from the first record's id (the segment's base).
-        let scan = scan_segment_file(&key().file_path(&data_dir, 0)).unwrap();
+        let scan = scan_segment_file(&key().file_path(&data_dir, EntryId(0))).unwrap();
         assert_eq!(scan.last_entry_id, Some(1)); // 0, 1
     }
 
@@ -161,25 +162,25 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let data_dir = dir.path().to_path_buf();
         write_segment(
-            &key().file_path(&data_dir, 0),
+            &key().file_path(&data_dir, EntryId(0)),
             &[encode_batch("alpha", 1), encode_batch("beta", 1)].concat(),
         );
 
         let recovered = RecoveredSegments::scan_data_dir(&data_dir).unwrap();
         let mut w = ReplayWriter::new(data_dir.clone(), recovered);
         assert_eq!(
-            w.replay(&RoutingHeader::new(key(), 1, 1), b"beta-again")
+            w.replay(&RoutingHeader::new(key(), EntryId(1), 1), b"beta-again")
                 .unwrap(),
             Decision::Skip
         );
         assert_eq!(
-            w.replay(&RoutingHeader::new(key(), 2, 1), b"gamma")
+            w.replay(&RoutingHeader::new(key(), EntryId(2), 1), b"gamma")
                 .unwrap(),
             Decision::Append
         );
         w.finish().unwrap();
 
-        let scan = scan_segment_file(&key().file_path(&data_dir, 0)).unwrap();
+        let scan = scan_segment_file(&key().file_path(&data_dir, EntryId(0))).unwrap();
         assert_eq!(scan.last_entry_id, Some(2)); // 0, 1, 2
     }
 
@@ -189,18 +190,18 @@ mod tests {
         let data_dir = dir.path().to_path_buf();
         let mut bytes = encode_batch("alpha", 1); // verified prefix: entry 0
         bytes.extend_from_slice(b"torn-uncommitted-tail");
-        write_segment(&key().file_path(&data_dir, 0), &bytes);
+        write_segment(&key().file_path(&data_dir, EntryId(0)), &bytes);
 
         let recovered = RecoveredSegments::scan_data_dir(&data_dir).unwrap();
         let mut w = ReplayWriter::new(data_dir.clone(), recovered);
         assert_eq!(
-            w.replay(&RoutingHeader::new(key(), 1, 1), b"beta").unwrap(),
+            w.replay(&RoutingHeader::new(key(), EntryId(1), 1), b"beta").unwrap(),
             Decision::Append
         );
         w.finish().unwrap();
 
         // The torn tail was truncated to valid_len, so the file re-scans clean.
-        let scan = scan_segment_file(&key().file_path(&data_dir, 0)).unwrap();
+        let scan = scan_segment_file(&key().file_path(&data_dir, EntryId(0))).unwrap();
         assert_eq!(scan.last_entry_id, Some(1)); // 0, 1 — tail gone, beta clean
     }
 
@@ -211,7 +212,7 @@ mod tests {
         let recovered = RecoveredSegments::scan_data_dir(data_dir).unwrap();
         let mut w = ReplayWriter::new(data_dir.to_path_buf(), recovered);
         for &(seg, entry_id, payload) in stream {
-            w.replay(&RoutingHeader::new(seg, entry_id, 1), payload.as_bytes())
+            w.replay(&RoutingHeader::new(seg, EntryId(entry_id), 1), payload.as_bytes())
                 .unwrap();
         }
         w.finish().unwrap();
@@ -224,8 +225,8 @@ mod tests {
         let a = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
         let b = SegmentKey::new(TopicId(1), RangeId(1), SegmentId(0));
         // Each segment already has its entry 0 checkpointed on disk.
-        write_segment(&a.file_path(&data_dir, 0), &encode_batch("a0", 1));
-        write_segment(&b.file_path(&data_dir, 0), &encode_batch("b0", 1));
+        write_segment(&a.file_path(&data_dir, EntryId(0)), &encode_batch("a0", 1));
+        write_segment(&b.file_path(&data_dir, EntryId(0)), &encode_batch("b0", 1));
 
         // Interleaved across two notional WAL files: the checkpointed entries
         // reappear (overlap), plus new suffix entries.
@@ -239,19 +240,19 @@ mod tests {
 
         replay_stream(&data_dir, &stream);
         // Each segment's prefix is reconstructed contiguously.
-        let scan_a = scan_segment_file(&a.file_path(&data_dir, 0)).unwrap();
-        let scan_b = scan_segment_file(&b.file_path(&data_dir, 0)).unwrap();
+        let scan_a = scan_segment_file(&a.file_path(&data_dir, EntryId(0))).unwrap();
+        let scan_b = scan_segment_file(&b.file_path(&data_dir, EntryId(0))).unwrap();
         assert_eq!(scan_a.last_entry_id, Some(2)); // a0, a1, a2
         assert_eq!(scan_b.last_entry_id, Some(1)); // b0, b1
 
-        let a_bytes = fs::read(a.file_path(&data_dir, 0)).unwrap();
-        let b_bytes = fs::read(b.file_path(&data_dir, 0)).unwrap();
+        let a_bytes = fs::read(a.file_path(&data_dir, EntryId(0))).unwrap();
+        let b_bytes = fs::read(b.file_path(&data_dir, EntryId(0))).unwrap();
 
         // Re-running scan + replay over the same disk changes nothing — every
         // record now dedups against the higher cursors.
         replay_stream(&data_dir, &stream);
-        assert_eq!(fs::read(a.file_path(&data_dir, 0)).unwrap(), a_bytes);
-        assert_eq!(fs::read(b.file_path(&data_dir, 0)).unwrap(), b_bytes);
+        assert_eq!(fs::read(a.file_path(&data_dir, EntryId(0))).unwrap(), a_bytes);
+        assert_eq!(fs::read(b.file_path(&data_dir, EntryId(0))).unwrap(), b_bytes);
     }
 
     #[test]
@@ -260,7 +261,7 @@ mod tests {
         let data_dir = dir.path().to_path_buf();
         let s = key();
         write_segment(
-            &s.file_path(&data_dir, 0),
+            &s.file_path(&data_dir, EntryId(0)),
             &[
                 encode_batch("e0", 1),
                 encode_batch("e1", 1),
@@ -268,20 +269,20 @@ mod tests {
             ]
             .concat(),
         );
-        let before = fs::read(s.file_path(&data_dir, 0)).unwrap();
+        let before = fs::read(s.file_path(&data_dir, EntryId(0))).unwrap();
 
         let recovered = RecoveredSegments::scan_data_dir(&data_dir).unwrap();
         let mut w = ReplayWriter::new(data_dir.clone(), recovered);
         // The WAL re-presents entries already checkpointed → all skipped.
         for entry_id in 0u64..=2 {
             assert_eq!(
-                w.replay(&RoutingHeader::new(s, entry_id, 1), b"dup")
+                w.replay(&RoutingHeader::new(s, EntryId(entry_id), 1), b"dup")
                     .unwrap(),
                 Decision::Skip
             );
         }
         w.finish().unwrap();
 
-        assert_eq!(fs::read(s.file_path(&data_dir, 0)).unwrap(), before);
+        assert_eq!(fs::read(s.file_path(&data_dir, EntryId(0))).unwrap(), before);
     }
 }

--- a/src/data_plane/recovery/segment_scan.rs
+++ b/src/data_plane/recovery/segment_scan.rs
@@ -96,7 +96,7 @@ impl RecoveredSegments {
             .get(&header.segment_key())
             .and_then(|scan| scan.last_entry_id)
         {
-            Some(cursor) if header.entry_id <= cursor => Decision::Skip,
+            Some(cursor) if *header.entry_id <= cursor => Decision::Skip,
             _ => Decision::Append,
         }
     }
@@ -281,7 +281,7 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
-    use crate::control_plane::metadata::SegmentId;
+    use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 
     /// Encodes entries the way `CheckpointWorker::process_job` (`checkpoint.rs`)
     /// does: each entry is a bare-payload `Data` record followed by a `BatchEnd`
@@ -422,12 +422,12 @@ mod tests {
         let k2 = SegmentKey::new(TopicId(1), RangeId(2), SegmentId(5));
         let k3 = SegmentKey::new(TopicId(7), RangeId(0), SegmentId(3));
         write_segment_file(
-            &k1.file_path(data_dir, 0),
+            &k1.file_path(data_dir, EntryId(0)),
             &encode_segment(&[("a", 1), ("b", 1)]),
         );
-        write_segment_file(&k2.file_path(data_dir, 100), &encode_segment(&[("c", 1)]));
+        write_segment_file(&k2.file_path(data_dir, EntryId(100)), &encode_segment(&[("c", 1)]));
         write_segment_file(
-            &k3.file_path(data_dir, 50),
+            &k3.file_path(data_dir, EntryId(50)),
             &encode_segment(&[("d", 1), ("e", 1), ("f", 1)]),
         );
 
@@ -444,7 +444,7 @@ mod tests {
         let data_dir = dir.path();
 
         let real = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
-        write_segment_file(&real.file_path(data_dir, 0), &encode_segment(&[("a", 1)]));
+        write_segment_file(&real.file_path(data_dir, EntryId(0)), &encode_segment(&[("a", 1)]));
 
         // A WAL sibling dir, a non-id topic dir, and a foreign file in a real
         // range dir — none should abort the walk or land in the map.
@@ -470,7 +470,7 @@ mod tests {
     }
 
     fn routing(entry_id: u64) -> RoutingHeader {
-        RoutingHeader::new(seg_key(), entry_id, 1)
+        RoutingHeader::new(seg_key(), EntryId(entry_id), 1)
     }
 
     fn scanned(start_entry_id: u64, last_entry_id: Option<u64>, valid_len: u64) -> SegmentScan {

--- a/src/data_plane/segment_writer.rs
+++ b/src/data_plane/segment_writer.rs
@@ -7,6 +7,7 @@
 //! file) — the one place segment files are written, so the framing and the
 //! anchor predicate live in exactly one spot.
 
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 use crate::data_plane::sparse_index::{SparseEntry, is_index_anchor};
 use crate::data_plane::wal::WalRecord;
@@ -112,7 +113,7 @@ impl SegmentAppender {
     /// cheapest payload form (an Arc-backed clone) rather than forcing a copy.
     pub(crate) fn append_entry(
         &mut self,
-        entry_id: u64,
+        entry_id: EntryId,
         record: WalRecord,
     ) -> io::Result<Option<SparseEntry>> {
         let data_start = self.next_pos;
@@ -120,7 +121,7 @@ impl SegmentAppender {
         let end = WalRecord::batch_end();
         end.encode_to(&mut self.writer)?;
         self.next_pos += record.encoded_size() as u64 + end.encoded_size() as u64;
-        Ok(is_index_anchor(data_start, entry_id)
-            .then(|| SparseEntry::new(self.segment_key, entry_id, data_start.to_be_bytes())))
+        Ok(is_index_anchor(data_start, *entry_id)
+            .then(|| SparseEntry::new(self.segment_key, *entry_id, data_start.to_be_bytes())))
     }
 }

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -23,6 +23,7 @@ use crate::config::DataNodeConfig;
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::messages::{CoordinatorSealRequest, MultiRaftActorCommand};
 use crate::control_plane::membership::ShardGroupId;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::states::segment::tracker::{SegmentRole, SegmentTracker};
 use crate::data_plane::states::segment_store::SegmentReadState;
 use crate::data_plane::timer::{BatchFlushTimer, ReplicationTimer};
@@ -50,11 +51,11 @@ const ORPHAN_GC_BATCH: usize = 64;
 struct PendingCatchUp {
     appender: SegmentAppender,
     shard_group_id: ShardGroupId,
-    start_offset: u64,
-    sealed_end: u64,
+    start_offset: EntryId,
+    sealed_end: EntryId,
     /// Highest entry id written so far; `None` until the first append. A resume
     /// re-requests `(last_written, sealed_end]`.
-    last_written: Option<u64>,
+    last_written: Option<EntryId>,
     /// Re-drives since the last append — the stall detector. Reset on append.
     idle_rounds: u32,
     anchors: Vec<SparseEntry>,
@@ -236,12 +237,12 @@ impl<W: WalStorage> DataPlane<W> {
         let start_entry_id = tracker.start_entry_id();
 
         // Translate the absolute entry_id to a 0-based cache position.
-        let cache_position = cmd.entry_id.saturating_sub(start_entry_id);
+        let cache_position = cmd.entry_id.saturating_sub(*start_entry_id);
 
         // The active tail can have `committed_entry_id = 0` and no entries
         // yet committed; distinguish "no data committed at all" by also
         // checking against the cache read cursor.
-        if cache_position >= read_cursor {
+        if *cache_position >= read_cursor {
             // Past the tail — nothing to return.
             let _ = cmd.reply.send(FetchResult::Records {
                 entries: Vec::new(),
@@ -257,14 +258,14 @@ impl<W: WalStorage> DataPlane<W> {
         let max_bytes = cmd.max_bytes as usize;
 
         while let Some(entry_arc) =
-            cache.read_committed(next_entry_id.saturating_sub(start_entry_id))
+            cache.read_committed(*next_entry_id.saturating_sub(*start_entry_id))
         {
             let payload_len = entry_arc.data.len();
             // Always include at least one entry (even if max_bytes is small).
             if !entries.is_empty() && bytes_read + payload_len > max_bytes {
                 break;
             }
-            next_entry_id = entry_arc.entry_id + 1;
+            next_entry_id = entry_arc.entry_id + 1u64;
             entries.push(entry_arc);
             bytes_read += payload_len;
 
@@ -286,8 +287,8 @@ impl<W: WalStorage> DataPlane<W> {
         &self,
         cmd: Fetch,
         key: SegmentKey,
-        start_entry_id: u64,
-        end_entry_id: u64,
+        start_entry_id: EntryId,
+        end_entry_id: EntryId,
     ) {
         if cmd.entry_id > end_entry_id {
             let _ = cmd.reply.send(FetchResult::EntryIdOutOfRange);
@@ -322,7 +323,8 @@ impl<W: WalStorage> DataPlane<W> {
         // active index. Resolve via the highest indexable offset (u64::MAX)
         // to land on whatever's currently active.
         let Some(SegmentReadState::Active(key)) =
-            self.segments.resolve(cmd.topic_id, cmd.range_id, u64::MAX)
+            self.segments
+                .resolve(cmd.topic_id, cmd.range_id, EntryId(u64::MAX))
         else {
             let _ = cmd.reply.send(ListOffsetsResult::SegmentNotLocal);
             return;
@@ -463,7 +465,7 @@ impl<W: WalStorage> DataPlane<W> {
                 continue;
             };
             self.recovered.remove(&key);
-            if let Err(e) = OrphanCandidate::new(key, start_offset).delete(&self.config.data_dir) {
+            if let Err(e) = OrphanCandidate::new(key, *start_offset).delete(&self.config.data_dir) {
                 tracing::warn!("retention: deleting segment file {key:?} failed: {e}");
             }
             self.out.store_delete_segment_index(key);
@@ -575,9 +577,10 @@ impl<W: WalStorage> DataPlane<W> {
     /// Highest verified entry id we already hold for this sealed segment — from the
     /// live sealed store (a survivor or a prior catch-up) or the recovered inventory
     /// (a restarted node's on-disk data). `None` if we hold nothing.
-    fn local_sealed_progress(&self, key: &SegmentKey) -> Option<u64> {
+    fn local_sealed_progress(&self, key: &SegmentKey) -> Option<EntryId> {
         let registered = self.segments.sealed_bounds(key).map(|(_, end)| end);
-        registered.max(self.recovered.get(key))
+        let recovered = self.recovered.get(key).map(EntryId);
+        registered.max(recovered)
     }
 
     /// Highest durable (fsync'd) entry id this node holds for `key`, across every
@@ -585,7 +588,7 @@ impl<W: WalStorage> DataPlane<W> {
     /// still following), the sealed store, or the recovered inventory. `None` if
     /// we hold nothing. Reported in a `SealBoundaryReport` so the coordinator can seal
     /// a leader-crashed segment at the `min` of survivors' durable extents.
-    fn durable_end(&self, key: &SegmentKey) -> Option<u64> {
+    fn durable_end(&self, key: &SegmentKey) -> Option<EntryId> {
         let live = self
             .segments
             .get(key)
@@ -614,7 +617,7 @@ impl<W: WalStorage> DataPlane<W> {
     fn open_catch_up_appender(
         key: SegmentKey,
         path: &std::path::Path,
-        local: Option<u64>,
+        local: Option<EntryId>,
     ) -> std::io::Result<SegmentAppender> {
         match local {
             None => SegmentAppender::create(key, path),
@@ -641,7 +644,9 @@ impl<W: WalStorage> DataPlane<W> {
             // Append only the strictly-next id; skip duplicates / out-of-order. A
             // resume can overlap a stalled stream's tail, and a double append would
             // overstate the verified prefix.
-            let next = pending.last_written.map_or(pending.start_offset, |w| w + 1);
+            let next = pending
+                .last_written
+                .map_or(pending.start_offset, |w| w + 1u64);
             if entry.entry_id != next {
                 continue;
             }
@@ -698,7 +703,7 @@ impl<W: WalStorage> DataPlane<W> {
         };
         if scan
             .last_entry_id
-            .is_none_or(|last| last < pending.sealed_end)
+            .is_none_or(|last| EntryId(last) < pending.sealed_end)
         {
             tracing::warn!(
                 "catch-up incomplete for {:?}: have {:?}, need {}; not registering",
@@ -745,7 +750,7 @@ impl<W: WalStorage> DataPlane<W> {
             );
             return;
         };
-        let start = cmd.local_end.map_or(start_offset, |held| held + 1);
+        let start = cmd.local_end.map_or(start_offset, |held| held + 1u64);
         if start > sealed_end {
             // The requester is already at or past OUR committed end — nothing to
             // stream. Confirm completion immediately and skip a pointless cold-read
@@ -762,9 +767,9 @@ impl<W: WalStorage> DataPlane<W> {
         &self,
         requester: NodeId,
         segment_key: SegmentKey,
-        start_offset: u64, // Segment base — names the file (`{segment_id}-{start_offset}.seg`)
-        sealed_end: u64,
-        read_from: u64,
+        start_offset: EntryId, // Segment base — names the file (`{segment_id}-{start_offset}.seg`)
+        sealed_end: EntryId,
+        read_from: EntryId,
     ) {
         let req = ColdReadRequest {
             segment_key,
@@ -1026,10 +1031,10 @@ impl<W: WalStorage> DataPlane<W> {
                 if let Some(tracker) = self.segments.get_mut(&cmd.segment_key) {
                     let start = tracker
                         .last_committed_entry_id()
-                        .map_or(tracker.start_entry_id(), |c| c + 1);
+                        .map_or(tracker.start_entry_id(), |c| c + 1u64);
 
-                    for offset in start..=end {
-                        tracker.commit_entry(offset);
+                    for offset in *start..=*end {
+                        tracker.commit_entry(EntryId(offset));
                     }
                 }
             }
@@ -1080,7 +1085,7 @@ impl<W: WalStorage> DataPlane<W> {
         }
     }
 
-    fn commit_segment(&mut self, segment_key: SegmentKey, entry_id: u64) {
+    fn commit_segment(&mut self, segment_key: SegmentKey, entry_id: EntryId) {
         let Some(tracker) = self.segments.get_mut(&segment_key) else {
             return;
         };
@@ -1476,7 +1481,7 @@ mod tests {
                 segment_key: key,
                 shard_group_id: ShardGroupId(1),
                 replica_set,
-                start_entry_id: 0,
+                start_entry_id: EntryId(0),
             }
             .into(),
         )
@@ -1571,7 +1576,7 @@ mod tests {
 
         let tracker = dp.segments.get(&test_key()).unwrap();
         assert_eq!(tracker.size_bytes(), 12);
-        assert_eq!(tracker.next_entry_id(), 0);
+        assert_eq!(tracker.next_entry_id(), EntryId(0));
     }
 
     #[test]
@@ -1818,7 +1823,7 @@ mod tests {
             let t = dp.segments.get(&test_key()).unwrap();
             assert_eq!(t.staged_entries().len(), 3);
             assert_eq!(t.cache_write_cursor(), 0);
-            assert_eq!(t.next_entry_id(), 0);
+            assert_eq!(t.next_entry_id(), EntryId(0));
         }
 
         dp.flush_batch();
@@ -1826,7 +1831,7 @@ mod tests {
         let t = dp.segments.get(&test_key()).unwrap();
         assert!(t.staged_entries().is_empty());
         assert_eq!(t.cache_write_cursor(), 3);
-        assert_eq!(t.next_entry_id(), 3);
+        assert_eq!(t.next_entry_id(), EntryId(3));
         assert_eq!(t.cache_read_cursor(), 3);
     }
 
@@ -1918,7 +1923,7 @@ mod tests {
         );
         dp.out.transport_cmds.clear();
 
-        dp.commit_segment(test_key(), 0);
+        dp.commit_segment(test_key(), EntryId(0));
 
         let cache = dp.segments.get(&test_key()).unwrap().cache();
         assert_eq!(cache.load_read_cursor(), 1);
@@ -1938,7 +1943,7 @@ mod tests {
                 replica_set: vec![leader, test_node_id()],
                 data: b"setup".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -1963,7 +1968,7 @@ mod tests {
                 replica_set: vec![leader.clone(), test_node_id()],
                 data: b"data".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -1986,7 +1991,7 @@ mod tests {
                 replica_set: vec![NodeId::new("other-leader"), NodeId::new("other-follower")],
                 data: b"data".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -2006,7 +2011,7 @@ mod tests {
                 replica_set: vec![leader.clone(), test_node_id()],
                 data: b"data".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -2015,13 +2020,13 @@ mod tests {
         dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
             CommitAdvance {
                 segment_key: test_key(),
-                committed_entry_id: 0,
+                committed_entry_id: EntryId(0),
             }
             .into(),
         ));
 
         let tracker = dp.segments.get(&test_key()).unwrap();
-        assert_eq!(tracker.committed_entry_id(), 0);
+        assert_eq!(tracker.committed_entry_id(), EntryId(0));
         assert_eq!(tracker.cache().load_read_cursor(), 1);
     }
 
@@ -2125,7 +2130,7 @@ mod tests {
                 replica_set: vec![leader, test_node_id()],
                 data: b"data".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -2147,7 +2152,7 @@ mod tests {
         dp.handle_command(DataPlaneCommand::DataPlaneTimeoutCallback(
             DataPlaneTimeoutCallback::BatchFlushDeadline,
         ));
-        dp.segments.get_mut(&test_key()).unwrap().commit_entry(0);
+        dp.segments.get_mut(&test_key()).unwrap().commit_entry(EntryId(0));
 
         dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
             SealResponse {
@@ -2222,7 +2227,7 @@ mod tests {
                 replica_set: vec![leader, test_node_id()],
                 data: b"data".to_vec().into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
             }
             .into(),
         ));
@@ -2260,7 +2265,7 @@ mod tests {
 
         let resolved = dp
             .segments
-            .resolve(TopicId(1), RangeId(0), 0)
+            .resolve(TopicId(1), RangeId(0), EntryId(0))
             .expect("active segment should resolve");
         assert!(matches!(resolved, SegmentReadState::Active(k) if k == test_key()));
     }
@@ -2299,18 +2304,18 @@ mod tests {
         let s0 = test_key();
         let s1 = s0.with_segment_id(SegmentId(1));
 
-        let lookup = dp.segments.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        let lookup = dp.segments.resolve(TopicId(1), RangeId(0), EntryId(0)).unwrap();
         match lookup {
             SegmentReadState::Sealed {
                 key, end_entry_id, ..
             } => {
                 assert_eq!(key, s0);
-                assert_eq!(end_entry_id, 0);
+                assert_eq!(end_entry_id, EntryId(0));
             }
             other => panic!("expected Sealed, got {other:?}"),
         }
 
-        let active = dp.segments.resolve(TopicId(1), RangeId(0), 1).unwrap();
+        let active = dp.segments.resolve(TopicId(1), RangeId(0), EntryId(1)).unwrap();
         assert!(matches!(active, SegmentReadState::Active(k) if k == s1));
     }
 
@@ -2358,12 +2363,12 @@ mod tests {
 
         // Offset 0 resolves to the active successor (which reuses start 0), not
         // an empty sealed segment — the old segment owned no committed offsets.
-        let resolved = dp.segments.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        let resolved = dp.segments.resolve(TopicId(1), RangeId(0), EntryId(0)).unwrap();
         assert!(
             matches!(resolved, SegmentReadState::Active(k) if k == s1),
             "offset 0 must resolve to the active successor, got {resolved:?}",
         );
-        assert_eq!(dp.segments.get(&s1).unwrap().start_entry_id(), 0);
+        assert_eq!(dp.segments.get(&s1).unwrap().start_entry_id(), EntryId(0));
 
         // The replayed record commits on flush (single replica) and is readable
         // at offset 0 — proving no record was stranded by the seal.
@@ -2428,7 +2433,7 @@ mod tests {
         // Write the segment file + sparse index exactly as the checkpoint worker
         // would (Data + BatchEnd per entry), then seal so the resolver routes
         // offset 0 to the sealed table → cold path.
-        let seg_path = test_key().file_path(dir.path(), 0);
+        let seg_path = test_key().file_path(dir.path(), EntryId(0));
         if let Some(parent) = seg_path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
@@ -2464,7 +2469,7 @@ mod tests {
         dp.process(DataPlaneMessage::Query(DataPlaneQuery::Fetch(Fetch {
             topic_id: TopicId(1),
             range_id: RangeId(0),
-            entry_id: 0,
+            entry_id: EntryId(0),
             max_bytes: 1 << 20,
             progress_signal: RangeProgressSignal::Active,
             reply,
@@ -2483,7 +2488,7 @@ mod tests {
         };
         let got: Vec<(u64, u32, Vec<u8>)> = entries
             .iter()
-            .map(|e| (e.entry_id, e.record_count, e.data.to_vec()))
+            .map(|e| (*e.entry_id, e.record_count, e.data.to_vec()))
             .collect();
         assert_eq!(
             got,
@@ -2494,7 +2499,7 @@ mod tests {
             ],
             "cold read must restore payloads AND record_counts from disk"
         );
-        assert_eq!(next_entry_id, 3);
+        assert_eq!(next_entry_id, EntryId(3));
     }
 
     // ── Catch-up source side (commit 20) ──────────────────────────────────
@@ -2523,9 +2528,9 @@ mod tests {
             SegmentRole::Leader,
             vec![],
             ShardGroupId(1),
-            0,
+            EntryId(0),
         );
-        tracker.commit_entry(10);
+        tracker.commit_entry(EntryId(10));
         dp.segments.insert_active(test_key(), tracker);
         dp.segments.take_active_and_seal(test_key());
         (dp, cold_read_rx)
@@ -2544,17 +2549,17 @@ mod tests {
             CatchUpRequest {
                 segment_key: test_key(),
                 from: requester.clone(),
-                local_end: Some(4),
+                local_end: Some(EntryId(4)),
             }
             .into(),
         ));
 
         let req = cold_read_rx.try_recv().expect("dispatched cold read");
-        assert_eq!(req.start_entry_offset, 5); // requester's local_end + 1
-        assert_eq!(req.end_entry_id, 10); // the source's own sealed end
+        assert_eq!(req.start_entry_offset, EntryId(5)); // requester's local_end + 1
+        assert_eq!(req.end_entry_id, EntryId(10)); // the source's own sealed end
         assert!(matches!(
             req.reply,
-            ColdReadReply::CatchUp(cu) if cu.requester == requester && cu.sealed_end == 10
+            ColdReadReply::CatchUp(cu) if cu.requester == requester && cu.sealed_end == EntryId(10)
         ));
     }
 
@@ -2571,7 +2576,7 @@ mod tests {
             CatchUpRequest {
                 segment_key: test_key(),
                 from: requester.clone(),
-                local_end: Some(10), // == the source's sealed end
+                local_end: Some(EntryId(10)), // == the source's sealed end
             }
             .into(),
         ));
@@ -2605,29 +2610,29 @@ mod tests {
             Arc::new(CachedEntry {
                 data: Bytes::copy_from_slice(b"a").into(),
                 record_count: 1,
-                entry_id: 0,
+                entry_id: EntryId(0),
                 lsn: 0,
             }),
             Arc::new(CachedEntry {
                 data: Bytes::copy_from_slice(b"bb").into(),
                 record_count: 2,
-                entry_id: 1,
+                entry_id: EntryId(1),
                 lsn: 0,
             }),
             Arc::new(CachedEntry {
                 data: Bytes::copy_from_slice(b"ccc").into(),
                 record_count: 3,
-                entry_id: 2,
+                entry_id: EntryId(2),
                 lsn: 0,
             }),
         ];
         dp.handle_command(DataPlaneCommand::CatchUpReadComplete(CatchUpReadComplete {
             requester: requester.clone(),
             segment_key: test_key(),
-            start_offset: 0,
-            sealed_end: 2,
+            start_offset: EntryId(0),
+            sealed_end: EntryId(2),
             entries,
-            next_offset: 3,
+            next_offset: EntryId(3),
         }));
 
         assert_eq!(dp.out.transport_cmds.len(), 2);
@@ -2643,7 +2648,7 @@ mod tests {
         let got: Vec<(u64, u32, Vec<u8>)> = c
             .entries
             .iter()
-            .map(|e| (e.entry_id, e.record_count, e.data.to_vec()))
+            .map(|e| (*e.entry_id, e.record_count, e.data.to_vec()))
             .collect();
         assert_eq!(
             got,
@@ -2689,15 +2694,15 @@ mod tests {
         dp.handle_command(DataPlaneCommand::CatchUpReadComplete(CatchUpReadComplete {
             requester: requester.clone(),
             segment_key: test_key(),
-            start_offset: 0,
-            sealed_end: 9,
+            start_offset: EntryId(0),
+            sealed_end: EntryId(9),
             entries: vec![Arc::new(CachedEntry {
                 data: Bytes::copy_from_slice(b"x").into(),
                 record_count: 1,
-                entry_id: 4,
+                entry_id: EntryId(4),
                 lsn: 0,
             })],
-            next_offset: 5,
+            next_offset: EntryId(5),
         }));
 
         // One chunk, no Done yet.
@@ -2712,11 +2717,11 @@ mod tests {
 
         // The next read was re-armed against the pool, resuming at next_offset.
         let req = cold_read_rx.try_recv().expect("re-armed cold read");
-        assert_eq!(req.start_entry_offset, 5);
-        assert_eq!(req.end_entry_id, 9);
+        assert_eq!(req.start_entry_offset, EntryId(5));
+        assert_eq!(req.end_entry_id, EntryId(9));
         assert!(matches!(
             req.reply,
-            ColdReadReply::CatchUp(cu) if cu.requester == requester && cu.sealed_end == 9
+            ColdReadReply::CatchUp(cu) if cu.requester == requester && cu.sealed_end == EntryId(9)
         ));
     }
 
@@ -2738,8 +2743,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 2,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(2),
                 replica_set: vec![test_node_id(), source.clone()],
             }
             .into(),
@@ -2763,17 +2768,17 @@ mod tests {
                 segment_key: test_key(),
                 entries: vec![
                     CatchUpEntry {
-                        entry_id: 0,
+                        entry_id: EntryId(0),
                         data: b"a".to_vec().into(),
                         record_count: 1,
                     },
                     CatchUpEntry {
-                        entry_id: 1,
+                        entry_id: EntryId(1),
                         data: b"bb".to_vec().into(),
                         record_count: 2,
                     },
                     CatchUpEntry {
-                        entry_id: 2,
+                        entry_id: EntryId(2),
                         data: b"ccc".to_vec().into(),
                         record_count: 3,
                     },
@@ -2790,9 +2795,9 @@ mod tests {
         ));
 
         // Registered cold-readable at its sealed bounds...
-        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((0, 2)));
+        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((EntryId(0), EntryId(2))));
         // ...the file verifies through the sealed end...
-        let scan = scan_segment_file(&test_key().file_path(dir.path(), 0)).unwrap();
+        let scan = scan_segment_file(&test_key().file_path(dir.path(), EntryId(0))).unwrap();
         assert_eq!(scan.last_entry_id, Some(2));
         // ...and the suffix anchors were handed to the checkpoint worker (entry 0
         // at byte 0 is always an anchor).
@@ -2822,8 +2827,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 5, // need through 5...
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(5), // need through 5...
                 replica_set: vec![test_node_id(), NodeId::new("source")],
             }
             .into(),
@@ -2834,17 +2839,17 @@ mod tests {
                 segment_key: test_key(),
                 entries: vec![
                     CatchUpEntry {
-                        entry_id: 0,
+                        entry_id: EntryId(0),
                         data: b"a".to_vec().into(),
                         record_count: 1,
                     },
                     CatchUpEntry {
-                        entry_id: 1,
+                        entry_id: EntryId(1),
                         data: b"b".to_vec().into(),
                         record_count: 1,
                     },
                     CatchUpEntry {
-                        entry_id: 2,
+                        entry_id: EntryId(2),
                         data: b"c".to_vec().into(),
                         record_count: 1,
                     },
@@ -2889,8 +2894,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 2,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(2),
                 replica_set: vec![test_node_id(), NodeId::new("peer")],
             }
             .into(),
@@ -2907,7 +2912,7 @@ mod tests {
             DataPlaneInterNodeCommand::CatchUpAck(a) if a.segment_key == test_key()
         ));
         // ...and the segment is now registered cold-readable at the sealed bounds.
-        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((0, 2)));
+        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((EntryId(0), EntryId(2))));
     }
 
     #[test]
@@ -2924,14 +2929,14 @@ mod tests {
         recovered.advance(reused, 0);
         let mut dp = make_data_plane_with(&dir, LocalInventory::from_recovered(&recovered));
 
-        let stray_path = stray.file_path(dir.path(), 0);
-        let reused_path = reused.file_path(dir.path(), 0);
+        let stray_path = stray.file_path(dir.path(), EntryId(0));
+        let reused_path = reused.file_path(dir.path(), EntryId(0));
         write_seg_file(&stray_path, &[(b"x", 1)]);
         write_seg_file(&reused_path, &[(b"y", 1)]);
 
         // The owning group reassigned `reused` here and its catch-up registered it (the
         // lottery won) — now a live sealed segment. `stray` was never assigned here.
-        dp.segments.insert_sealed_from_catch_up(reused, 0, 0);
+        dp.segments.insert_sealed_from_catch_up(reused, EntryId(0), EntryId(0));
 
         let (reply_tx, mut reply_rx) = tokio::sync::mpsc::channel(1);
         dp.handle_orphan_gc_check(OrphanGcCheck { reply: reply_tx });
@@ -2967,7 +2972,7 @@ mod tests {
     fn orphan_gc_skips_a_segment_with_an_in_flight_catch_up() {
         let dir = tempfile::tempdir().unwrap();
         // A partial local copy + matching cursor → a real in-flight (delta) catch-up.
-        let path = test_key().file_path(dir.path(), 0);
+        let path = test_key().file_path(dir.path(), EntryId(0));
         write_seg_file(&path, &[(b"a", 1), (b"b", 1)]);
         let mut dp = make_data_plane_with(&dir, inventory_with(test_key(), 1));
 
@@ -2975,8 +2980,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 4,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(4),
                 replica_set: vec![test_node_id(), NodeId::new("source")],
             }
             .into(),
@@ -3011,10 +3016,10 @@ mod tests {
         use crate::data_plane::checkpoint::CheckpointTask;
         let dir = tempfile::tempdir().unwrap();
         let key = test_key();
-        let path = key.file_path(dir.path(), 0);
+        let path = key.file_path(dir.path(), EntryId(0));
         write_seg_file(&path, &[(b"a", 1)]);
         let mut dp = make_data_plane(&dir);
-        dp.segments.insert_sealed_from_catch_up(key, 0, 0);
+        dp.segments.insert_sealed_from_catch_up(key, EntryId(0), EntryId(0));
         assert!(dp.segments.sealed_bounds(&key).is_some());
 
         dp.handle_command(DataPlaneCommand::DataPlaneInterNodeCommand(
@@ -3069,7 +3074,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // A partial local copy on disk plus the matching inventory cursor.
         write_seg_file(
-            &test_key().file_path(dir.path(), 0),
+            &test_key().file_path(dir.path(), EntryId(0)),
             &[(b"a", 1), (b"b", 1)],
         );
         let mut dp = make_data_plane_with(&dir, inventory_with(test_key(), 1));
@@ -3078,8 +3083,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 4,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(4),
                 replica_set: vec![test_node_id(), NodeId::new("source")],
             }
             .into(),
@@ -3091,7 +3096,7 @@ mod tests {
         };
         assert!(matches!(
             &s.message,
-            DataPlaneInterNodeCommand::CatchUpRequest(r) if r.local_end == Some(1)
+            DataPlaneInterNodeCommand::CatchUpRequest(r) if r.local_end == Some(EntryId(1))
         ));
     }
 
@@ -3108,8 +3113,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: 2,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(2),
                 // self (test-node) is a follower here; `leader` is replica_set[0].
                 replica_set: vec![leader.clone(), test_node_id(), follower.clone()],
             }
@@ -3132,8 +3137,8 @@ mod tests {
             CatchUpAssignment {
                 segment_key: test_key(),
                 shard_group_id: ShardGroupId(1),
-                start_entry_id: 0,
-                sealed_end_entry_id: sealed_end,
+                start_entry_id: EntryId(0),
+                sealed_end_entry_id: EntryId(sealed_end),
                 replica_set: vec![test_node_id(), source.clone()],
             }
             .into(),
@@ -3147,7 +3152,7 @@ mod tests {
                 entries: ids
                     .iter()
                     .map(|&entry_id| CatchUpEntry {
-                        entry_id,
+                        entry_id: EntryId(entry_id),
                         data: b"x".to_vec().into(),
                         record_count: 1,
                     })
@@ -3237,8 +3242,8 @@ mod tests {
         ));
 
         // Verified exactly through the sealed end — no duplicate inflation.
-        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((0, 4)));
-        let scan = scan_segment_file(&test_key().file_path(dir.path(), 0)).unwrap();
+        assert_eq!(dp.segments.sealed_bounds(&test_key()), Some((EntryId(0), EntryId(4))));
+        let scan = scan_segment_file(&test_key().file_path(dir.path(), EntryId(0))).unwrap();
         assert_eq!(scan.last_entry_id, Some(4));
     }
 
@@ -3260,7 +3265,7 @@ mod tests {
                     replica_set: vec![leader.clone(), test_node_id()],
                     data: b"x".to_vec().into(),
                     record_count: 1,
-                    entry_id,
+                    entry_id: EntryId(entry_id),
                 }
                 .into(),
             ));
@@ -3269,12 +3274,12 @@ mod tests {
 
         assert_eq!(
             dp.segments.get(&test_key()).unwrap().committed_entry_id(),
-            0,
+            EntryId(0),
             "follower hasn't been told of any commit"
         );
         assert_eq!(
             dp.durable_end(&test_key()),
-            Some(2),
+            Some(EntryId(2)),
             "durable extent is the highest fsync'd entry, ahead of the commit cursor"
         );
     }
@@ -3286,12 +3291,12 @@ mod tests {
         // Sealed store: a sealed segment with bounds (0, 10).
         let sealed_dir = tempfile::tempdir().unwrap();
         let (sealed_dp, _rx) = source_with_sealed_segment(&sealed_dir);
-        assert_eq!(sealed_dp.durable_end(&test_key()), Some(10));
+        assert_eq!(sealed_dp.durable_end(&test_key()), Some(EntryId(10)));
 
         // Recovered inventory only (restarted node, not yet in the live store).
         let recovered_dir = tempfile::tempdir().unwrap();
         let recovered_dp = make_data_plane_with(&recovered_dir, inventory_with(test_key(), 7));
-        assert_eq!(recovered_dp.durable_end(&test_key()), Some(7));
+        assert_eq!(recovered_dp.durable_end(&test_key()), Some(EntryId(7)));
 
         // Hold nothing → None.
         let empty_dir = tempfile::tempdir().unwrap();
@@ -3324,6 +3329,6 @@ mod tests {
         };
         assert_eq!(report.segment_key, test_key());
         assert_eq!(report.from, test_node_id());
-        assert_eq!(report.durable_end, Some(4));
+        assert_eq!(report.durable_end, Some(EntryId(4)));
     }
 }

--- a/src/data_plane/states/replication.rs
+++ b/src/data_plane/states/replication.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 
 use crate::control_plane::NodeId;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 use crate::data_plane::messages::command::{ProduceAck, ReplicaAppend};
 use crate::data_plane::states::segment::cache::CachedEntry;
@@ -19,11 +20,11 @@ pub(crate) struct ReplicationState {
 pub(crate) struct PendingBatch {
     pub(crate) replies: Vec<oneshot::Sender<ProduceAck>>,
     pub(crate) pending_acks: HashSet<NodeId>,
-    pub(crate) entry_id: u64,
+    pub(crate) entry_id: EntryId,
 }
 
 pub(crate) struct AckCommitted {
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub replies: Vec<oneshot::Sender<ProduceAck>>,
     pub reset_timer_seq: Option<u64>,
 }
@@ -223,7 +224,7 @@ mod tests {
         NodeId::new(id)
     }
 
-    fn cached_entry(entry_id: u64) -> Arc<CachedEntry> {
+    fn cached_entry(entry_id: EntryId) -> Arc<CachedEntry> {
         Arc::new(CachedEntry {
             data: EntryPayload::from(Bytes::from("data")),
             record_count: 1,
@@ -235,7 +236,7 @@ mod tests {
     fn pending_repl(
         segment_key: SegmentKey,
         followers: Vec<NodeId>,
-        entry_id: u64,
+        entry_id: EntryId,
     ) -> PendingReplicationBatch {
         PendingReplicationBatch {
             segment_key,
@@ -252,7 +253,7 @@ mod tests {
         let sk = key(0);
 
         state.enqueue_reply(sk, reply_tx);
-        let repl = pending_repl(sk, vec![node("f1"), node("f2")], 0);
+        let repl = pending_repl(sk, vec![node("f1"), node("f2")], EntryId(0));
 
         let seq = state.begin_replication(&repl);
         assert!(seq.is_some());
@@ -264,11 +265,11 @@ mod tests {
         let mut state = ReplicationState::default();
         let sk = key(0);
 
-        let repl1 = pending_repl(sk, vec![node("f1")], 0);
+        let repl1 = pending_repl(sk, vec![node("f1")], EntryId(0));
         let seq = state.begin_replication(&repl1);
         assert!(seq.is_some());
 
-        let repl2 = pending_repl(sk, vec![node("f1")], 1);
+        let repl2 = pending_repl(sk, vec![node("f1")], EntryId(1));
         let seq2 = state.begin_replication(&repl2);
         assert!(seq2.is_none());
     }
@@ -283,7 +284,7 @@ mod tests {
         state.enqueue_reply(sk, tx1);
         state.enqueue_reply(sk, tx2);
 
-        let repl = pending_repl(sk, vec![node("f1")], 0);
+        let repl = pending_repl(sk, vec![node("f1")], EntryId(0));
         state.begin_replication(&repl);
 
         assert_eq!(
@@ -299,7 +300,7 @@ mod tests {
         let f1 = node("f1");
         let f2 = node("f2");
 
-        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 0);
+        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], EntryId(0));
         state.begin_replication(&repl);
 
         let result = state.process_ack(&sk, &f1);
@@ -315,13 +316,13 @@ mod tests {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         state.enqueue_reply(sk, tx);
-        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], 42);
+        let repl = pending_repl(sk, vec![f1.clone(), f2.clone()], EntryId(42));
         state.begin_replication(&repl);
 
         assert!(state.process_ack(&sk, &f1).is_none());
 
         let committed = state.process_ack(&sk, &f2).unwrap();
-        assert_eq!(committed.entry_id, 42);
+        assert_eq!(committed.entry_id, EntryId(42));
         assert_eq!(committed.replies.len(), 1);
         assert!(committed.reset_timer_seq.is_none());
 
@@ -332,10 +333,10 @@ mod tests {
             .into_iter()
             .next()
             .unwrap()
-            .send(ProduceAck::Ok { entry_id: 42 });
+            .send(ProduceAck::Ok { entry_id: EntryId(42) });
         assert!(matches!(
             rx.blocking_recv().unwrap(),
-            ProduceAck::Ok { entry_id: 42 }
+            ProduceAck::Ok { entry_id: EntryId(42) }
         ));
     }
 
@@ -345,14 +346,14 @@ mod tests {
         let sk = key(0);
         let f1 = node("f1");
 
-        let repl1 = pending_repl(sk, vec![f1.clone()], 0);
+        let repl1 = pending_repl(sk, vec![f1.clone()], EntryId(0));
         let first_seq = state.begin_replication(&repl1).unwrap();
 
-        let repl2 = pending_repl(sk, vec![f1.clone()], 1);
+        let repl2 = pending_repl(sk, vec![f1.clone()], EntryId(1));
         assert!(state.begin_replication(&repl2).is_none());
 
         let committed = state.process_ack(&sk, &f1).unwrap();
-        assert_eq!(committed.entry_id, 0);
+        assert_eq!(committed.entry_id, EntryId(0));
         let new_seq = committed.reset_timer_seq.unwrap();
         assert_ne!(first_seq, new_seq);
         assert!(state.is_active_timer(&sk, new_seq));
@@ -372,10 +373,10 @@ mod tests {
         let sk = key(0);
         let f1 = node("f1");
 
-        let repl1 = pending_repl(sk, vec![f1.clone()], 0);
+        let repl1 = pending_repl(sk, vec![f1.clone()], EntryId(0));
         let first_seq = state.begin_replication(&repl1).unwrap();
 
-        let repl2 = pending_repl(sk, vec![f1.clone()], 1);
+        let repl2 = pending_repl(sk, vec![f1.clone()], EntryId(1));
         state.begin_replication(&repl2);
 
         state.process_ack(&sk, &f1).unwrap();

--- a/src/data_plane/states/segment/cache.rs
+++ b/src/data_plane/states/segment/cache.rs
@@ -6,13 +6,14 @@ use std::sync::{
 use arc_swap::ArcSwapOption;
 use tokio::sync::Notify;
 
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::EntryPayload;
 
 #[derive(Debug, Clone)]
 pub struct CachedEntry {
     pub data: EntryPayload,
     pub record_count: u32,
-    pub entry_id: u64,
+    pub entry_id: EntryId,
     pub lsn: u64,
 }
 #[cfg(any(test, debug_assertions))]
@@ -217,7 +218,7 @@ mod tests {
         Arc::new(CachedEntry {
             data: EntryPayload::from(Bytes::from("test")),
             record_count: 1,
-            entry_id,
+            entry_id: EntryId(entry_id),
             lsn,
         })
     }
@@ -231,7 +232,7 @@ mod tests {
         cache.advance_read_cursor(1);
 
         let read = cache.read_committed(0).unwrap();
-        assert_eq!(read.entry_id, 0);
+        assert_eq!(read.entry_id, EntryId(0));
     }
 
     #[test]
@@ -264,7 +265,7 @@ mod tests {
 
         for i in 0..3u64 {
             let entry = cache.read_committed(i).unwrap();
-            assert_eq!(entry.entry_id, i);
+            assert_eq!(entry.entry_id, EntryId(i));
         }
     }
 
@@ -309,7 +310,7 @@ mod tests {
         cache.advance_read_cursor(6);
 
         let entry = cache.read_committed(5).unwrap();
-        assert_eq!(entry.entry_id, 5);
+        assert_eq!(entry.entry_id, EntryId(5));
     }
 
     #[test]

--- a/src/data_plane/states/segment/record.rs
+++ b/src/data_plane/states/segment/record.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bytes::{BufMut, Bytes, BytesMut};
 
-use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 use crate::data_plane::{EntryPayload, SegmentKey};
 
 const ROUTING_HEADER_SIZE: usize = 36;
@@ -12,12 +12,12 @@ pub(crate) struct RoutingHeader {
     topic_id: TopicId,
     range_id: RangeId,
     segment_id: SegmentId,
-    pub(crate) entry_id: u64,
+    pub(crate) entry_id: EntryId,
     pub(crate) record_count: u32,
 }
 
 impl RoutingHeader {
-    pub(crate) fn new(key: SegmentKey, entry_id: u64, record_count: u32) -> Self {
+    pub(crate) fn new(key: SegmentKey, entry_id: EntryId, record_count: u32) -> Self {
         Self {
             topic_id: key.topic_id,
             range_id: key.range_id,
@@ -35,7 +35,7 @@ impl RoutingHeader {
         buf.put_u64(self.topic_id.0);
         buf.put_u64(*self.range_id);
         buf.put_u64(self.segment_id.0);
-        buf.put_u64(self.entry_id);
+        buf.put_u64(*self.entry_id);
         buf.put_u32(self.record_count);
     }
 
@@ -58,7 +58,7 @@ impl RoutingHeader {
             topic_id: TopicId(u64::from_be_bytes(data[0..8].try_into().unwrap())),
             range_id: RangeId(u64::from_be_bytes(data[8..16].try_into().unwrap())),
             segment_id: SegmentId(u64::from_be_bytes(data[16..24].try_into().unwrap())),
-            entry_id: u64::from_be_bytes(data[24..32].try_into().unwrap()),
+            entry_id: EntryId(u64::from_be_bytes(data[24..32].try_into().unwrap())),
             record_count: u32::from_be_bytes(data[32..36].try_into().unwrap()),
         })
     }
@@ -103,7 +103,7 @@ mod tests {
             topic_id: TopicId(42),
             range_id: RangeId(7),
             segment_id: SegmentId(3),
-            entry_id: 999,
+            entry_id: EntryId(999),
             record_count: 50,
         };
         let mut buf = BytesMut::new();
@@ -119,7 +119,7 @@ mod tests {
             topic_id: TopicId(1),
             range_id: RangeId(2),
             segment_id: SegmentId(3),
-            entry_id: 100,
+            entry_id: EntryId(100),
             record_count: 5,
         };
         let entry_data = b"opaque entry payload";

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use crate::control_plane::NodeId;
 use crate::control_plane::membership::ShardGroupId;
+use crate::control_plane::metadata::EntryId;
 use crate::data_plane::{EntryPayload, SegmentKey, checkpoint::CheckpointJob, wal::WalRecord};
 
 use super::cache::CachedEntry;
@@ -24,12 +25,12 @@ pub(crate) struct SegmentTracker {
     role: SegmentRole,
     replica_set: Vec<NodeId>,
     shard_group_id: ShardGroupId,
-    committed_entry_id: u64,
-    next_entry_id: u64,
+    committed_entry_id: EntryId,
+    next_entry_id: EntryId,
     /// The entry id this segment was created with. Stable for the segment's
     /// lifetime; used by the data-plane (range, offset) → segment resolver to
     /// pin BTreeMap keys to a per-segment identity that survives writes.
-    start_entry_id: u64,
+    start_entry_id: EntryId,
     staged_entries: Vec<StagedEntry>,
     created_at: std::time::Instant,
 }
@@ -49,9 +50,9 @@ impl SegmentTracker {
             role,
             replica_set,
             shard_group_id,
-            committed_entry_id: 0,
-            next_entry_id: 0,
-            start_entry_id: 0,
+            committed_entry_id: EntryId::MIN,
+            next_entry_id: EntryId::MIN,
+            start_entry_id: EntryId::MIN,
             staged_entries: Vec::new(),
             created_at: std::time::Instant::now(),
         }
@@ -62,7 +63,7 @@ impl SegmentTracker {
         role: SegmentRole,
         replica_set: Vec<NodeId>,
         shard_group_id: ShardGroupId,
-        start_entry_id: u64,
+        start_entry_id: EntryId,
     ) -> Self {
         let mut tracker = Self::new(path, role, replica_set, shard_group_id);
         tracker.next_entry_id = start_entry_id;
@@ -70,7 +71,7 @@ impl SegmentTracker {
         tracker
     }
 
-    pub(crate) fn start_entry_id(&self) -> u64 {
+    pub(crate) fn start_entry_id(&self) -> EntryId {
         self.start_entry_id
     }
 
@@ -119,7 +120,7 @@ impl SegmentTracker {
             .drain(..)
             .map(|s| {
                 let entry_id = self.next_entry_id;
-                self.next_entry_id += 1;
+                self.next_entry_id += 1u64;
                 let entry = Arc::new(CachedEntry {
                     data: s.data,
                     record_count: s.record_count,
@@ -161,7 +162,7 @@ impl SegmentTracker {
         }
     }
 
-    pub(crate) fn commit_entry(&mut self, entry_id: u64) {
+    pub(crate) fn commit_entry(&mut self, entry_id: EntryId) {
         let commit = self.cache.load_read_cursor();
 
         #[cfg(debug_assertions)]
@@ -185,7 +186,7 @@ impl SegmentTracker {
         self.checkpoint_lsn
     }
 
-    pub(crate) fn committed_entry_id(&self) -> u64 {
+    pub(crate) fn committed_entry_id(&self) -> EntryId {
         self.committed_entry_id
     }
 
@@ -195,13 +196,13 @@ impl SegmentTracker {
 
     /// Successor starts one past the last committed entry — or at `old_start`
     /// when nothing committed, so replayed records keep their entry ids.
-    pub(crate) fn successor_start_entry_id(&self) -> u64 {
+    pub(crate) fn successor_start_entry_id(&self) -> EntryId {
         self.start_entry_id() + self.committed_count()
     }
 
     /// Last committed entry id, or `None` if nothing committed yet — the seal
     /// boundary, so a segment sealed before its first commit owns no offsets.
-    pub(crate) fn last_committed_entry_id(&self) -> Option<u64> {
+    pub(crate) fn last_committed_entry_id(&self) -> Option<EntryId> {
         (self.committed_count() > 0).then_some(self.committed_entry_id)
     }
 
@@ -209,7 +210,7 @@ impl SegmentTracker {
     /// `next_entry_id` only advances in `publish_staged` (after `wal.flush_batch()`),
     /// so `next_entry_id - 1` is durable — and can run ahead of the notified
     /// `committed_entry_id`.
-    pub(crate) fn durable_end_entry_id(&self) -> Option<u64> {
+    pub(crate) fn durable_end_entry_id(&self) -> Option<EntryId> {
         (self.next_entry_id > self.start_entry_id).then(|| self.next_entry_id - 1)
     }
 
@@ -233,7 +234,7 @@ impl SegmentTracker {
         segment_key: SegmentKey,
         data: EntryPayload,
         record_count: u32,
-        entry_id: u64,
+        entry_id: EntryId,
     ) {
         let expected = self.next_entry_id + self.staged_entries.len() as u64;
         if entry_id < expected {
@@ -312,7 +313,7 @@ pub mod tests {
         pub fn cache(&self) -> Arc<SegmentRingBuffer> {
             self.cache.clone()
         }
-        pub fn next_entry_id(&self) -> u64 {
+        pub fn next_entry_id(&self) -> EntryId {
             self.next_entry_id
         }
 
@@ -360,9 +361,9 @@ pub mod tests {
             SegmentRole::Follower,
             vec![NodeId::new("leader"), NodeId::new("follower")],
             ShardGroupId(1),
-            5,
+            EntryId(5),
         );
-        t.stage_entry_from_replica(test_key(), Bytes::from("data").into(), 1, 5);
+        t.stage_entry_from_replica(test_key(), Bytes::from("data").into(), 1, EntryId(5));
         assert!(t.has_staged());
 
         // Publish to advance next_entry_id
@@ -371,9 +372,9 @@ pub mod tests {
         t.publish_staged(1);
 
         // Duplicate entry_id (5) should be skipped since next is now 6
-        t.stage_entry_from_replica(test_key(), Bytes::from("dup").into(), 1, 5);
+        t.stage_entry_from_replica(test_key(), Bytes::from("dup").into(), 1, EntryId(5));
         assert!(!t.has_staged());
-        assert_eq!(t.next_entry_id, 6);
+        assert_eq!(t.next_entry_id, EntryId(6));
         t.assert_invariants();
     }
 
@@ -392,9 +393,9 @@ pub mod tests {
         assert_eq!(t.cache_read_cursor(), 0);
 
         for i in 0..3u64 {
-            t.commit_entry(i);
+            t.commit_entry(EntryId(i));
             assert_eq!(t.cache_read_cursor(), i + 1);
-            assert_eq!(t.committed_entry_id(), i);
+            assert_eq!(t.committed_entry_id(), EntryId(i));
         }
         t.assert_invariants();
     }
@@ -408,14 +409,14 @@ pub mod tests {
 
         assert!(!wal_buf.is_empty());
         assert!(t.has_staged());
-        assert_eq!(t.next_entry_id, 0);
+        assert_eq!(t.next_entry_id, EntryId(0));
 
         let entries = t.publish_staged(1);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].entry_id, 0);
+        assert_eq!(entries[0].entry_id, EntryId(0));
         assert_eq!(entries[0].record_count, 3);
         assert!(!t.has_staged());
-        assert_eq!(t.next_entry_id, 1);
+        assert_eq!(t.next_entry_id, EntryId(1));
         t.assert_invariants();
     }
 

--- a/src/data_plane/states/segment_store.rs
+++ b/src/data_plane/states/segment_store.rs
@@ -24,7 +24,7 @@
 use super::segment::tracker::SegmentTracker;
 use std::collections::{BTreeMap, HashMap};
 
-use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
+use crate::control_plane::metadata::{EntryId, RangeId, SegmentId, TopicId};
 use crate::data_plane::SegmentKey;
 
 /// Where a segment's data currently lives once its tracker has been dropped.
@@ -36,7 +36,7 @@ pub(crate) struct SealedSegmentLocation {
     /// Last entry id in the segment (inclusive). Set at seal time from the
     /// tracker's `committed_entry_id`.
     #[allow(dead_code)]
-    pub(crate) end_entry_id: u64,
+    pub(crate) end_entry_id: EntryId,
 }
 
 /// Outcome of `SegmentStore::resolve`. Splits "active" (tail cache + WAL via
@@ -49,15 +49,15 @@ pub(crate) enum SegmentReadState {
     Active(SegmentKey),
     Sealed {
         key: SegmentKey,
-        start_entry_id: u64,
-        end_entry_id: u64,
+        start_entry_id: EntryId,
+        end_entry_id: EntryId,
     },
 }
 
 pub(crate) struct SegmentStore {
     by_key: HashMap<SegmentKey, SegmentTracker>,
-    active_by_range: HashMap<(TopicId, RangeId), BTreeMap<u64, SegmentId>>,
-    sealed_by_range: HashMap<(TopicId, RangeId), BTreeMap<u64, SealedSegmentLocation>>,
+    active_by_range: HashMap<(TopicId, RangeId), BTreeMap<EntryId, SegmentId>>,
+    sealed_by_range: HashMap<(TopicId, RangeId), BTreeMap<EntryId, SealedSegmentLocation>>,
 }
 
 impl SegmentStore {
@@ -122,7 +122,7 @@ impl SegmentStore {
             .insert(start, key.segment_id);
     }
 
-    pub(crate) fn unindex_active(&mut self, key: SegmentKey, start_entry_id: u64) {
+    pub(crate) fn unindex_active(&mut self, key: SegmentKey, start_entry_id: EntryId) {
         let Some(active) = self.active_by_range.get_mut(&(key.topic_id, key.range_id)) else {
             return;
         };
@@ -171,8 +171,8 @@ impl SegmentStore {
     pub(crate) fn insert_sealed_from_catch_up(
         &mut self,
         key: SegmentKey,
-        start_entry_id: u64,
-        end_entry_id: u64,
+        start_entry_id: EntryId,
+        end_entry_id: EntryId,
     ) {
         debug_assert!(
             !self.by_key.contains_key(&key),
@@ -203,7 +203,7 @@ impl SegmentStore {
         &self,
         topic_id: TopicId,
         range_id: RangeId,
-        entry_id: u64,
+        entry_id: EntryId,
     ) -> Option<SegmentReadState> {
         // ACTIVE PATH
         if let Some(active) = self.active_by_range.get(&(topic_id, range_id))
@@ -240,7 +240,7 @@ impl SegmentStore {
     /// its sparse-index entries. Removes the live tracker (active) or the sealed-index
     /// slot, whichever holds it. `None` if this node doesn't track it — already gone
     /// or never had it; the caller no-ops and orphan GC is the backstop.
-    pub(crate) fn remove_segment(&mut self, key: &SegmentKey) -> Option<u64> {
+    pub(crate) fn remove_segment(&mut self, key: &SegmentKey) -> Option<EntryId> {
         if let Some(tracker) = self.by_key.remove(key) {
             let start = tracker.start_entry_id();
             self.unindex_active(*key, start);
@@ -267,7 +267,7 @@ impl SegmentStore {
     /// `None` if this node holds no sealed segment with that id (GC'd, never had it, or a race), in
     /// which case the source declines and the requester re-drives. O(n) in the
     /// range's sealed segments; catch-up is death-driven and rare.
-    pub(crate) fn sealed_bounds(&self, key: &SegmentKey) -> Option<(u64, u64)> {
+    pub(crate) fn sealed_bounds(&self, key: &SegmentKey) -> Option<(EntryId, EntryId)> {
         let sealed = self.sealed_by_range.get(&(key.topic_id, key.range_id))?;
         sealed.iter().find_map(|(&start, loc)| {
             (loc.segment_id == key.segment_id).then_some((start, loc.end_entry_id))
@@ -335,7 +335,7 @@ mod tests {
             SegmentRole::Leader,
             vec![],
             ShardGroupId(1),
-            start,
+            EntryId(start),
         )
     }
 
@@ -344,7 +344,7 @@ mod tests {
         let mut store = SegmentStore::new();
         let k = key(1, 0, 0);
         store.insert_active(k, tracker(0));
-        let r = store.resolve(TopicId(1), RangeId(0), 5).unwrap();
+        let r = store.resolve(TopicId(1), RangeId(0), EntryId(5)).unwrap();
         assert!(matches!(r, SegmentReadState::Active(g) if g == k));
     }
 
@@ -355,9 +355,9 @@ mod tests {
         let s1 = key(1, 0, 1);
         store.insert_active(s0, tracker(0));
         store.insert_active(s1, tracker(100));
-        let mid = store.resolve(TopicId(1), RangeId(0), 50).unwrap();
-        let edge = store.resolve(TopicId(1), RangeId(0), 99).unwrap();
-        let next = store.resolve(TopicId(1), RangeId(0), 100).unwrap();
+        let mid = store.resolve(TopicId(1), RangeId(0), EntryId(50)).unwrap();
+        let edge = store.resolve(TopicId(1), RangeId(0), EntryId(99)).unwrap();
+        let next = store.resolve(TopicId(1), RangeId(0), EntryId(100)).unwrap();
         assert!(matches!(mid, SegmentReadState::Active(g) if g == s0));
         assert!(matches!(edge, SegmentReadState::Active(g) if g == s0));
         assert!(matches!(next, SegmentReadState::Active(g) if g == s1));
@@ -368,13 +368,13 @@ mod tests {
         let mut store = SegmentStore::new();
         let k = key(1, 0, 0);
         let mut t = tracker(0);
-        t.commit_entry(42);
+        t.commit_entry(EntryId(42));
         store.insert_active(k, t);
 
         let taken = store.take_active_and_seal(k);
         assert!(taken.is_some());
 
-        let r = store.resolve(TopicId(1), RangeId(0), 10).unwrap();
+        let r = store.resolve(TopicId(1), RangeId(0), EntryId(10)).unwrap();
         match r {
             SegmentReadState::Sealed {
                 key: g,
@@ -382,14 +382,14 @@ mod tests {
                 end_entry_id,
             } => {
                 assert_eq!(g, k);
-                assert_eq!(start_entry_id, 0);
-                assert_eq!(end_entry_id, 42);
+                assert_eq!(start_entry_id, EntryId(0));
+                assert_eq!(end_entry_id, EntryId(42));
             }
             other => panic!("expected Sealed, got {other:?}"),
         }
 
         // Offset past sealed end_entry_id → no segment found.
-        assert!(store.resolve(TopicId(1), RangeId(0), 43).is_none());
+        assert!(store.resolve(TopicId(1), RangeId(0), EntryId(43)).is_none());
     }
 
     /// A segment sealed before its first commit owns no offsets, so it must end
@@ -405,14 +405,14 @@ mod tests {
         assert!(taken.is_some());
 
         assert!(
-            store.resolve(TopicId(1), RangeId(0), 0).is_none(),
+            store.resolve(TopicId(1), RangeId(0), EntryId(0)).is_none(),
             "a segment sealed with nothing committed must not claim offset 0",
         );
 
         // The successor reuses start 0 and now serves offset 0.
         let s1 = key(1, 0, 1);
         store.insert_active(s1, tracker(0));
-        let r = store.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        let r = store.resolve(TopicId(1), RangeId(0), EntryId(0)).unwrap();
         assert!(matches!(r, SegmentReadState::Active(g) if g == s1));
     }
 
@@ -424,9 +424,9 @@ mod tests {
         let successor = key(1, 0, 1);
         store.insert_active(successor, tracker(0)); // successor already at start 0
 
-        store.unindex_active(key(1, 0, 0), 0); // try to unindex the OLD segment id
+        store.unindex_active(key(1, 0, 0), EntryId(0)); // try to unindex the OLD segment id
 
-        let r = store.resolve(TopicId(1), RangeId(0), 0).unwrap();
+        let r = store.resolve(TopicId(1), RangeId(0), EntryId(0)).unwrap();
         assert!(
             matches!(r, SegmentReadState::Active(g) if g == successor),
             "unindexing a different segment id must not evict the successor",
@@ -438,11 +438,11 @@ mod tests {
         let mut store = SegmentStore::new();
         let k = key(1, 0, 7);
         let mut t = tracker(20);
-        t.commit_entry(99);
+        t.commit_entry(EntryId(99));
         store.insert_active(k, t);
         store.take_active_and_seal(k);
 
-        assert_eq!(store.sealed_bounds(&k), Some((20, 99)));
+        assert_eq!(store.sealed_bounds(&k), Some((EntryId(20), EntryId(99))));
         // Same range, a segment id this node never sealed → None.
         assert_eq!(store.sealed_bounds(&key(1, 0, 8)), None);
         // A range with no sealed segments at all → None.
@@ -454,19 +454,19 @@ mod tests {
         let mut store = SegmentStore::new();
         let k = key(1, 0, 5);
         // Received whole via catch-up — never active here.
-        store.insert_sealed_from_catch_up(k, 100, 142);
+        store.insert_sealed_from_catch_up(k, EntryId(100), EntryId(142));
 
-        assert_eq!(store.sealed_bounds(&k), Some((100, 142)));
+        assert_eq!(store.sealed_bounds(&k), Some((EntryId(100), EntryId(142))));
         // And the resolver routes an in-range offset to it (cold path).
-        match store.resolve(TopicId(1), RangeId(0), 120).unwrap() {
+        match store.resolve(TopicId(1), RangeId(0), EntryId(120)).unwrap() {
             SegmentReadState::Sealed {
                 key: g,
                 start_entry_id,
                 end_entry_id,
             } => {
                 assert_eq!(g, k);
-                assert_eq!(start_entry_id, 100);
-                assert_eq!(end_entry_id, 142);
+                assert_eq!(start_entry_id, EntryId(100));
+                assert_eq!(end_entry_id, EntryId(142));
             }
             other => panic!("expected Sealed, got {other:?}"),
         }

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -9,7 +9,7 @@ use crate::connections::protocol::{
     ControlPlaneRequest, ControlPlaneResponse, DataPlaneResponse, FetchByIdRequest, FetchRequest,
     NodeState, ProduceRequest, RangeProgressSignal, TopicDetail,
 };
-use crate::control_plane::metadata::RangeId;
+use crate::control_plane::metadata::{EntryId, RangeId};
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
 use crate::it::helpers::{default_env, send_request, try_send_request};
 use crate::it::sim::invariants::{query_shard_info, query_shard_leader};
@@ -470,7 +470,7 @@ fn produce_then_fetch_hot() -> turmoil::Result {
                 && !batch.is_empty()
             {
                 progress_signal = signal;
-                next_entry_id = next;
+                next_entry_id = *next;
                 entries.extend(batch);
                 if entries.len() >= 3 {
                     break;
@@ -486,7 +486,7 @@ fn produce_then_fetch_hot() -> turmoil::Result {
             "all three produced records should fetch, got {}",
             entries.len()
         );
-        assert_eq!(entries[0].entry_id, 0);
+        assert_eq!(entries[0].entry_id, EntryId(0));
         assert_eq!(entries[0].data, b"rec-0");
         assert_eq!(entries[1].data, b"rec-1");
         assert_eq!(entries[2].data, b"rec-2");
@@ -563,7 +563,7 @@ fn age_seal_rolls_the_active_segment() -> turmoil::Result {
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id > 0
+                && *seg.start_entry_id > 0
             {
                 rolled_start = Some(seg.start_entry_id);
                 break;
@@ -677,7 +677,7 @@ fn sealed_segment_repair_catches_up_the_spare() -> turmoil::Result {
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id > 0
+                && *seg.start_entry_id > 0
             {
                 let replicas = seg
                     .replica_set
@@ -718,7 +718,7 @@ fn sealed_segment_repair_catches_up_the_spare() -> turmoil::Result {
                 ClientRequest::DataPlane(ClientDataPlaneRequest::FetchById(FetchByIdRequest {
                     topic_id,
                     range_id: RangeId(0),
-                    entry_id: 0,
+                    entry_id: EntryId(0),
                     max_bytes: 1 << 20,
                 }));
             if let ClientResponse::DataPlane(DataPlaneResponse::Fetched { entries, .. }) =
@@ -835,7 +835,7 @@ fn leader_crash_seals_active_segment_at_min_and_continues() -> turmoil::Result {
                 && let Some(write_leader) = seg.replica_set.first()
             {
                 assert_eq!(
-                    seg.start_entry_id, 0,
+                    seg.start_entry_id, EntryId(0),
                     "segment must still be active at offset 0"
                 );
                 chosen = Some((detail.topic_id, write_leader.node_id.clone()));
@@ -873,7 +873,7 @@ fn leader_crash_seals_active_segment_at_min_and_continues() -> turmoil::Result {
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id == 1
+                && *seg.start_entry_id == 1
             {
                 if let Some(new_leader) = seg.replica_set.first() {
                     assert!(
@@ -900,7 +900,7 @@ fn leader_crash_seals_active_segment_at_min_and_continues() -> turmoil::Result {
                     ClientRequest::DataPlane(ClientDataPlaneRequest::FetchById(FetchByIdRequest {
                         topic_id,
                         range_id: RangeId(0),
-                        entry_id: 0,
+                        entry_id: EntryId(0),
                         max_bytes: 1 << 20,
                     }));
                 if let ClientResponse::DataPlane(DataPlaneResponse::Fetched { entries, .. }) =
@@ -1022,7 +1022,7 @@ fn sealed_repair_survives_coordinator_crash() -> turmoil::Result {
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id > 0
+                && *seg.start_entry_id > 0
             {
                 let replicas = seg
                     .replica_set
@@ -1095,7 +1095,7 @@ fn sealed_repair_survives_coordinator_crash() -> turmoil::Result {
                 ClientRequest::DataPlane(ClientDataPlaneRequest::FetchById(FetchByIdRequest {
                     topic_id,
                     range_id: RangeId(0),
-                    entry_id: 0,
+                    entry_id: EntryId(0),
                     max_bytes: 1 << 20,
                 }));
             if let ClientResponse::DataPlane(DataPlaneResponse::Fetched { entries, .. }) =
@@ -1209,7 +1209,7 @@ fn catch_up_redrive_recovers_dropped_assignment() -> turmoil::Result {
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id > 0
+                && *seg.start_entry_id > 0
             {
                 let replicas = seg
                     .replica_set
@@ -1253,7 +1253,7 @@ fn catch_up_redrive_recovers_dropped_assignment() -> turmoil::Result {
         let fetch = ClientRequest::DataPlane(ClientDataPlaneRequest::FetchById(FetchByIdRequest {
             topic_id,
             range_id: RangeId(0),
-            entry_id: 0,
+            entry_id: EntryId(0),
             max_bytes: 1 << 20,
         }));
 
@@ -1430,7 +1430,7 @@ fn restarted_node_reuses_recovered_segment_on_reassignment() -> turmoil::Result 
                     .ranges
                     .first()
                     .and_then(|r| r.active_segment.as_ref())
-                && seg.start_entry_id > 0
+                && *seg.start_entry_id > 0
             {
                 topic_id = Some(detail.topic_id);
                 break;
@@ -1450,7 +1450,7 @@ fn restarted_node_reuses_recovered_segment_on_reassignment() -> turmoil::Result 
         let fetch = ClientRequest::DataPlane(ClientDataPlaneRequest::FetchById(FetchByIdRequest {
             topic_id,
             range_id: RangeId(0),
-            entry_id: 0,
+            entry_id: EntryId(0),
             max_bytes: 1 << 20,
         }));
         let mut served = false;

--- a/src/it/e2e/client_protocol.rs
+++ b/src/it/e2e/client_protocol.rs
@@ -9,8 +9,9 @@ use crate::connections::protocol::{
     ControlPlaneRequest, ControlPlaneResponse, DataPlaneResponse, FetchByIdRequest, FetchRequest,
     NodeState, ProduceRequest, RangeProgressSignal, TopicDetail,
 };
-use crate::control_plane::metadata::{EntryId, RangeId};
+use crate::control_plane::membership::ShardGroupId;
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
+use crate::control_plane::metadata::{EntryId, RangeId};
 use crate::it::helpers::{default_env, send_request, try_send_request};
 use crate::it::sim::invariants::{query_shard_info, query_shard_leader};
 
@@ -451,12 +452,12 @@ fn produce_then_fetch_hot() -> turmoil::Result {
         // empty response just means "keep polling"; never reaching all three is
         // a failure.
         let mut entries = Vec::new();
-        let mut next_entry_id = 0u64;
+        let mut next_entry_id = EntryId(0u64);
         let mut progress_signal = RangeProgressSignal::Active;
         for _ in 0..80 {
             let fetch = ClientRequest::DataPlane(ClientDataPlaneRequest::Fetch(FetchRequest {
                 topic_name: TOPIC.into(),
-                range_id: 0,
+                range_id: RangeId(0),
                 entry_id: next_entry_id,
                 record_index: 0,
                 max_bytes: 1 << 20,
@@ -470,7 +471,7 @@ fn produce_then_fetch_hot() -> turmoil::Result {
                 && !batch.is_empty()
             {
                 progress_signal = signal;
-                next_entry_id = *next;
+                next_entry_id = next;
                 entries.extend(batch);
                 if entries.len() >= 3 {
                     break;
@@ -490,7 +491,7 @@ fn produce_then_fetch_hot() -> turmoil::Result {
         assert_eq!(entries[0].data, b"rec-0");
         assert_eq!(entries[1].data, b"rec-1");
         assert_eq!(entries[2].data, b"rec-2");
-        assert_eq!(next_entry_id, 3);
+        assert_eq!(*next_entry_id, 3);
         assert!(
             matches!(progress_signal, RangeProgressSignal::Active),
             "fresh single-range topic stays Active, got {progress_signal:?}"
@@ -835,7 +836,8 @@ fn leader_crash_seals_active_segment_at_min_and_continues() -> turmoil::Result {
                 && let Some(write_leader) = seg.replica_set.first()
             {
                 assert_eq!(
-                    seg.start_entry_id, EntryId(0),
+                    seg.start_entry_id,
+                    EntryId(0),
                     "segment must still be active at offset 0"
                 );
                 chosen = Some((detail.topic_id, write_leader.node_id.clone()));
@@ -849,7 +851,7 @@ fn leader_crash_seals_active_segment_at_min_and_continues() -> turmoil::Result {
             .find(|n| leader_id.starts_with(n))
             .expect("write-leader must be one of the nodes");
         tracing::info!(
-            "[LEADERCRASH] topic_id={topic_id} write-leader={leader_id} victim={victim_node}"
+            "[LEADERCRASH] topic_id={topic_id:?} write-leader={leader_id} victim={victim_node}"
         );
         *victim_w.lock().unwrap() = Some(victim_node.to_string());
 
@@ -1056,7 +1058,7 @@ fn sealed_repair_survives_coordinator_crash() -> turmoil::Result {
             .find(|(n, _)| !replicas.iter().any(|r| r.starts_with(n)))
             .expect("a spare node");
         tracing::info!(
-            "[COORDCRASH] shard={shard_group_id} leader/victim={leader_id} spare={spare:?}"
+            "[COORDCRASH] shard={shard_group_id:?} leader/victim={leader_id} spare={spare:?}"
         );
         *victim_w.lock().unwrap() = Some(victim_node.to_string());
 
@@ -1506,7 +1508,7 @@ fn restarted_node_reuses_recovered_segment_on_reassignment() -> turmoil::Result 
 /// Resolve the topic shard group's metadata leader: `(shard_group_id, leader node id)`.
 /// Reads the group + members from any node (a ring lookup), then polls members for an
 /// authoritative Raft leader (a non-member's `GetShardLeader` is `None`).
-async fn metadata_leader(topic: &str, nodes: &[(&str, u16)]) -> Option<(u64, String)> {
+async fn metadata_leader(topic: &str, nodes: &[(&str, u16)]) -> Option<(ShardGroupId, String)> {
     for _ in 0..60 {
         tokio::time::sleep(Duration::from_secs(1)).await;
         let mut info = None;

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -13,11 +13,13 @@ use turmoil::Builder;
 
 use super::{NodeSpec, host_cluster};
 use crate::client::{
-    Client, ClientError, Consumer, ConsumerConfig, KeyInterest, PartitionStrategy, RetryPolicy,
-    StartPolicy, StoragePolicy,
+    BufferConfig, Client, ClientError, CompressionCodec, Consumer, ConsumerConfig, KeyInterest,
+    PartitionStrategy, Producer, ProducerConfig, RetryPolicy, StartPolicy, StoragePolicy,
+    TopicDetail,
 };
 use crate::config::Environment;
-use crate::control_plane::metadata::RangeId;
+use crate::connections::protocol::ClientResponse;
+use crate::control_plane::metadata::{EntryId, RangeId};
 
 /// (name, client_port, raft/cluster_port) for the standard 3-node cluster.
 static NODES: [NodeSpec; 3] = [
@@ -399,16 +401,16 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "compressed-topic".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(50),
                     max_batch_bytes: 1024 * 1024,
                     max_batch_records: 100,
                 },
-                codec: crate::client::CompressionCodec::Lz4,
+                codec: CompressionCodec::Lz4,
             },
         );
 
@@ -436,7 +438,7 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
         let fetch_req = FetchByIdRequest {
             topic_id,
             range_id,
-            entry_id,
+            entry_id: EntryId(entry_id),
             max_bytes: 65536,
         };
 
@@ -444,26 +446,24 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
             .call(leader_addr, ClientDataPlaneRequest::FetchById(fetch_req))
             .await
             .expect("fetch");
-        if let crate::connections::protocol::ClientResponse::DataPlane(
-            DataPlaneResponse::Fetched { entries, .. },
-        ) = served.response
+        if let ClientResponse::DataPlane(DataPlaneResponse::Fetched { entries, .. }) =
+            served.response
         {
             assert_eq!(entries.len(), 1);
             let entry = &entries[0];
-            assert_eq!(entry.entry_id, entry_id);
+            assert_eq!(entry.entry_id, EntryId(entry_id));
             assert_eq!(entry.record_count, 2);
 
             // Verify that the first byte of the stored payload is indeed the Lz4 codec tag (1)
             assert_eq!(
                 entry.data[0],
-                crate::client::CompressionCodec::Lz4 as u8,
+                CompressionCodec::Lz4 as u8,
                 "Stored payload must lead with Lz4 tag"
             );
 
             // Decompress and decode records from the retrieved payload
-            let decoded_records =
-                crate::client::CompressionCodec::decode_payload(&entry.data, entry.record_count)
-                    .expect("Decompress and decode batch");
+            let decoded_records = CompressionCodec::decode_payload(&entry.data, entry.record_count)
+                .expect("Decompress and decode batch");
 
             assert_eq!(decoded_records.len(), 2);
             assert_eq!(decoded_records[0].key, b"ckey");
@@ -501,16 +501,16 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
         // Warm the cache
         client.resolve_topic("zstd-topic").await.expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "zstd-topic".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(50),
                     max_batch_bytes: 1024 * 1024,
                     max_batch_records: 100,
                 },
-                codec: crate::client::CompressionCodec::Zstd,
+                codec: CompressionCodec::Zstd,
             },
         );
 
@@ -535,7 +535,7 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
         let fetch_req = FetchByIdRequest {
             topic_id,
             range_id,
-            entry_id,
+            entry_id: EntryId(entry_id),
             max_bytes: 65536,
         };
 
@@ -543,26 +543,24 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
             .call(leader_addr, ClientDataPlaneRequest::FetchById(fetch_req))
             .await
             .expect("fetch");
-        if let crate::connections::protocol::ClientResponse::DataPlane(
-            DataPlaneResponse::Fetched { entries, .. },
-        ) = served.response
+        if let ClientResponse::DataPlane(DataPlaneResponse::Fetched { entries, .. }) =
+            served.response
         {
             assert_eq!(entries.len(), 1);
             let entry = &entries[0];
-            assert_eq!(entry.entry_id, entry_id);
+            assert_eq!(entry.entry_id, EntryId(entry_id));
             assert_eq!(entry.record_count, 2);
 
             // Verify that the first byte of the stored payload is indeed the Zstd codec tag (2)
             assert_eq!(
                 entry.data[0],
-                crate::client::CompressionCodec::Zstd as u8,
+                CompressionCodec::Zstd as u8,
                 "Stored payload must lead with Zstd tag"
             );
 
             // Decompress and decode records from the retrieved payload
-            let decoded_records =
-                crate::client::CompressionCodec::decode_payload(&entry.data, entry.record_count)
-                    .expect("Decompress and decode batch");
+            let decoded_records = CompressionCodec::decode_payload(&entry.data, entry.record_count)
+                .expect("Decompress and decode batch");
 
             assert_eq!(decoded_records.len(), 2);
             assert_eq!(decoded_records[0].key, b"zkey");
@@ -599,16 +597,16 @@ fn producer_concurrency_stress() -> turmoil::Result {
         // Warm the cache
         client.resolve_topic("prod-stress").await.expect("resolve");
 
-        let producer = Arc::new(crate::client::Producer::new(
+        let producer = Arc::new(Producer::new(
             client.clone(),
             "prod-stress".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(30),
                     max_batch_bytes: 1024 * 1024,
                     max_batch_records: 100,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         ));
 
@@ -698,17 +696,17 @@ fn producer_overlapping_linger_scenario() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "linger-overlap".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(100),
                     // Threshold is 2 records
                     max_batch_bytes: 1024 * 1024,
                     max_batch_records: 2,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -799,16 +797,16 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
             .expect("resolve");
 
         // Produce 5 records
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "basic-consume".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 5,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -920,16 +918,16 @@ fn consumer_latest_starts_at_end_of_active_segment() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "basic-consume-latest".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 5,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -1009,16 +1007,16 @@ fn consumer_key_filtering_multi_range() -> turmoil::Result {
             .expect("resolve");
 
         // Produce a record, then wait for roll, 3 times to trigger split
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "key-filter-multi".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 1,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -1112,16 +1110,16 @@ fn consumer_range_split_consume() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "split-consume".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 1,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -1224,16 +1222,16 @@ fn consumer_retention_recovery() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "retention-recover".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 1,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -1312,16 +1310,16 @@ fn consumer_prefetch_sealed_segments() -> turmoil::Result {
             .await
             .expect("resolve");
 
-        let producer = crate::client::Producer::new(
+        let producer = Producer::new(
             client.clone(),
             "prefetch-topic".to_string(),
-            crate::client::ProducerConfig {
-                buffer: crate::client::BufferConfig {
+            ProducerConfig {
+                buffer: BufferConfig {
                     linger: Duration::from_millis(10),
                     max_batch_bytes: 1024,
                     max_batch_records: 1,
                 },
-                codec: crate::client::CompressionCodec::None,
+                codec: CompressionCodec::None,
             },
         );
 
@@ -1404,7 +1402,7 @@ async fn wait_for_segment_roll(
                 return;
             }
             if let Some(seg) = &range.active_segment
-                && seg.segment_id >= expected_segment_id
+                && *seg.segment_id >= expected_segment_id
             {
                 return;
             }
@@ -1416,7 +1414,7 @@ async fn wait_for_segment_roll(
     );
 }
 
-async fn wait_for_split(client: &Client, topic: &str) -> crate::connections::protocol::TopicDetail {
+async fn wait_for_split(client: &Client, topic: &str) -> TopicDetail {
     for _ in 0..240 {
         tokio::time::sleep(Duration::from_millis(250)).await;
         if let Ok(detail) = client.resolve_topic(topic).await
@@ -1439,7 +1437,7 @@ async fn wait_for_retention_deletion(client: &Client, topic: &str, range_id: u64
                 .find(|r| r.range_id == RangeId(range_id))
             && range.sealed_segments.is_empty()
             && let Some(seg) = &range.active_segment
-            && seg.start_entry_id > 0
+            && seg.start_entry_id > 0.into()
         {
             return;
         }

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -438,7 +438,7 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
         let fetch_req = FetchByIdRequest {
             topic_id,
             range_id,
-            entry_id: EntryId(entry_id),
+            entry_id,
             max_bytes: 65536,
         };
 
@@ -451,7 +451,7 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
         {
             assert_eq!(entries.len(), 1);
             let entry = &entries[0];
-            assert_eq!(entry.entry_id, EntryId(entry_id));
+            assert_eq!(entry.entry_id, entry_id);
             assert_eq!(entry.record_count, 2);
 
             // Verify that the first byte of the stored payload is indeed the Lz4 codec tag (1)
@@ -535,7 +535,7 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
         let fetch_req = FetchByIdRequest {
             topic_id,
             range_id,
-            entry_id: EntryId(entry_id),
+            entry_id,
             max_bytes: 65536,
         };
 
@@ -548,7 +548,7 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
         {
             assert_eq!(entries.len(), 1);
             let entry = &entries[0];
-            assert_eq!(entry.entry_id, EntryId(entry_id));
+            assert_eq!(entry.entry_id, entry_id);
             assert_eq!(entry.record_count, 2);
 
             // Verify that the first byte of the stored payload is indeed the Zstd codec tag (2)
@@ -644,7 +644,7 @@ fn producer_concurrency_stress() -> turmoil::Result {
 
         // Assert that batching actually happened: the number of unique entry IDs
         // must be significantly less than the total number of records (500).
-        let unique_ids: HashSet<u64> = all_ids.into_iter().collect();
+        let unique_ids: HashSet<EntryId> = all_ids.into_iter().collect();
         assert!(
             unique_ids.len() < (TASKS * RECORDS_PER_TASK) / 2,
             "Records must be batched; unique entry IDs: {}, total: {}",

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -1,5 +1,6 @@
 use super::{NodeSpec, host_cluster};
 use crate::client::{Client, Consumer, ConsumerConfig, KeyInterest, Producer, ProducerConfig, StartPolicy};
+use crate::control_plane::metadata::RangeState;
 use crate::control_plane::metadata::strategy::{PartitionStrategy, StoragePolicy};
 use std::sync::Arc;
 use std::time::Duration;
@@ -423,12 +424,12 @@ fn consumer_group_split_rebalance() {
                     let r_opt = detail.ranges.iter().find(|r| r.range_id == RangeId(0));
                     match r_opt {
                         Some(r) => {
-                            if r.state == crate::control_plane::metadata::RangeState::Sealed {
+                            if r.state == RangeState::Sealed {
                                 rolled = true;
                                 break;
                             }
                             if let Some(s) = &r.active_segment
-                                && s.segment_id >= (i + 1) as u64
+                                && *s.segment_id >= (i + 1) as u64
                             {
                                 rolled = true;
                                 break;

--- a/src/it/raft/election.rs
+++ b/src/it/raft/election.rs
@@ -9,7 +9,7 @@ use turmoil::Builder;
 
 use crate::control_plane::NodeId;
 use crate::control_plane::consensus::actor::MultiRaftActor;
-use crate::control_plane::consensus::messages::{MultiRaftActorCommand, RaftTimer};
+use crate::control_plane::consensus::messages::{EnsureGroup, MultiRaftActorCommand, RaftTimer};
 use crate::control_plane::consensus::transport::RaftTransportActor;
 use crate::control_plane::membership::actor::SwimActor;
 use crate::control_plane::membership::{ShardGroup, ShardGroupId};
@@ -134,7 +134,7 @@ async fn run_raft_node(
     );
 
     raft_tx
-        .send(crate::control_plane::consensus::messages::EnsureGroup {
+        .send(EnsureGroup {
             group: group.clone(),
         })
         .await

--- a/src/it/sim/invariants.rs
+++ b/src/it/sim/invariants.rs
@@ -5,6 +5,7 @@ use crate::connections::protocol::{
 use crate::connections::reader::ClientStreamReader;
 use crate::connections::writer::ClientRawWriter;
 use crate::control_plane::SwimNodeState;
+use crate::control_plane::membership::ShardGroupId;
 use crate::it::helpers::get_members;
 use crate::net::TcpStream;
 use std::time::Duration;
@@ -76,7 +77,7 @@ pub async fn assert_membership_converged(
 /// all non-None answers name the same leader.
 pub async fn assert_single_leader(
     nodes: &[(&str, u16)],
-    shard_group_id: u64,
+    shard_group_id: ShardGroupId,
     timeout: Duration,
 ) -> turmoil::Result {
     tokio::time::sleep(timeout).await;
@@ -99,7 +100,7 @@ pub async fn assert_single_leader(
                 *l,
                 first,
                 "split-brain detected for shard {}: node[{}] reports leader {:?}, node[0] reports {:?}",
-                shard_group_id,
+                *shard_group_id,
                 i + 1,
                 l,
                 first
@@ -121,7 +122,7 @@ pub async fn assert_single_leader(
 /// observable signal, and that is what this asserts (#133).
 pub async fn assert_leader_converges(
     nodes: &[(&str, u16)],
-    shard_group_id: u64,
+    shard_group_id: ShardGroupId,
     crashed: &str,
     budget: Duration,
 ) -> turmoil::Result {
@@ -147,7 +148,7 @@ pub async fn assert_leader_converges(
         assert!(
             tokio::time::Instant::now() < deadline,
             "shard {}: nodes did not converge on a single replacement leader within {:?} (views: {:?}, crashed: {:?})",
-            shard_group_id,
+            *shard_group_id,
             budget,
             views,
             crashed
@@ -195,7 +196,7 @@ pub async fn assert_topic_visible_on_quorum(
 pub(in crate::it) async fn query_shard_leader(
     host: &str,
     port: u16,
-    shard_group_id: u64,
+    shard_group_id: ShardGroupId,
 ) -> turmoil::Result<Option<String>> {
     let stream =
         tokio::time::timeout(Duration::from_secs(2), TcpStream::connect((host, port))).await??;

--- a/src/it/sim/properties.rs
+++ b/src/it/sim/properties.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use turmoil::Builder;
 
 use crate::StartUp;
+use crate::connections::protocol::ControlPlaneResponse;
 use crate::it::helpers::{check_alive_count, check_dead_or_not_exist, default_env};
 use crate::it::sim::invariants::{
     assert_leader_converges, assert_membership_converged, assert_single_leader,
@@ -103,7 +104,7 @@ fn metadata_visible() -> turmoil::Result {
         for _ in 0..30u32 {
             tokio::time::sleep(Duration::from_secs(1)).await;
             for i in 1..=3u8 {
-                if let Some(crate::connections::protocol::ControlPlaneResponse::TopicCreated) =
+                if let Some(ControlPlaneResponse::TopicCreated) =
                     try_propose(&node_name(i), client_port(i), &req).await
                 {
                     acked = true;
@@ -198,7 +199,7 @@ fn leader_elects_after_kill() -> turmoil::Result {
             }
             if !topic_acked {
                 for i in 1..=3u8 {
-                    if let Some(crate::connections::protocol::ControlPlaneResponse::TopicCreated) =
+                    if let Some(ControlPlaneResponse::TopicCreated) =
                         try_propose(&node_name(i), client_port(i), &req).await
                     {
                         topic_acked = true;

--- a/src/it/sim/properties.rs
+++ b/src/it/sim/properties.rs
@@ -6,6 +6,7 @@ use turmoil::Builder;
 
 use crate::StartUp;
 use crate::connections::protocol::ControlPlaneResponse;
+use crate::control_plane::membership::ShardGroupId;
 use crate::it::helpers::{check_alive_count, check_dead_or_not_exist, default_env};
 use crate::it::sim::invariants::{
     assert_leader_converges, assert_membership_converged, assert_single_leader,
@@ -184,7 +185,7 @@ fn leader_elects_after_kill() -> turmoil::Result {
         // ── Phase 1: topology + an initial leader agreed by ≥2 nodes ──
         let req = make_create_topic_req("leader-kill-test");
         let phase1_deadline = t0 + Duration::from_secs(30);
-        let mut shard_group_id: Option<u64> = None;
+        let mut shard_group_id: Option<ShardGroupId> = None;
         let mut topic_acked = false;
         let mut agreed_leader: Option<String> = None;
         let mut last_round: Vec<Option<String>> = vec![None, None, None];
@@ -234,7 +235,7 @@ fn leader_elects_after_kill() -> turmoil::Result {
         let initial_leader = agreed_leader.unwrap_or_else(|| {
             panic!(
                 "phase1: no quorum-agreed leader within 30s \
-                 (shard {shard_group_id}, topic_acked: {topic_acked}, \
+                 (shard {shard_group_id:?}, topic_acked: {topic_acked}, \
                  last views from node-1..3: {last_round:?})"
             )
         });
@@ -242,21 +243,14 @@ fn leader_elects_after_kill() -> turmoil::Result {
         assert!(
             topic_acked,
             "phase1: CreateTopic never acked within 30s \
-             (shard {shard_group_id}, leader {initial_leader}, \
+             (shard {shard_group_id:?}, leader {initial_leader}, \
              last views from node-1..3: {last_round:?})"
         );
 
         let victim_idx = (1..=3u8)
             .find(|i| initial_leader.starts_with(node_name(*i).as_str()))
             .unwrap_or_else(|| panic!("leader id {initial_leader:?} maps to no known host"));
-        tracing::info!(
-            elapsed = ?t0.elapsed(),
-            shard_group_id,
-            %initial_leader,
-            victim_idx,
-            topic_acked,
-            "phase1 done"
-        );
+
         victim_tx.store(victim_idx, Ordering::SeqCst);
 
         // Wait for the driver to perform the crash (it gates on the store above).


### PR DESCRIPTION


### Changes
1. Global Type Safety: Replaced the raw  u64  primitive log entry offset type with the newtype wrapper  EntryId  across all system boundaries (including Client, Data-Plane Storage, Control Plane, and Network Protocols).

2. E2E Integration & Unit Tests Refactored: Updated all test scenarios (both raw data-plane queries, WAL replay scans, segment indexing, consumer group rebalancing, and crash recovery simulators) to construct request payloads and assert offsets using  EntryId .)



### Issue found
While refactoring, I found that current consumer offset calculation violates type-safety and WILL incur offset error, double consumption. The problem emerges as the type becomes clear and specific to entry id which is different than offset WITHIN the entry. 