### PR TITLE
Implement consumer Latest and record-position fixes

### DIFF
--- a/diagrams/clients/c3_consumer.md
+++ b/diagrams/clients/c3_consumer.md
@@ -100,6 +100,45 @@ identically whether it came from a hot replica or a cold segment file.
 
 ---
 
+## Record positions inside batched entries
+
+An entry is the broker's unit of durability, replication, and fetch. The producer may
+place several application records into one entry during its linger window, then compress
+and publish that batch as one opaque payload. The broker stamps one entry id on the whole
+payload; it does not know or index the individual records inside.
+
+That leaves three values in the consumer-facing position:
+
+| Coordinate | Meaning | Advances when |
+|---|---|---|
+| Entry id | Physical position of a stored entry in a range | A produce batch commits |
+| Batch offset | Record position inside that entry | The consumer decodes records from the payload |
+| Absolute offset | Logical record progress for the consumer stream | Each application record is delivered |
+
+The entry id and batch offset are the structural coordinate: together they identify the
+last delivered record closely enough for a restarted consumer to resume without either
+replaying or skipping records. The absolute offset is still important for progress,
+diagnostics, and lag, but it is not a storage seek key. Batch sizes vary with linger timing,
+byte limits, record limits, compression, and caller concurrency; a logical record counter
+therefore cannot be converted into an entry id.
+
+```
+entry 0: [record 0, record 1, record 2]
+entry 1: [record 0, record 1]
+entry 2: [record 0]
+
+committed position: entry 1, batch offset 1, absolute offset 4
+resume fetches:      entry 1
+resume skips:        record 0 and record 1 inside entry 1
+first delivered:     entry 2, record 0, absolute offset 5
+```
+
+This split keeps the broker opaque. The data plane stores and serves bytes; the consumer,
+which already has to decode the entry before delivery, is the layer that can see the
+intra-entry record boundary and attach the correct record-level position.
+
+---
+
 ## Lineage, made concrete
 
 The whole reason consume is more than "read a partition" is that ranges reshape live.
@@ -123,9 +162,28 @@ reconstruct the DAG from any historical ancestor when starting *earliest*.
 
 `ListOffsets` returns a range's surviving start and committed end — used to (a) bound a
 read window, and (b) recover from retention: a consumer that fell behind and fetched a
-now-deleted segment (see d7) skips forward to the surviving start. Durable offset
-*commit* (remembering where a consumer left off across restarts) is a consumer-group
-concern, out of scope here — C3 is a single consumer driving its own cursors.
+now-deleted segment (see d7) skips forward to the surviving start.
+
+Durable offset *storage* is a consumer-group concern (see d8), but C3 defines the position
+that gets stored because it is the layer that turns entries into application records. A
+committed position is a **last delivered** coordinate, not a next-record coordinate:
+
+| Stored field | Why it is stored |
+|---|---|
+| Range | Identifies which range the position belongs to |
+| Entry id | Tells the resumed consumer which physical entry to fetch first |
+| Batch offset | Tells the resumed consumer how much of that entry was already processed |
+| Absolute offset | Restores the logical record counter after restart and supports lag reporting |
+
+On resume, a saved position overrides the configured start policy for that range. The
+consumer fetches the saved entry, drops records with batch offsets less than or equal to
+the saved batch offset, then delivers the first unread record with the saved absolute
+offset plus one. The skip applies only to the saved entry; once that entry has been
+evaluated, later entries stream normally.
+
+If the saved entry has already fallen behind retention, the normal retention path wins:
+the cursor moves to the surviving start and the intra-entry skip is discarded because the
+physical entry it referred to no longer exists.
 
 ---
 
@@ -174,17 +232,21 @@ across; at a **merge**, hold the successor's first fetch until both parents drai
    `ListOffsets`.
 6. **Record decode** — read each entry's codec tag and decompress before surfacing
    records to the application (the producer/consumer contract from `c2_producer.md`).
-7. **Prefetch the next sealed segment** — while draining a sealed segment, pre-open the
+7. **Record-level positions** — surface entry id, batch offset, and absolute offset with
+   each delivered record; use the structural coordinate for resume and the absolute offset
+   for logical progress.
+8. **Prefetch the next sealed segment** — while draining a sealed segment, pre-open the
    next segment's replica connection and speculatively fetch past the current segment's
    end, so a hand-off to a segment on another node doesn't stall on connect + cold-read
    latency. Driven entirely from cached per-segment placement — no server cooperation;
    off on the active tail.
-8. **Tests** — against the simulated cluster: ordered drain of a range, a split mid-
+9. **Tests** — against the simulated cluster: ordered drain of a range, a split mid-
    consume (fan-out to children, each key once), a merge mid-consume (both parents
    drained before successor), read from a non-leader replica, by-id fetch after
    resolving the topic id, skip-forward past a retention-deleted segment, a compressed
-   entry decoded by its codec tag, and a historical read crossing a sealed-segment
-   boundary onto a different replica, served from a prewarmed next segment (no stall).
+   entry decoded by its codec tag, record-level resume from the middle of a batched
+   entry, and a historical read crossing a sealed-segment boundary onto a different
+   replica, served from a prewarmed next segment (no stall).
 
 ## See also
 
@@ -192,6 +254,8 @@ across; at a **merge**, hold the successor's first fetch until both parents drai
 - `d4_consumer_range_tracking.md` — the server side of the in-band progress signal and
   range transitions.
 - `d7_retention_gc.md` — retention deletion and the skip-forward recovery.
+- `d8_consumer_offset_management.md` — consumer-group offset storage and cooperative
+  assignment.
 - `d1_storage_engine.md` — the cold-read pool and the within-node hot/cold seam this
   prefetch mirrors, and the opaque payload the consumer decompresses.
 - `client_roadmap.md` — consumer-group / durable-offset backlog context.

--- a/src/client/consumer/cursor.rs
+++ b/src/client/consumer/cursor.rs
@@ -284,8 +284,9 @@ impl RangeCursor {
             .filter(|r| r.state == RangeState::Active)
             .filter(|r| interest.matches(r))
             .map(|r| {
-                // ! Why start_entry_id when it is latest cursors? now it barely means 'starting from active segment', not the last entry of active segment.
-                // TODO e2e test that covers this case
+                // Metadata can choose the active ranges, but only ListOffsets can
+                // resolve the live tail. The async consumer bootstrap overwrites
+                // this placeholder before starting fetch tasks.
                 let start_entry = r.active_segment.as_ref().map_or(0, |s| *s.start_entry_id);
                 RangeCursor::new(
                     r.range_id,

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -96,16 +96,10 @@ impl Consumer {
 
         if matches!(config.start_policy, StartPolicy::Latest) {
             for cursor in cursors.iter_mut() {
-                let has_saved_offset =
-                    consumer_group.is_some() && cursor.next_entry_id > EntryId::default();
-                if !has_saved_offset
-                    && let Ok((_, committed_entry_id)) =
-                        client.fetch_range_entry_ids(&topic, cursor.range_id).await
-                {
-                    // ! next_entry_id = committed_entry_id? How come commited_entry becomes the next one.
-                    // TODO shouldn't it be committed_entry_id + 1? Or wrong naming
-                    cursor.next_entry_id = committed_entry_id;
-                }
+                let (_, tail_entry_id) = client
+                    .fetch_range_entry_ids(&topic, cursor.range_id)
+                    .await?;
+                cursor.next_entry_id = tail_entry_id;
             }
         }
 

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -126,20 +126,28 @@ impl TopicFetchManagerState {
         let metadata = ctx.metadata.load();
 
         for range in to_start {
-            let (resolved_entry_id, skip_below_offset, next_absolute_offset) =
-                if let Some(pos) = saved_offsets.get(&range) {
-                    // Prefer explicitly saved offsets. The committed offset is a
-                    // record-level checkpoint. Because one entry can contain multiple
-                    // records, the next entry we fetch begins at the physical batch containing
-                    // the committed offset, and we skip any records that have already been processed.
-                    (
-                        pos.entry_id,
-                        Some(pos.batch_offset),
-                        pos.absolute_offset.saturating_add(1),
-                    )
-                } else {
-                    (self.resolve_start_entry_id(range, ctx).await, None, 0)
+            let (resolved_entry_id, skip_below_offset, next_absolute_offset) = if let Some(pos) =
+                saved_offsets.get(&range)
+            {
+                // Prefer explicitly saved offsets. The committed offset is a
+                // record-level checkpoint. Because one entry can contain multiple
+                // records, the next entry we fetch begins at the physical batch containing
+                // the committed offset, and we skip any records that have already been processed.
+                (
+                    pos.entry_id,
+                    Some(pos.batch_offset),
+                    pos.absolute_offset.saturating_add(1),
+                )
+            } else {
+                let resolved = match self.resolve_start_entry_id(range, ctx).await {
+                    Ok(resolved) => resolved,
+                    Err(error) => {
+                        tracing::warn!(?range, ?error, "failed to resolve consumer start entry id");
+                        continue;
+                    }
                 };
+                (resolved, None, 0)
+            };
 
             if self.should_skip_start(range, &metadata.ranges, &saved_offsets, resolved_entry_id) {
                 continue;
@@ -186,23 +194,24 @@ impl TopicFetchManagerState {
     /// In EastGuard:
     /// - **Entry ID** refers to the physical index of a record in the range's log.
     /// - **Offset** refers to the logical consumer-committed checkpoint (which is the last processed entry ID).
-    async fn resolve_start_entry_id(&self, range: RangeId, ctx: &Arc<ConsumerContext>) -> EntryId {
+    async fn resolve_start_entry_id(
+        &self,
+        range: RangeId,
+        ctx: &Arc<ConsumerContext>,
+    ) -> Result<EntryId, ClientError> {
         // 1. Fetch the latest boundary from the replica if the start policy is Latest.
-        // Note: fetch_range_entry_ids returns (start_entry_id, committed_entry_id).
-        if matches!(self.start_policy(), StartPolicy::Latest)
-            && let Ok((_, committed_entry_id)) =
-                ctx.client.fetch_range_entry_ids(&ctx.topic, range).await
-        {
-            return committed_entry_id;
+        if matches!(self.start_policy(), StartPolicy::Latest) {
+            let (_, tail_entry_id) = ctx.client.fetch_range_entry_ids(&ctx.topic, range).await?;
+            return Ok(tail_entry_id);
         }
 
         // 2. Fallback to the local cursor's next entry ID.
         if let Some(cursor) = self.cursors.get(range) {
-            return cursor.next_entry_id;
+            return Ok(cursor.next_entry_id);
         }
 
         // 3. Default start entry ID is 0
-        EntryId::default()
+        Ok(EntryId::default())
     }
 
     async fn abort_all(&mut self) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,6 +41,7 @@ use routing::RoutingCache;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use tokio::time::Instant;
 
 /// A connection to an EastGuard cluster. Cheap to construct (connections are lazy);
 /// share one across tasks behind an `Arc` — every method takes `&self` and the pool
@@ -94,40 +95,60 @@ impl Client {
         }
     }
 
+    /// Returns the range's surviving start and the next entry id to request at
+    /// the observed tail. The second value is not the last committed entry id.
     pub async fn fetch_range_entry_ids(
         &self,
         topic: &str,
         range_id: RangeId,
     ) -> Result<(EntryId, EntryId), ClientError> {
-        let detail = self.resolve_topic(topic).await?;
-        let addr = detail
-            .ranges
-            .iter()
-            .find(|r| r.range_id == range_id)
-            .and_then(|r| {
-                r.active_segment
-                    .as_ref()
-                    .or_else(|| r.sealed_segments.last())
-            })
-            .and_then(|seg| seg.pick_replica())
-            .unwrap_or_else(|| self.next_known_node());
+        let deadline = Instant::now() + self.retry.deadline;
+        let mut backoff = self.retry.initial_backoff;
+        let mut last_error = None;
 
-        let req = RangeOffsetRequest {
-            topic_name: topic.to_string(),
-            range_id,
-        };
+        loop {
+            if Instant::now() >= deadline {
+                return Err(ClientError::Timeout {
+                    waited: self.retry.deadline,
+                    last_error,
+                });
+            }
 
-        let served = self.call(addr, req).await?;
+            let detail = self.resolve_topic(topic).await?;
+            let addr = detail
+                .ranges
+                .iter()
+                .find(|r| r.range_id == range_id)
+                .and_then(|r| {
+                    r.active_segment
+                        .as_ref()
+                        .or_else(|| r.sealed_segments.last())
+                })
+                .and_then(|seg| seg.pick_replica())
+                .unwrap_or_else(|| self.next_known_node());
 
-        let ClientResponse::DataPlane(DataPlaneResponse::RangeOffset {
-            start_entry_id,
-            committed_entry_id,
-        }) = served.response
-        else {
-            return Err(ClientError::UnexpectedResponse);
-        };
+            let req = RangeOffsetRequest {
+                topic_name: topic.to_string(),
+                range_id,
+            };
 
-        Ok((start_entry_id, committed_entry_id))
+            let served = self.call(addr, req).await?;
+
+            match served.response {
+                ClientResponse::DataPlane(DataPlaneResponse::RangeOffset {
+                    start_entry_id,
+                    next_entry_id,
+                }) => return Ok((start_entry_id, next_entry_id)),
+                ClientResponse::DataPlane(DataPlaneResponse::SegmentNotLocal) => {
+                    last_error = Some("range offsets segment not local".to_string());
+                }
+                _ => return Err(ClientError::UnexpectedResponse),
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(backoff.min(remaining)).await;
+            backoff = (backoff * 2).min(self.retry.max_backoff);
+        }
     }
 
     pub async fn fetch_all_saved_offsets(

--- a/src/connections/protocol/data_plane.rs
+++ b/src/connections/protocol/data_plane.rs
@@ -99,7 +99,7 @@ pub enum DataPlaneResponse {
 
     RangeOffset {
         start_entry_id: EntryId,
-        committed_entry_id: EntryId,
+        next_entry_id: EntryId,
     },
     // `NotWriteLeader` is the segment's data-replica write leader (`replica_set[0]`),
     // distinct from the metadata Raft leader (`ControlPlaneResponse::NotRaftLeader`).
@@ -128,10 +128,10 @@ impl DataPlaneResponse {
         match value {
             ListOffsetsResult::RangeOffsets {
                 start_entry_id,
-                committed_entry_id,
+                next_entry_id,
             } => DataPlaneResponse::RangeOffset {
                 start_entry_id,
-                committed_entry_id,
+                next_entry_id,
             },
             ListOffsetsResult::SegmentNotLocal => DataPlaneResponse::SegmentNotLocal,
             ListOffsetsResult::InternalError(s) => DataPlaneResponse::InternalError(s),

--- a/src/data_plane/messages/query.rs
+++ b/src/data_plane/messages/query.rs
@@ -75,7 +75,7 @@ pub struct ListOffsets {
 pub enum ListOffsetsResult {
     RangeOffsets {
         start_entry_id: EntryId,
-        committed_entry_id: EntryId,
+        next_entry_id: EntryId,
     },
     SegmentNotLocal,
     #[allow(dead_code)] // reserved for future failure modes

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -336,7 +336,7 @@ impl<W: WalStorage> DataPlane<W> {
         };
         let _ = cmd.reply.send(ListOffsetsResult::RangeOffsets {
             start_entry_id: tracker.start_entry_id(),
-            committed_entry_id: tracker.successor_start_entry_id(),
+            next_entry_id: tracker.successor_start_entry_id(),
         });
     }
 


### PR DESCRIPTION
  Summary:
  - Clarified `ListOffsets` semantics by renaming the offset-query result from committed_entry_id to
    next_entry_id.
      - The value is the observed tail / next entry to fetch, not the last committed entry.

  - Updated `StartPolicy::Latest` bootstrap to resolve the live tail via ListOffsets instead of treating the
    active segment start as “latest.”

  - Added retry/backoff in fetch_range_entry_ids() for transient SegmentNotLocal responses during roll/split
    metadata propagation.


