### PR TITLE
fix: AtMostOnce does not provide at-most-once delivery

### DIFF
--- a/src/bin/eg-cli/commands.rs
+++ b/src/bin/eg-cli/commands.rs
@@ -313,9 +313,9 @@ async fn handle_consume(client: &Arc<Client>, request: ConsumeRequest) -> anyhow
 fn parse_delivery_semantic(value: &str) -> anyhow::Result<DeliverySemantic> {
     match value {
         "at-least-once" => Ok(DeliverySemantic::AtLeastOnce),
-        "at-most-once" => Ok(DeliverySemantic::AtMostOnce),
+        "at-most-once" | "at-most-once-best-effort" => Ok(DeliverySemantic::AtMostOnceBestEffort),
         _ => anyhow::bail!(
-            "invalid --delivery '{}'; expected at-least-once or at-most-once",
+            "invalid --delivery '{}'; expected at-least-once or at-most-once-best-effort",
             value
         ),
     }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -357,19 +357,18 @@ impl ConsumerGroup {
                 Ok(d) => d,
                 Err(e) => {
                     tracing::error!(?range_id, error = ?e, "Failed to serialize offset payload");
-                    return; // Skip this range, retry on next tick
+                    return Err(ClientError::on_control("commit", range_id, e.to_string()));
                 }
             };
 
             //  Send over network
-            if let Err(e) = self
-                .offset_producer
+            self.offset_producer
                 .send(self.routing_key().as_bytes(), data)
                 .await
-            {
-                tracing::warn!(?range_id, error = ?e, "Failed to send offset commit to broker");
-                return; // Skip this range, retry on next tick
-            }
+                .map_err(|e| {
+                    tracing::warn!(?range_id, error = ?e, "Failed to send offset commit to broker");
+                    e
+                })?;
 
             // Update DashMap safely
             if let Some(mut entry) = self.offsets.get_mut(&range_id) {
@@ -379,9 +378,11 @@ impl ConsumerGroup {
                     entry.committed = Some(position);
                 }
             }
+            Ok(())
         });
 
-        futures::future::join_all(futures).await;
+        futures::future::try_join_all(futures).await?;
+
         Ok(())
     }
 

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -47,7 +47,7 @@ impl ConsumerRecord {
 #[derive(Debug, Clone)]
 pub enum DeliverySemantic {
     AtLeastOnce,
-    AtMostOnce,
+    AtMostOnceBestEffort,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -175,7 +175,7 @@ impl Consumer {
 
         match self.delivery_semantic {
             DeliverySemantic::AtLeastOnce => group.ack_offset(record.range_id, record.position),
-            DeliverySemantic::AtMostOnce => Ok(()),
+            DeliverySemantic::AtMostOnceBestEffort => Ok(()),
         }
     }
 
@@ -256,7 +256,7 @@ impl Consumer {
                     DeliverySemantic::AtLeastOnce => {
                         group.record_delivery(rec.range_id, rec.position)?;
                     }
-                    DeliverySemantic::AtMostOnce => {
+                    DeliverySemantic::AtMostOnceBestEffort => {
                         group.record_delivery(rec.range_id, rec.position)?;
                         group.ack_offset(rec.range_id, rec.position)?;
                     }

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -137,7 +137,7 @@ fn at_most_once_auto_commit_commits_delivery() {
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
-            group_config_with_semantic(group_id.clone(), DeliverySemantic::AtMostOnce),
+            group_config_with_semantic(group_id.clone(), DeliverySemantic::AtMostOnceBestEffort),
         )
         .await
         .unwrap();
@@ -159,7 +159,7 @@ fn at_most_once_auto_commit_commits_delivery() {
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
-            group_config_with_semantic(group_id, DeliverySemantic::AtMostOnce),
+            group_config_with_semantic(group_id, DeliverySemantic::AtMostOnceBestEffort),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Code Changes: Renamed the semantic from  AtMostOnce  to  AtMostOnceBestEffort  in:
- mod.rs (reverted the synchronous commit back to best-effort asynchronous commits to avoid RTT throughput penalties).
- CLI parser in commands.rs.
- Integration tests in consumer_group_test.rs.

Also fixed offset commit failures being reported as success.