### PR TITLE
feat: seal boundary report

### DIFF
--- a/docs/backlogs.md
+++ b/docs/backlogs.md
@@ -122,7 +122,57 @@ need removal.
 Snapshotting and compaction should be a 1.0 gate, or the release must carry
 explicit workload and lifetime limits.
 
+### High — resurrected nodes retain stale active-segment ownership
+
+SWIM now permits a still-running node to refute a `Dead` observation at a
+higher incarnation after a partition heals. The cluster may already have rolled
+every active segment that named that node and committed successor replica sets,
+but the resurrected process does not run crash recovery and may retain its old
+in-memory active-segment assignments.
+
+The restarted-node path does not close this gap: restart creates a fresh node
+identity, discards active ownership, and treats recovered files as passive sealed
+inventory. A live resurrection keeps the old identity and memory. It may therefore
+continue accepting requests against a segment the metadata authority has sealed,
+without receiving either the committed roll or an explicit revocation. Requiring
+all data replicas to acknowledge prevents those stale writes from committing in
+the usual partition case, but that is not an ownership fence and does not reclaim
+the stale state.
+
+Add an authoritative reconciliation path when a node resurrects:
+
+- Fence writes until its active assignments have been checked against committed
+  metadata.
+- Revoke and locally seal assignments that no longer name the node.
+- Preserve only data that can safely participate in sealed-segment catch-up;
+  discard or quarantine private uncommitted tails.
+- Make the reconciliation idempotent across repeated Alive gossip and another
+  partition during recovery.
+
+Cover this with a deterministic partition/heal test in which the old segment
+leader is declared dead, a successor segment commits, and the same process later
+refutes Dead. The test must prove that the old segment cannot accept a successful
+write after resurrection and that the successor remains the sole active segment.
+
 ## Important pre-1.0 gaps
+
+### Stale local Raft replicas are not retired after ring displacement
+
+A peer removed by a committed Raft membership change is no longer a replication
+target, so a partitioned copy cannot rely on receiving and applying the log entry
+that evicted it. Applying peer removal also does not invoke group destruction;
+that lifecycle is a separate explicit operation. After the partition heals, ring
+reconciliation can stage the node as a learner for groups it should host again,
+but groups it no longer owns can remain locally instantiated with obsolete logs
+and timers.
+
+Add local group-lifecycle reconciliation against the stable ring view. A group
+that no longer belongs on the node should stop elections and traffic promptly,
+then delete its persisted state only after a stability window protects against
+ring flapping. A group assigned back to the node should reuse its durable prefix
+only through learner catch-up, with the current leader remaining authoritative.
+Exercise both outcomes under partition/heal simulation: re-admission to the same
+group and permanent displacement from it.
 
 ### Offset restoration is expensive and can return a partial snapshot
 
@@ -137,15 +187,15 @@ O(total offset history) per rebalance.
 Offsets need compacted-key semantics, a direct lookup API, or an authoritative
 indexed state store.
 
-### Unknown-end sealed segments cannot be fully repaired
+### Unknown-end sealed-segment recovery [Resolved]
 
-When seal-boundary recovery exhausts its attempts, it falls back to an unknown
-end. Reconciliation explicitly skips sealed segments with unknown ends, as
-reflected by existing tests and the recovery path. Such segments can remain
-permanently under-replicated.
+Unknown-end segments remain durable recovery candidates after the initial gather
+budget expires. Periodic reconciliation and coordinator takeover restart boundary
+discovery; a later complete gather corrects the boundary exactly once and ordinary
+sealed-segment repair resumes.
 
-Define an operator-visible recovery state and a later retry/manual repair
-pathway rather than accepting permanent unknown-end metadata silently.
+Recovery remains automatic; there is no separate operator retry path to maintain.
+Unexpected and conflicting reports are rejected without changing gather progress.
 
 ### No stable wire or storage-format compatibility policy
 
@@ -203,6 +253,8 @@ Before 1.0, add deterministic coverage for:
 - Conflicting consumer-group membership views.
 - System-topic replica loss.
 - Network partitions during Raft membership transitions and segment rolls.
+- Same-identity SWIM resurrection after Raft-peer eviction and active-segment
+  replacement.
 - Rolling upgrades with mixed protocol/storage versions.
 - Long-running metadata growth and snapshot restore.
 

--- a/docs/data-plane/d5_crash_recovery.md
+++ b/docs/data-plane/d5_crash_recovery.md
@@ -22,7 +22,8 @@ can be copied back from a healthy replica.
 already saw the old identity die, the cluster sealed every active segment it
 touched, and moved on. The restarted node resumes no leadership, no followership,
 and no active segment. It joins fresh, with a disk full of data from its previous
-life. (`Dead` is terminal in SWIM — a restart is never the old identity revived.)
+life. (While EastGuard's SWIM allows a running but partitioned node to refute its own
+`Dead` state, a restarted node gets a new `NodeId` and thus never revives its old identity.)
 
 Together these give recovery one job:
 

--- a/docs/metadata-management/mental-model.md
+++ b/docs/metadata-management/mental-model.md
@@ -56,7 +56,7 @@ SWIM (Scalable Weakly-consistent Infection-style Membership) addresses the scali
 
 **Failure detection via probes.** Each protocol period, every node picks a random target and pings it. If the target does not reply, the prober asks K other nodes to ping the target on its behalf — *indirect probing*. This separates "the link to me is bad" from "the node is dead": the indirect probes reach the target via different network paths. Only if all indirect probes also fail is the target moved from Alive to Suspect.
 
-**The node state machine: Alive → Suspect → Dead.** Suspect is a probation state — the suspected node gets a chance to refute the suspicion. If it does not refute within a timeout, it moves to Dead.
+**The node state machine: Alive → Suspect → Dead.** Suspect is a probation state — the suspected node gets a chance to refute the suspicion. If it does not refute within a timeout, it moves to Dead. (In EastGuard, a running node can also transition from `Dead` back to `Alive` at a higher incarnation number to heal network partitions.)
 
 **Dissemination via gossip, not broadcast.** Once a node confirms a death, it does not broadcast — it piggybacks the fact on its ongoing probe traffic. "By the way, C is dead" rides as a small footer on the regular ping packet that was going to be sent anyway. The information spreads infection-style through the cluster.
 
@@ -184,9 +184,9 @@ For operational invariants, see `.claude/rules/storage-layout.md`.
 
 ## Eventual consistency is delayed truth, not fake truth
 
-A common misread of "eventually consistent" is "approximate" or "best-effort". SWIM is neither. With incarnation numbers and the suspect-then-confirm machinery, SWIM's view is **monotonic and eventually correct** — a node marked dead really is dead; it just took some gossip rounds for everyone to find out.
+A common misread of "eventually consistent" is "approximate" or "best-effort". SWIM is neither. With incarnation numbers and the suspect-then-confirm machinery, SWIM's view is **eventually correct**. While a node marked dead is treated as dead for ongoing operations, EastGuard allows **partition healing**: a running node that receives gossip claiming it is dead refutes the claim by incrementing its incarnation number, resurrecting itself back to Alive.
 
-So when SWIM says "X is dead", that is a real fact about the world. The only question is when each node learns it.
+Therefore, a node confirmed dead really is dead in the absence of a healed partition. When a partition heals, the resurrected node's higher incarnation overrides the terminal Dead state and the cluster adapts.
 
 This matters because it justifies trusting SWIM's *current snapshot* as a basis for action. We are not acting on a guess; we are acting on a truth that arrived with delay.
 

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -543,11 +543,17 @@ impl MultiRaft {
     /// Feed a survivor's durable extent into the subsystem; if it completes a
     /// gather, execute the resulting seal.
     fn handle_seal_boundary_report(&mut self, report: SealBoundaryReport) {
-        if let Some(step) =
-            self.seal_recovery
-                .record(report.segment_key, report.from, report.durable_end)
+        match self
+            .seal_recovery
+            .record(report.segment_key, report.from, report.durable_end)
         {
-            self.execute_seal_step(step);
+            Ok(Some(step)) => self.execute_seal_step(step),
+            Ok(None) => {}
+            Err(error) => tracing::warn!(
+                segment = ?report.segment_key,
+                ?error,
+                "rejected seal-boundary report",
+            ),
         }
     }
 

--- a/src/control_plane/consensus/seal_recovery.rs
+++ b/src/control_plane/consensus/seal_recovery.rs
@@ -16,6 +16,17 @@ use crate::control_plane::membership::ShardGroupId;
 use crate::control_plane::metadata::EntryId;
 use crate::data_plane::SegmentKey;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SealBoundaryReportError {
+    UnknownRecovery,
+    UnexpectedReporter(NodeId),
+    ConflictingReport {
+        reporter: NodeId,
+        previous: Option<EntryId>,
+        incoming: Option<EntryId>,
+    },
+}
+
 /// How many drive passes a gather waits for every survivor to report before
 /// giving up and sealing with an unknown end.
 pub(crate) const GATHER_ATTEMPTS: u32 = 3;
@@ -68,8 +79,34 @@ impl SealEndGather {
         self.nodes.contains(node)
     }
 
-    fn record(&mut self, from: NodeId, durable_end: Option<EntryId>) {
+    fn record(
+        &mut self,
+        segment_key: SegmentKey,
+        from: NodeId,
+        durable_end: Option<EntryId>,
+    ) -> Result<Option<SealEndStep>, SealBoundaryReportError> {
+        if self.proposed {
+            return Ok(None);
+        }
+        if !self.awaits(&from) {
+            return Err(SealBoundaryReportError::UnexpectedReporter(from));
+        }
+        if let Some(previous) = self.reports.get(&from) {
+            if *previous != durable_end {
+                return Err(SealBoundaryReportError::ConflictingReport {
+                    reporter: from,
+                    previous: *previous,
+                    incoming: durable_end,
+                });
+            }
+            return Ok(None);
+        }
         self.reports.insert(from, durable_end);
+        if !self.is_complete() {
+            return Ok(None);
+        }
+        self.proposed = true;
+        Ok(Some(self.seal(segment_key)))
     }
 
     fn is_complete(&self) -> bool {
@@ -210,17 +247,11 @@ impl SealEndRecovery {
         segment_key: SegmentKey,
         from: NodeId,
         durable_end: Option<EntryId>,
-    ) -> Option<SealEndStep> {
-        let g = self.gathers.get_mut(&segment_key)?;
-        if g.proposed || !g.awaits(&from) {
-            return None;
-        }
-        g.record(from, durable_end);
-        if !g.is_complete() {
-            return None;
-        }
-        g.proposed = true;
-        Some(g.seal(segment_key))
+    ) -> Result<Option<SealEndStep>, SealBoundaryReportError> {
+        self.gathers
+            .get_mut(&segment_key)
+            .ok_or(SealBoundaryReportError::UnknownRecovery)?
+            .record(segment_key, from, durable_end)
     }
 
     /// Drop `group`'s gathers whose segment is no longer leaderless.
@@ -280,8 +311,9 @@ mod tests {
     fn gather_with(reports: &[(&str, Option<u64>)]) -> SealEndGather {
         let nodes = reports.iter().map(|(n, _)| node(n)).collect();
         let mut g = SealEndGather::new(ShardGroupId(0), nodes);
+        let key = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
         for (n, end) in reports {
-            g.record(node(n), end.map(EntryId));
+            let _ = g.record(key, node(n), end.map(EntryId)).unwrap();
         }
         g
     }
@@ -356,16 +388,23 @@ mod tests {
         let mut recovery = SealEndRecovery::default();
         recovery.advance(ShardGroupId(1), vec![(seg, vec![node("y"), node("z")])]);
 
-        assert!(recovery.record(seg, node("y"), Some(EntryId(50))).is_none()); // partial
+        assert!(matches!(
+            recovery.record(seg, node("y"), Some(EntryId(50))),
+            Ok(None)
+        )); // partial
         let step = recovery
             .record(seg, node("z"), Some(EntryId(40)))
+            .expect("valid report")
             .expect("completes");
         assert!(matches!(
             step,
             SealEndStep::Seal { end: Some(EntryId(40)), leader: Some(l), .. } if l == node("y")
         ));
         // A late/duplicate report after the roll is proposed is ignored.
-        assert!(recovery.record(seg, node("y"), Some(EntryId(99))).is_none());
+        assert!(matches!(
+            recovery.record(seg, node("y"), Some(EntryId(99))),
+            Ok(None)
+        ));
 
         // Until metadata stops reporting the candidate, the proposal may have
         // been truncated and must be emitted again.
@@ -378,6 +417,31 @@ mod tests {
                 ..
             }]
         ));
+    }
+
+    #[test]
+    fn conflicting_and_unexpected_reports_are_rejected() {
+        let seg = SegmentKey::new(TopicId(0), RangeId(0), SegmentId(0));
+        let mut recovery = SealEndRecovery::default();
+        recovery.advance(ShardGroupId(1), vec![(seg, vec![node("y"), node("z")])]);
+
+        assert!(matches!(
+            recovery.record(seg, node("x"), Some(EntryId(10))),
+            Err(SealBoundaryReportError::UnexpectedReporter(reporter)) if reporter == node("x")
+        ));
+        assert!(matches!(
+            recovery.record(seg, node("y"), Some(EntryId(50))),
+            Ok(None)
+        ));
+        assert!(matches!(
+            recovery.record(seg, node("y"), Some(EntryId(49))),
+            Err(SealBoundaryReportError::ConflictingReport {
+                reporter,
+                previous: Some(EntryId(50)),
+                incoming: Some(EntryId(49)),
+            }) if reporter == node("y")
+        ));
+        assert_eq!(recovery.gathers[&seg].reports.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
closes #184 

### Changes
No operater-facing boundary recovery surface - everything fully automated
- Public SDK inspection/retry methods.
- Admin wire requests and responses.
- Consensus actor query commands and status models.
- Associated controller and operator-retry tests.

Kept only the essential behavior:
- Automatic periodic and takeover recovery.
- Rejection and warning logs for unexpected or conflicting boundary reports.
- Focused validation covering automatic retry and report safety.
