### PR TITLE
fix: cache invalidation on client

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -186,6 +186,9 @@ impl Client {
         let request_generation = req.generation;
 
         let served = self.call(leader.client_addr(), req).await?;
+        if served.redirected {
+            self.cache.invalidate(topic_name);
+        }
         match served.response {
             ClientResponse::DataPlane(DataPlaneResponse::ConsumerOffsetCommitted) => Ok(()),
             ClientResponse::DataPlane(DataPlaneResponse::StaleConsumerGroupEpoch(stale)) => {
@@ -215,6 +218,9 @@ impl Client {
                 let served = self
                     .call(leader.client_addr(), FetchConsumerOffsetRequest(offset))
                     .await?;
+                if served.redirected {
+                    self.cache.invalidate(topic_name);
+                }
                 match served.response {
                     ClientResponse::DataPlane(DataPlaneResponse::ConsumerOffset(position)) => {
                         Ok(position.map(|p| (range_id, p)))
@@ -336,14 +342,19 @@ impl Client {
         };
 
         let served = self.call(start, request).await?;
-        // A redirect -> the cached leader was stale; drop it so the next produce re-describes.
-        if served.redirected {
+        // A redirect or stale range means the cached route is stale; drop it so
+        // the next produce re-describes.
+        if served.redirected
+            || matches!(
+                &served.response,
+                ClientResponse::DataPlane(DataPlaneResponse::StaleRange)
+            )
+        {
             self.cache.invalidate(topic);
         }
         match served.response {
             ClientResponse::DataPlane(DataPlaneResponse::Produced { entry_id }) => Ok(entry_id),
             ClientResponse::DataPlane(DataPlaneResponse::StaleRange) => {
-                self.cache.invalidate(topic);
                 Err(ClientError::StaleRange)
             }
             _ => Err(ClientError::UnexpectedResponse),

--- a/src/client/routing.rs
+++ b/src/client/routing.rs
@@ -174,7 +174,13 @@ impl RoutingCache {
                     range_id: r.range_id,
                     keyspace_start: r.keyspace_start.clone(),
                     write_leader: r.write_leader.as_ref().map(|_| wrong.clone()),
-                    replica_addrs: r.replica_addrs.clone(),
+                    replica_addrs: if r.replica_addrs.is_empty() {
+                        Box::new([])
+                    } else {
+                        std::iter::once(wrong.clone())
+                            .chain(r.replica_addrs.iter().skip(1).cloned())
+                            .collect()
+                    },
                 })
                 .collect();
 

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -21,6 +21,7 @@ use crate::config::Environment;
 use crate::connections::protocol::ClientResponse;
 use crate::control_plane::metadata::{EntryId, RangeId};
 use crate::control_plane::{NodeAddress, NodeAddressInfo, NodeId};
+use crate::data_plane::consumer_offset_management::ledger::ConsumerOffsetKey;
 use crate::it::e2e::{NODES, NODES_4};
 
 /// Per-test cluster tweaks for the SDK suite: pinned node-id suffix + low vnode
@@ -301,6 +302,61 @@ fn client_corrects_stale_write_leader() -> turmoil::Result {
             client.cached_write_leader("stale", b"k"),
             Some(real),
             "re-resolved back to the real write leader"
+        );
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Consumer-offset reads use the same redirect correction as produce and evict a
+/// stale topic route after following the current leader's hint.
+#[test]
+#[serial_test::serial]
+fn consumer_offset_read_corrects_stale_write_leader() -> turmoil::Result {
+    let mut sim = build_sim(90);
+    host_cluster(&mut sim, &NODES, sim_cluster);
+
+    sim.client("test-client", async {
+        let client = Client::connect(client_seeds()).expect("client connects");
+        client
+            .create_topic("stale-offset", policy())
+            .await
+            .expect("create");
+        let detail = client
+            .resolve_topic("stale-offset")
+            .await
+            .expect("describe seeds the routing cache");
+        let range_id = detail.ranges[0].range_id;
+        let real = client
+            .cached_write_leader("stale-offset", b"k")
+            .expect("write leader cached after describe");
+        let wrong_addr = client_seeds()
+            .into_iter()
+            .find(|addr| *addr != real.client_addr())
+            .expect("another node");
+        let wrong = NodeAddressInfo::new(
+            NodeId::new("wrong"),
+            NodeAddress::test(wrong_addr, wrong_addr),
+        );
+        client.poison_cache("stale-offset", wrong);
+
+        let offsets = client
+            .fetch_consumer_offsets(
+                "stale-offset",
+                vec![ConsumerOffsetKey {
+                    topic_id: detail.topic_id,
+                    range_id,
+                    group_id: "group".to_string(),
+                }]
+                .into_boxed_slice(),
+            )
+            .await
+            .expect("offset read follows the leader redirect");
+        assert!(offsets.is_empty(), "the group has no committed offset");
+        assert!(
+            client.cached_write_leader("stale-offset", b"k").is_none(),
+            "redirect invalidates the stale topic route"
         );
         Ok(())
     });


### PR DESCRIPTION
### test : `consumer_offset_read_corrects_stale_write_leader`

### changes 
cache invalidation on redirection in 
- Client::commit_consumer_offset
- Client::fetch_consumer_offsets
- Client::produce_to_range