### PR TITLE
feat: node-wide hot cache budget and pressure-triggered checkpoint sy…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,22 @@ pub struct Environment {
     )]
     pub batch_max_bytes: usize,
 
+    /// Node-wide hot cache budget for published segment entries. When resident
+    /// hot cache bytes cross `HOT_CACHE_PRESSURE_WATERMARK`, the
+    /// data plane submits a checkpoint for the largest checkpointable segment.
+    /// Set to 0 to disable pressure-triggered checkpoints.
+    #[arg(
+        long,
+        env = "HOT_CACHE_BUDGET_BYTES",
+        default_value_t = 4 * 1024 * 1024 * 1024
+    )]
+    pub hot_cache_budget_bytes: u64,
+
+    /// Fraction of `HOT_CACHE_BUDGET_BYTES` that triggers cache-pressure
+    /// checkpointing. Mirrors Pulsar's broker cache eviction watermark shape.
+    #[arg(long, env = "HOT_CACHE_PRESSURE_WATERMARK", default_value_t = 0.9)]
+    pub hot_cache_pressure_watermark: f64,
+
     #[arg(long, env = "SEAL_REQUEST_TIMEOUT_SECS", default_value_t = 5)]
     pub seal_request_timeout_secs: u64,
 
@@ -361,6 +377,8 @@ impl Environment {
             ),
             segment_size_limit: self.segment_size_limit_bytes,
             batch_max_bytes: self.batch_max_bytes,
+            hot_cache_budget_bytes: self.hot_cache_budget_bytes,
+            hot_cache_pressure_watermark: self.hot_cache_pressure_watermark,
             seal_request_timeout: std::time::Duration::from_secs(self.seal_request_timeout_secs),
             orphan_gc_interval: std::time::Duration::from_secs(self.orphan_gc_interval_secs),
             data_dir: self.data_dir_path(),
@@ -374,6 +392,8 @@ pub struct DataNodeConfig {
     pub age_check_interval: std::time::Duration,
     pub segment_size_limit: u64,
     pub batch_max_bytes: usize,
+    pub hot_cache_budget_bytes: u64,
+    pub hot_cache_pressure_watermark: f64,
     pub seal_request_timeout: std::time::Duration,
     pub orphan_gc_interval: std::time::Duration,
     pub data_dir: PathBuf,
@@ -382,6 +402,14 @@ pub struct DataNodeConfig {
 impl DataNodeConfig {
     pub(crate) fn age_check_ticks(&self) -> u64 {
         self.age_check_interval.as_millis() as u64 / TICK_PERIOD_100_MS
+    }
+
+    pub(crate) fn cache_pressure_threshold_bytes(&self) -> Option<u64> {
+        if self.hot_cache_budget_bytes == 0 {
+            return None;
+        }
+        let watermark = self.hot_cache_pressure_watermark.clamp(0.0, 1.0);
+        Some((self.hot_cache_budget_bytes as f64 * watermark) as u64)
     }
 }
 
@@ -414,6 +442,8 @@ mod tests {
             segment_age_check_interval_secs: 60,
             segment_size_limit_bytes: 1024 * 1024 * 1024,
             batch_max_bytes: 10 * 1024 * 1024,
+            hot_cache_budget_bytes: 4 * 1024 * 1024 * 1024,
+            hot_cache_pressure_watermark: 0.9,
             seal_request_timeout_secs: 5,
             orphan_gc_interval_secs: 300,
         }

--- a/src/data_plane/checkpoint.rs
+++ b/src/data_plane/checkpoint.rs
@@ -101,6 +101,7 @@ impl CheckpointWorker {
             segment_key: job.segment_key,
             checkpointed_lsn: checkpoint.last_lsn(),
             new_frontier: checkpoint.new_frontier,
+            checkpointed_bytes: checkpoint.byte_len(),
         }
         .into();
         let _ = data_plane_tx.send(DataPlaneMessage::Command(completion));

--- a/src/data_plane/messages/command.rs
+++ b/src/data_plane/messages/command.rs
@@ -267,6 +267,7 @@ pub struct CheckpointComplete {
     pub segment_key: SegmentKey,
     pub checkpointed_lsn: u64,
     pub new_frontier: u64,
+    pub checkpointed_bytes: u64,
 }
 
 /// The cold-read pool's reply for a catch-up *source* read.

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -90,6 +90,7 @@ pub struct DataPlane<W: WalStorage> {
     /// full-copy and to skip transfer when we already hold the segment.
     recovered: LocalInventory,
     pending_seals: std::collections::HashSet<SegmentKey>,
+    pressure_checkpoints_in_flight: BTreeSet<SegmentKey>,
 }
 
 impl<W: WalStorage> DataPlane<W> {
@@ -118,6 +119,7 @@ impl<W: WalStorage> DataPlane<W> {
             out,
             recovered,
             pending_seals: std::collections::HashSet::new(),
+            pressure_checkpoints_in_flight: BTreeSet::new(),
         }
     }
 
@@ -341,8 +343,14 @@ impl<W: WalStorage> DataPlane<W> {
     }
 
     fn handle_checkpoint_complete(&mut self, complete: CheckpointComplete) {
+        self.pressure_checkpoints_in_flight
+            .remove(&complete.segment_key);
         if let Some(tracker) = self.segments.get_mut(&complete.segment_key) {
-            tracker.advance_checkpoint(complete.checkpointed_lsn, complete.new_frontier);
+            tracker.advance_checkpoint(
+                complete.checkpointed_lsn,
+                complete.new_frontier,
+                complete.checkpointed_bytes,
+            );
         }
 
         let watermark = self.compute_checkpoint_watermark();
@@ -1279,6 +1287,7 @@ impl<W: WalStorage> DataPlane<W> {
 
         self.buffer_byte_count = 0;
         self.needs_flush = false;
+        self.submit_checkpoint_if_cache_pressure();
     }
 
     fn compute_checkpoint_watermark(&self) -> u64 {
@@ -1289,21 +1298,35 @@ impl<W: WalStorage> DataPlane<W> {
             .unwrap_or(0)
     }
 
-    // Kept for the node-level cache budget pressure path described in D1.
-    #[allow(dead_code)]
+    fn hot_cache_bytes(&self) -> u64 {
+        self.segments.values().map(|t| t.hot_cache_bytes()).sum()
+    }
+
+    fn submit_checkpoint_if_cache_pressure(&mut self) {
+        let Some(threshold) = self.config.cache_pressure_threshold_bytes() else {
+            return;
+        };
+        if threshold == 0 || self.hot_cache_bytes() >= threshold {
+            self.submit_checkpoint_for_pressure();
+        }
+    }
+
     fn submit_checkpoint_for_pressure(&mut self) {
         let mut candidates: Vec<(SegmentKey, u64)> = self
             .segments
             .iter()
-            .map(|(key, tracker)| (*key, tracker.uncheckpointed()))
+            .filter(|(key, _)| !self.pressure_checkpoints_in_flight.contains(key))
+            .map(|(key, tracker)| (*key, tracker.checkpointable_bytes()))
             .collect();
 
         candidates.sort_by_key(|b| std::cmp::Reverse(b.1));
 
-        if let Some((key, _)) = candidates.first()
+        if let Some((key, bytes)) = candidates.first()
+            && *bytes > 0
             && let Some(tracker) = self.segments.get(key)
         {
             self.out.store_checkpoint(tracker.checkpoint(*key));
+            self.pressure_checkpoints_in_flight.insert(*key);
         }
     }
 
@@ -1405,6 +1428,8 @@ mod tests {
             age_check_interval: std::time::Duration::from_secs(60),
             segment_size_limit: 1024 * 1024 * 1024,
             batch_max_bytes: TEST_BATCH_MAX_BYTES,
+            hot_cache_budget_bytes: 0,
+            hot_cache_pressure_watermark: 0.9,
             seal_request_timeout: std::time::Duration::from_secs(5),
             orphan_gc_interval: std::time::Duration::from_secs(300),
             data_dir: dir,
@@ -1705,6 +1730,116 @@ mod tests {
         assert!(!dp.has_buffered_data());
     }
 
+    #[test]
+    fn cache_pressure_checkpoint_disabled_when_budget_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.handle_command(assign_segment(test_key(), vec![]));
+
+        dp.handle_command(Produce {
+            segment_key: test_key(),
+            data: Bytes::from(vec![0u8; 16]).into(),
+            record_count: 1,
+            reply: oneshot::channel().0,
+        });
+        dp.flush_batch();
+
+        assert_eq!(dp.hot_cache_bytes(), 16);
+        assert!(dp.out.checkpoint_tasks.is_empty());
+    }
+
+    #[test]
+    fn cache_pressure_submits_largest_checkpointable_segment() {
+        use crate::data_plane::checkpoint::CheckpointTask;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.config.hot_cache_budget_bytes = 100;
+        dp.config.hot_cache_pressure_watermark = 0.5;
+
+        let small = SegmentKey::new(TopicId(1), RangeId(0), SegmentId(0));
+        let large = SegmentKey::new(TopicId(2), RangeId(0), SegmentId(0));
+        dp.handle_command(assign_segment(small, vec![]));
+        dp.handle_command(assign_segment(large, vec![]));
+
+        dp.handle_command(Produce {
+            segment_key: small,
+            data: Bytes::from(vec![0u8; 10]).into(),
+            record_count: 1,
+            reply: oneshot::channel().0,
+        });
+        dp.handle_command(Produce {
+            segment_key: large,
+            data: Bytes::from(vec![0u8; 45]).into(),
+            record_count: 1,
+            reply: oneshot::channel().0,
+        });
+        dp.flush_batch();
+
+        assert_eq!(dp.hot_cache_bytes(), 55);
+        assert_eq!(dp.out.checkpoint_tasks.len(), 1);
+        let CheckpointTask::Checkpoint(job) = &dp.out.checkpoint_tasks[0] else {
+            panic!("expected checkpoint task");
+        };
+        assert_eq!(job.segment_key, large);
+    }
+
+    #[test]
+    fn cache_pressure_counts_uncommitted_hot_bytes_but_checkpoints_only_committed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.config.hot_cache_budget_bytes = 10;
+        dp.config.hot_cache_pressure_watermark = 0.5;
+        dp.handle_command(assign_segment(
+            test_key(),
+            vec![test_node_id(), NodeId::new("follower")],
+        ));
+
+        dp.handle_command(Produce {
+            segment_key: test_key(),
+            data: Bytes::from(vec![0u8; 8]).into(),
+            record_count: 1,
+            reply: oneshot::channel().0,
+        });
+        dp.flush_batch();
+
+        assert_eq!(dp.hot_cache_bytes(), 8);
+        assert_eq!(
+            dp.segments.get(&test_key()).unwrap().checkpointable_bytes(),
+            0
+        );
+        assert!(dp.out.checkpoint_tasks.is_empty());
+    }
+
+    #[test]
+    fn cache_pressure_does_not_duplicate_in_flight_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.config.hot_cache_budget_bytes = 10;
+        dp.config.hot_cache_pressure_watermark = 0.5;
+        dp.handle_command(assign_segment(test_key(), vec![]));
+
+        dp.handle_command(Produce {
+            segment_key: test_key(),
+            data: Bytes::from(vec![0u8; 8]).into(),
+            record_count: 1,
+            reply: oneshot::channel().0,
+        });
+        dp.flush_batch();
+        assert_eq!(dp.out.checkpoint_tasks.len(), 1);
+
+        dp.submit_checkpoint_if_cache_pressure();
+        assert_eq!(dp.out.checkpoint_tasks.len(), 1);
+
+        dp.handle_command(DataPlaneCommand::CheckpointComplete(CheckpointComplete {
+            segment_key: test_key(),
+            checkpointed_lsn: 1,
+            new_frontier: 1,
+            checkpointed_bytes: 8,
+        }));
+        assert!(dp.pressure_checkpoints_in_flight.is_empty());
+    }
+
     /// A seal that arrives while the active segment still holds a staged-but-
     /// unflushed produce must carry that produce into the successor. The old
     /// tracker is retired (removed from the leader-staged sum), so dropping its
@@ -1782,6 +1917,7 @@ mod tests {
             segment_key: key1,
             checkpointed_lsn: 10,
             new_frontier: 0,
+            checkpointed_bytes: 0,
         }));
         assert_eq!(wal_file_count(), initial_count);
 
@@ -1789,6 +1925,7 @@ mod tests {
             segment_key: key2,
             checkpointed_lsn: 5,
             new_frontier: 0,
+            checkpointed_bytes: 0,
         }));
     }
 

--- a/src/data_plane/states/segment/cache.rs
+++ b/src/data_plane/states/segment/cache.rs
@@ -10,43 +10,60 @@ use crate::control_plane::metadata::EntryId;
 use crate::data_plane::EntryPayload;
 
 #[derive(Debug, Clone)]
-pub struct CachedEntry {
-    pub data: EntryPayload,
-    pub record_count: u32,
-    pub entry_id: EntryId,
-    pub lsn: u64,
+pub(crate) struct CachedEntry {
+    pub(crate) data: EntryPayload,
+    pub(crate) record_count: u32,
+    pub(crate) entry_id: EntryId,
+    pub(crate) lsn: u64,
 }
+
+impl CachedEntry {
+    pub(crate) fn byte_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
 #[cfg(any(test, debug_assertions))]
 use crate::test_traits::TAssertInvariant;
 
 const DEFAULT_CAPACITY: usize = 1024;
+const EMPTY_SLOT_POSITION: u64 = u64::MAX;
 
-// Slots use `ArcSwapOption` instead of raw `AtomicPtr` to make load + refcount
-// increment atomic. With `AtomicPtr`, a consumer at the hot/cold boundary
-// (position == eviction_frontier) could load a raw pointer, then get preempted
-// before calling `Arc::increment_strong_count`. If the publisher wraps the
-// entire ring (~1024 publishes) during that window, the slot is overwritten
-// and the old Arc freed — the consumer wakes up holding a dangling pointer.
-// `ArcSwapOption::load_full()` returns `Option<Arc<…>>` with the refcount
-// already incremented, closing this gap with ~2-5ns overhead per read —
-// negligible since batch processing cost dominates.
-//
-// Refcount lifecycle:
-//   - `store(Some(batch))`: slot takes ownership. If overwriting, old Arc is
-//     dropped (refcount -1). Old batch freed only if no readers hold it.
-//   - `load_full()`: returns a new Arc clone (refcount +1). Slot keeps its
-//     own ref independently. Caller dropping the Arc decrements refcount.
-//   - Eviction: `advance_eviction_frontier` moves the cursor but does NOT
-//     clear the slot. The old Arc stays alive until `publish` overwrites it
-//     on the next ring wrap. This is delayed cleanup, not a leak — the slot
-//     is logically evicted (readers rejected by frontier check) but the
-//     memory is reclaimed when the publisher physically reaches that slot.
+/// Slots use `ArcSwapOption` instead of raw `AtomicPtr` to make load + refcount
+/// increment atomic. With `AtomicPtr`, a consumer at the hot/cold boundary
+/// (position == eviction_frontier) could load a raw pointer, then get preempted
+/// before calling `Arc::increment_strong_count`. If the publisher wraps the
+/// entire ring (~1024 publishes) during that window, the slot is overwritten
+/// and the old Arc freed — the consumer wakes up holding a dangling pointer.
+/// `ArcSwapOption::load_full()` returns `Option<Arc<…>>` with the refcount
+/// already incremented, closing this gap with ~2-5ns overhead per read —
+/// negligible since batch processing cost dominates.
+///
+/// Refcount lifecycle:
+///   - `store(Some(batch))`: slot takes ownership. If overwriting, old Arc is
+///     dropped (refcount -1). Old batch freed only if no readers hold it.
+///   - `load_full()`: returns a new Arc clone (refcount +1). Slot keeps its
+///     own ref independently. Caller dropping the Arc decrements refcount.
+///   - Eviction: checkpoint completion advances the frontier and clears evicted
+///     slots that still hold the same cache position. If a slot wrapped and now
+///     holds a newer entry, it is left intact.
+///
+/// Ordering model:
+/// - [`slot_positions`](Self::slot_positions) and cursors(write_cursor, read_cursor, and eviction_frontier) are the publication fences.
+///   Writers store them with "Release"; readers load them with Acquire before trusting a slot or cursor boundary.
+///
+/// - [`slot_byte_lengths`](Self::slot_byte_lengths) and [`byte counter`](Self::hot_cache_bytes) are accounting only.
+///   They do not  make entry contents visible, so "Relaxed" is enough.
 pub(crate) struct SegmentRingBuffer {
     entries: Box<[ArcSwapOption<CachedEntry>]>,
+    slot_positions: Box<[AtomicU64]>,
+    slot_byte_lengths: Box<[AtomicU64]>,
     capacity: usize,
     write_cursor: AtomicU64,
     read_cursor: AtomicU64,
     eviction_frontier: AtomicU64,
+    hot_cache_bytes: AtomicU64,
+    checkpointable_bytes: AtomicU64,
     notify: Notify,
 }
 
@@ -64,13 +81,25 @@ impl SegmentRingBuffer {
             .take(capacity)
             .collect::<Vec<_>>()
             .into_boxed_slice();
+        let slot_positions = std::iter::repeat_with(|| AtomicU64::new(EMPTY_SLOT_POSITION))
+            .take(capacity)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let slot_byte_lengths = std::iter::repeat_with(|| AtomicU64::new(0))
+            .take(capacity)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
 
         SegmentRingBuffer {
             entries,
+            slot_positions,
+            slot_byte_lengths,
             capacity,
             write_cursor: AtomicU64::new(0),
             read_cursor: AtomicU64::new(0),
             eviction_frontier: AtomicU64::new(0),
+            hot_cache_bytes: AtomicU64::new(0),
+            checkpointable_bytes: AtomicU64::new(0),
             notify: Notify::new(),
         }
     }
@@ -79,19 +108,25 @@ impl SegmentRingBuffer {
         (position as usize) & (self.capacity - 1)
     }
 
-    // Write path (called by DataPlane)
-
     pub(super) fn publish(&self, entry: Arc<CachedEntry>) {
-        let tail = self.write_cursor.load(Ordering::Acquire);
+        let tail = self.write_cursor.load(Ordering::Relaxed);
         let idx = self.slot_index(tail);
-        self.entries[idx].store(Some(entry));
+        self.hot_cache_bytes
+            .fetch_add(entry.byte_len() as u64, Ordering::Relaxed);
 
-        // ! SAFETY: why not self.write_cursor.fetch_add(1)?
-        // ! because there is only one writer thread
+        self.slot_byte_lengths[idx].store(entry.byte_len() as u64, Ordering::Relaxed);
+        self.entries[idx].store(Some(entry));
+        self.slot_positions[idx].store(tail, Ordering::Release);
         self.write_cursor.store(tail + 1, Ordering::Release);
     }
 
-    pub(in crate::data_plane::states::segment) fn advance_read_cursor(&self, new_offset: u64) {
+    pub(crate) fn advance_read_cursor(&self, new_offset: u64) {
+        let old_offset = self.read_cursor.load(Ordering::Relaxed);
+        let committed_bytes: u64 = (old_offset..new_offset)
+            .map(|pos| self.byte_len_at(pos))
+            .sum();
+        self.checkpointable_bytes
+            .fetch_add(committed_bytes, Ordering::Relaxed);
         self.read_cursor.store(new_offset, Ordering::Release);
         self.notify.notify_waiters();
     }
@@ -114,7 +149,7 @@ impl SegmentRingBuffer {
         }
 
         let idx = self.slot_index(position);
-        self.entries[idx].load_full()
+        self.load_slot_at(idx, position)
     }
 
     /// Internal read: returns any published entry (committed or uncommitted).
@@ -127,7 +162,23 @@ impl SegmentRingBuffer {
         }
 
         let idx = self.slot_index(position);
+        self.load_slot_at(idx, position)
+    }
+
+    fn load_slot_at(&self, idx: usize, position: u64) -> Option<Arc<CachedEntry>> {
+        // The requested logical position maps to this physical slot, but does this slot still contain that logical position?”
+        if self.slot_positions[idx].load(Ordering::Acquire) != position {
+            return None;
+        }
         self.entries[idx].load_full()
+    }
+
+    fn byte_len_at(&self, position: u64) -> u64 {
+        let idx = self.slot_index(position);
+        if self.slot_positions[idx].load(Ordering::Acquire) != position {
+            return 0;
+        }
+        self.slot_byte_lengths[idx].load(Ordering::Relaxed)
     }
 
     pub(super) fn load_eviction_frontier(&self) -> u64 {
@@ -145,7 +196,7 @@ impl SegmentRingBuffer {
         let mut entries = Vec::new();
         for pos in frontier..commit {
             let idx: usize = self.slot_index(pos);
-            if let Some(entry) = self.entries[idx].load_full() {
+            if let Some(entry) = self.load_slot_at(idx, pos) {
                 entries.push(entry);
             }
         }
@@ -156,12 +207,50 @@ impl SegmentRingBuffer {
         }
     }
 
-    pub(in crate::data_plane::states::segment) fn advance_eviction_frontier(
-        &self,
-        new_frontier: u64,
-    ) {
+    pub(crate) fn complete_checkpoint(&self, new_frontier: u64, checkpointed_bytes: u64) {
+        let old_frontier = self.eviction_frontier.load(Ordering::Acquire);
+        if new_frontier <= old_frontier {
+            return;
+        }
+        self.clear_evicted_slots(old_frontier, new_frontier);
+
+        Self::fetch_sub_saturating(&self.hot_cache_bytes, checkpointed_bytes);
+        Self::fetch_sub_saturating(&self.checkpointable_bytes, checkpointed_bytes);
+
         self.eviction_frontier
             .store(new_frontier, Ordering::Release);
+    }
+
+    fn fetch_sub_saturating(counter: &AtomicU64, amount: u64) {
+        // why not fetch_sub? because such a raw atomic subtraction may underflow for u64.
+        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_sub(amount))
+        });
+    }
+
+    fn clear_evicted_slots(&self, old_frontier: u64, new_frontier: u64) {
+        for pos in old_frontier..new_frontier {
+            let idx = self.slot_index(pos);
+            if self.slot_positions[idx].load(Ordering::Acquire) == pos {
+                self.entries[idx].store(None);
+                self.slot_byte_lengths[idx].store(0, Ordering::Relaxed);
+                self.slot_positions[idx].store(EMPTY_SLOT_POSITION, Ordering::Release);
+            }
+        }
+    }
+
+    // Uses eviction_frontier..read_cursor, because checkpoint can only drain
+    // committed entries. The checkpoint worker itself uses the same boundary in
+    // drain_for_checkpoint().
+    pub(super) fn checkpointable_bytes(&self) -> u64 {
+        self.checkpointable_bytes.load(Ordering::Relaxed)
+    }
+
+    // hot_cache_bytes: budget pressure signal
+    // Uses (eviction_frontier..write_cursor), because this is total resident hot cache,
+    // including uncommitted published entries.
+    pub(crate) fn hot_cache_bytes(&self) -> u64 {
+        self.hot_cache_bytes.load(Ordering::Relaxed)
     }
 }
 
@@ -178,6 +267,13 @@ impl CheckpointBatch {
     pub(crate) fn last_lsn(&self) -> u64 {
         self.entries.last().map(|e| e.lsn).unwrap_or(0)
     }
+
+    pub(crate) fn byte_len(&self) -> u64 {
+        self.entries
+            .iter()
+            .map(|entry| entry.byte_len() as u64)
+            .sum()
+    }
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -193,10 +289,30 @@ impl TAssertInvariant for SegmentRingBuffer {
         );
         assert!(commit <= tail, "read_cursor ({commit}) > tail ({tail})");
 
+        let actual_hot: u64 = (frontier..tail)
+            .filter_map(|pos| self.load_published(pos))
+            .map(|entry| entry.byte_len() as u64)
+            .sum();
+        assert_eq!(
+            self.hot_cache_bytes.load(Ordering::Relaxed),
+            actual_hot,
+            "hot cache byte counter mismatch"
+        );
+
+        let actual_checkpointable: u64 = (frontier..commit)
+            .filter_map(|pos| self.load_published(pos))
+            .map(|entry| entry.byte_len() as u64)
+            .sum();
+        assert_eq!(
+            self.checkpointable_bytes.load(Ordering::Relaxed),
+            actual_checkpointable,
+            "checkpointable byte counter mismatch"
+        );
+
         for pos in frontier..tail {
             let idx = self.slot_index(pos);
             assert!(
-                self.entries[idx].load().is_some(),
+                self.load_slot_at(idx, pos).is_some(),
                 "empty slot at position {pos} (between frontier and tail)"
             );
         }
@@ -244,7 +360,7 @@ mod tests {
 
         cache.publish(make_entry(0, 1));
         cache.advance_read_cursor(1);
-        cache.advance_eviction_frontier(1);
+        cache.complete_checkpoint(1, 4);
 
         assert!(cache.read_committed(0).is_none());
     }
@@ -272,10 +388,44 @@ mod tests {
         cache.publish(make_entry(1, 2));
         cache.advance_read_cursor(2);
 
-        cache.advance_eviction_frontier(1);
+        cache.complete_checkpoint(1, 4);
 
         assert!(cache.read_committed(0).is_none());
         assert!(cache.read_committed(1).is_some());
+    }
+
+    #[test]
+    fn checkpoint_completion_clears_only_evicted_positions() {
+        let cache = SegmentRingBuffer::with_capacity(4);
+
+        for i in 0..4u64 {
+            cache.publish(make_entry(i, i + 1));
+        }
+        cache.advance_read_cursor(4);
+
+        cache.complete_checkpoint(2, 8);
+
+        assert!(cache.entries[0].load().is_none());
+        assert!(cache.entries[1].load().is_none());
+        assert!(cache.entries[2].load().is_some());
+        assert!(cache.entries[3].load().is_some());
+        assert_eq!(cache.hot_cache_bytes(), 8);
+        assert_eq!(cache.checkpointable_bytes(), 8);
+    }
+
+    #[test]
+    fn checkpoint_completion_does_not_clear_wrapped_newer_slot() {
+        let cache = SegmentRingBuffer::with_capacity(4);
+
+        for i in 0..5u64 {
+            cache.publish(make_entry(i, i + 1));
+            cache.advance_read_cursor(i + 1);
+        }
+
+        cache.complete_checkpoint(1, 4);
+
+        let entry = cache.load_published(4).expect("wrapped entry kept");
+        assert_eq!(entry.entry_id, EntryId(4));
     }
 
     #[test]
@@ -298,11 +448,11 @@ mod tests {
 
         for i in 0..6u64 {
             cache.publish(make_entry(i, i + 1));
+            cache.advance_read_cursor(i + 1);
             if i >= 1 {
-                cache.advance_eviction_frontier(i - 1);
+                cache.complete_checkpoint(i - 1, 4);
             }
         }
-        cache.advance_read_cursor(6);
 
         let entry = cache.read_committed(5).unwrap();
         assert_eq!(entry.entry_id, EntryId(5));
@@ -316,7 +466,7 @@ mod tests {
             cache.publish(make_entry(i, i + 1));
         }
         cache.advance_read_cursor(5);
-        cache.advance_eviction_frontier(2);
+        cache.complete_checkpoint(2, 8);
 
         let frontier = cache.load_eviction_frontier();
         let commit = cache.load_read_cursor();

--- a/src/data_plane/states/segment/tracker.rs
+++ b/src/data_plane/states/segment/tracker.rs
@@ -95,9 +95,12 @@ impl SegmentTracker {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn uncheckpointed(&self) -> u64 {
-        self.cache.load_write_cursor() - self.cache.load_eviction_frontier()
+    pub(crate) fn checkpointable_bytes(&self) -> u64 {
+        self.cache.checkpointable_bytes()
+    }
+
+    pub(crate) fn hot_cache_bytes(&self) -> u64 {
+        self.cache.hot_cache_bytes()
     }
 
     pub(crate) fn stage_to_wal(&mut self, wal_buf: &mut Vec<u8>) {
@@ -175,9 +178,15 @@ impl SegmentTracker {
         self.committed_entry_id = entry_id;
     }
 
-    pub(crate) fn advance_checkpoint(&mut self, checkpointed_lsn: u64, new_frontier: u64) {
+    pub(crate) fn advance_checkpoint(
+        &mut self,
+        checkpointed_lsn: u64,
+        new_frontier: u64,
+        checkpointed_bytes: u64,
+    ) {
         self.checkpoint_lsn = self.checkpoint_lsn.max(checkpointed_lsn);
-        self.cache.advance_eviction_frontier(new_frontier);
+        self.cache
+            .complete_checkpoint(new_frontier, checkpointed_bytes);
     }
 
     pub(crate) fn checkpoint_lsn(&self) -> u64 {
@@ -436,11 +445,11 @@ pub mod tests {
     fn advance_checkpoint_is_monotonic() {
         let mut t = make_tracker(SegmentRole::Leader);
         assert_eq!(t.checkpoint_lsn(), 0);
-        t.advance_checkpoint(10, 0);
+        t.advance_checkpoint(10, 0, 0);
         assert_eq!(t.checkpoint_lsn(), 10);
-        t.advance_checkpoint(5, 0); // shouldn't go backward
+        t.advance_checkpoint(5, 0, 0); // shouldn't go backward
         assert_eq!(t.checkpoint_lsn(), 10);
-        t.advance_checkpoint(20, 0);
+        t.advance_checkpoint(20, 0, 0);
         assert_eq!(t.checkpoint_lsn(), 20);
     }
 

--- a/src/it/helpers.rs
+++ b/src/it/helpers.rs
@@ -40,6 +40,8 @@ pub fn default_env(idx: u32, node_id: String, client_port: u16, cluster_port: u1
         segment_age_check_interval_secs: 60,
         segment_size_limit_bytes: 1024 * 1024 * 1024,
         batch_max_bytes: 10 * 1024 * 1024,
+        hot_cache_budget_bytes: 4 * 1024 * 1024 * 1024,
+        hot_cache_pressure_watermark: 0.9,
         seal_request_timeout_secs: 5,
         // Short in tests so the orphan-GC sweep actually fires within a sim run; still
         // comfortably longer than re-fill + catch-up, so the lottery completes first.


### PR DESCRIPTION
…stem for segment caches.

- hot_cache_budget_bytes: default 4GB
- hot_cache_pressure_watermark : default 0.9

CheckpointWorker calculates `checkpointed_bytes` the new byte_len() helper on CheckpointBatch to report back how much memory has been safely checkpointed/evicted

- add `slot_positions: Box<[AtomicU64]>`  and  `slot_byte_lengths: Box<[AtomicU64]>` to the ring buffer.
- Tracking physical-to-logical mapping via  slot_positions  guarantees that if the buffer wraps around, readers will not perform stale reads
- Replaces `advance_eviction_frontier` with `complete_checkpoint(new_frontier,checkpointed_bytes)`. This decrements the atomic counters (`hot_cache_bytes` and `checkpointable_bytes`) and clears only the slots whose logical positions match the evicted window (to avoid clearing slots that have already wrapped and contain newer data).