### PR TITLE
 feat(client): make consumer checkpoint lookup bounded and observable

### DIFF
--- a/docs/clients/c4_consumer_offset_commits.md
+++ b/docs/clients/c4_consumer_offset_commits.md
@@ -189,7 +189,13 @@ revoked ranges have already been discarded and are not included in the retry.
 The client sends one commit to the range's data leader. Server-side replication, generation
 validation, shared-WAL durability, and leader redirects are described in D8.
 
-When an actor starts, it first reads the group's durable position for its range:
+When actors start after a rebalance, they read the group's durable positions at the assignment
+generation. Each range leader answers only after that generation's ownership seal is durable,
+and the client serializes the multi-range lookup with its own commits. The independently routed
+reads therefore share one logical transition boundary rather than observing a mixture of old-
+and new-generation progress.
+
+For each range:
 
 - If present, fetch begins at the containing entry and filters batch records through the
   committed record offset.

--- a/docs/clients/c4_consumer_offset_commits.md
+++ b/docs/clients/c4_consumer_offset_commits.md
@@ -200,8 +200,10 @@ For each range:
 - If present, fetch begins at the containing entry and filters batch records through the
   committed record offset.
 - If absent, the configured earliest/latest start policy applies.
-- If the durable read is unavailable or times out, the actor does not start. A later rebalance
-  retries instead of assuming no offset exists.
+- If the durable read is unavailable or times out, the actor does not start. The failure is
+  returned through the consumer's record stream, and a later rebalance retries instead of
+  assuming no offset exists. When the lookup is part of explicit stale-commit recovery, the
+  failure is returned directly by the commit call.
 
 This fail-closed behavior prevents a temporary broker failure from replaying an entire range
 or skipping to its tail under the fallback start policy.

--- a/docs/data-plane/d8_consumer_offset_management.md
+++ b/docs/data-plane/d8_consumer_offset_management.md
@@ -239,7 +239,7 @@ acknowledgements while the asynchronous actor stops are in flight.
 | Leader WAL fsync fails | Commit fails; no replication acknowledgement |
 | Follower WAL fsync fails or connection disappears | Leader does not acknowledge the commit |
 | Offset snapshot fails | WAL remains pinned and recovery stays possible |
-| Durable-offset read is unavailable | New range actor remains unstarted; a later rebalance retries |
+| Durable-offset read is unavailable | New range actor remains unstarted; the client receives an error and a later rebalance retries |
 | Broker restarts | Snapshot plus shared-WAL replay reconstructs the ledger |
 
 ---

--- a/docs/data-plane/d8_consumer_offset_management.md
+++ b/docs/data-plane/d8_consumer_offset_management.md
@@ -207,10 +207,19 @@ A normal rebalance is incremental:
 2. Refresh metadata only if the cache cannot describe an assigned range.
 3. Expand active assignment into effective lineage ownership.
 4. Stop revoked range actors.
-5. Load durable offsets and start newly owned or previously unprovisioned ranges.
+5. Load durable offsets at the assignment generation and start newly owned or previously
+   unprovisioned ranges.
 
 Unchanged actors continue running. Rebuilding every actor on each heartbeat would cause
 avoidable duplicate delivery and control-plane traffic.
+
+The assignment generation is also the distributed offset-read boundary. Range leaders answer
+only after that generation's epoch seal is durable locally. Although different ranges may be
+served by different leaders, every answer therefore includes all commits before the ownership
+transition and excludes commits by the new owner. The recovering member serializes its own
+commits with this lookup, so it cannot advance one requested range while the remaining range
+leaders are still answering. This gives the range set one logical snapshot without a
+cross-range transaction.
 
 A stale commit is a stronger signal. The client fences delivery, stops all range actors,
 rebuilds effective ownership from the latest generation, retries only positions still owned,
@@ -225,6 +234,7 @@ acknowledgements while the asynchronous actor stops are in flight.
 |---|---|
 | Client routes to follower | Redirect to current data leader |
 | Assignment arrives before epoch seal | Commit parks until the seal arrives |
+| Offset read arrives before epoch seal is durable | Read is rejected; rebalance retries |
 | Old owner commits after reassignment | Rejected by generation fence |
 | Leader WAL fsync fails | Commit fails; no replication acknowledgement |
 | Follower WAL fsync fails or connection disappears | Leader does not acknowledge the commit |

--- a/src/client/consumer/context.rs
+++ b/src/client/consumer/context.rs
@@ -150,15 +150,6 @@ impl ConsumerContext {
 
         RangeLookupResult::NeedRefresh
     }
-
-    pub(crate) fn all_ranges(&self) -> Vec<RangeId> {
-        self.metadata
-            .load()
-            .ranges
-            .iter()
-            .map(|r| r.range_id)
-            .collect::<Vec<_>>()
-    }
 }
 
 pub(crate) fn compute_progress_signal(

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -245,13 +245,18 @@ impl ConsumerGroup {
         &self,
         ranges: Box<[RangeId]>,
     ) -> Result<std::collections::HashMap<RangeId, ConsumerOffsetPosition>, ClientError> {
+        // A generation is the distributed snapshot boundary. Holding the same
+        // lock used by commits prevents this member from advancing any requested
+        // checkpoint while range leaders independently serve that boundary.
+        let _guard = self.commit_lock.lock().await;
+        let generation = GenerationId(self.generation.load(AtomicOrdering::Acquire));
         let consumer_offset_keys = ranges
             .into_iter()
             .map(|r| self.consumer_offset_key(r))
             .collect();
 
         self.client
-            .fetch_consumer_offsets(&self.topic, consumer_offset_keys)
+            .fetch_consumer_offsets(&self.topic, consumer_offset_keys, generation)
             .await
     }
 }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -243,7 +243,7 @@ impl ConsumerGroup {
 
     pub(crate) async fn fetch_saved_offsets(
         &self,
-        ranges: Vec<RangeId>,
+        ranges: Box<[RangeId]>,
     ) -> Result<std::collections::HashMap<RangeId, ConsumerOffsetPosition>, ClientError> {
         let consumer_offset_keys = ranges
             .into_iter()

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -166,9 +166,8 @@ impl TopicFetchManagerState {
 
         let plan = self.prepare_rebalance(&group, ctx).await?;
 
-        let commit_result = group.commit_owned(&plan.effective).await;
-        self.provision_range_actors(plan.to_start, ctx).await;
-        commit_result
+        group.commit_owned(&plan.effective).await?;
+        self.provision_range_actors(plan.to_start, ctx).await
     }
 
     // It stops all fetch actors deliberately because a stale epoch invalidates the manager’s entire ownership snapshot, not just one range.
@@ -221,7 +220,9 @@ impl TopicFetchManagerState {
             return;
         };
 
-        self.provision_range_actors(plan.to_start, ctx).await;
+        if let Err(error) = self.provision_range_actors(plan.to_start, ctx).await {
+            self.report_rebalance_error(error);
+        }
     }
 
     async fn prepare_rebalance(
@@ -265,28 +266,37 @@ impl TopicFetchManagerState {
         Ok(plan)
     }
 
-    async fn provision_range_actors(&mut self, to_start: Vec<RangeId>, ctx: &Arc<ConsumerContext>) {
+    async fn provision_range_actors(
+        &mut self,
+        to_start: Vec<RangeId>,
+        ctx: &Arc<ConsumerContext>,
+    ) -> Result<(), ClientError> {
         if to_start.is_empty() {
-            return;
+            return Ok(());
         }
 
         let Some(group) = self.consumer_group.clone() else {
-            return;
+            return Ok(());
         };
 
         let metadata = ctx.metadata.load();
         let checkpoint_ranges = metadata.checkpoint_lookup_ranges(&to_start);
 
         // An unavailable offsets topic is not evidence that this group has no committed offsets.
-        // Leave the actor for this range unstarted so the next rebalance tick retries recovery.
-        let Ok(Ok(saved_offsets)) = tokio::time::timeout(
+        // Leave the actor unstarted, surface the failure, and let the next rebalance retry.
+        let saved_offsets = match tokio::time::timeout(
             Duration::from_secs(2),
             group.fetch_saved_offsets(checkpoint_ranges),
         )
         .await
-        else {
-            tracing::warn!("failed to recover/time-out fetch_all_saved_offsets");
-            return;
+        {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(ClientError::on_checkpoint_lookup(
+                    &to_start,
+                    "durable offset lookup timed out",
+                ));
+            }
         };
 
         for range in to_start {
@@ -332,6 +342,11 @@ impl TopicFetchManagerState {
                 );
             }
         }
+        Ok(())
+    }
+
+    fn report_rebalance_error(&self, error: ClientError) {
+        let _ = self.record_tx.send(Err(error));
     }
 
     /// Transfers a pending cursor into a live fetch actor.
@@ -603,6 +618,27 @@ mod tests {
             ConsumerConfig::new(StartPolicy::Earliest),
             record_tx,
         )
+    }
+
+    #[test]
+    fn rebalance_error_is_delivered_to_the_consumer() {
+        let (record_tx, record_rx) = flume::unbounded();
+        let state = TopicFetchManagerState::new(
+            PendingCursorStore::new(Vec::new()),
+            None,
+            ConsumerConfig::new(StartPolicy::Earliest),
+            record_tx,
+        );
+        state.report_rebalance_error(ClientError::on_checkpoint_lookup(
+            &[RangeId(4), RangeId(7)],
+            "lookup failed",
+        ));
+
+        assert!(matches!(
+            record_rx.recv().unwrap(),
+            Err(ClientError::ConsumerCheckpointLookupFailed { ranges, reason })
+                if *ranges == [4, 7] && reason == "lookup failed"
+        ));
     }
 
     fn split_ranges() -> Box<[RangeDetail]> {

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -274,19 +274,20 @@ impl TopicFetchManagerState {
             return;
         };
 
+        let metadata = ctx.metadata.load();
+        let checkpoint_ranges = metadata.checkpoint_lookup_ranges(&to_start);
+
         // An unavailable offsets topic is not evidence that this group has no committed offsets.
         // Leave the actor for this range unstarted so the next rebalance tick retries recovery.
         let Ok(Ok(saved_offsets)) = tokio::time::timeout(
             Duration::from_secs(2),
-            group.fetch_saved_offsets(ctx.all_ranges()),
+            group.fetch_saved_offsets(checkpoint_ranges),
         )
         .await
         else {
             tracing::warn!("failed to recover/time-out fetch_all_saved_offsets");
             return;
         };
-
-        let metadata = ctx.metadata.load();
 
         for range in to_start {
             let (resolved_entry_id, skip_below_offset, next_absolute_offset) = if let Some(pos) =
@@ -710,5 +711,60 @@ mod tests {
         };
         assert!(topic.lineage_depth(RangeId(0)) < topic.lineage_depth(RangeId(1)));
         assert!(topic.lineage_depth(RangeId(0)) < topic.lineage_depth(RangeId(2)));
+    }
+
+    #[test]
+    fn checkpoint_lookup_is_limited_to_starting_ranges_and_their_ancestors() {
+        let mut ranges = split_ranges().into_vec();
+        ranges.push(RangeDetail {
+            range_id: RangeId(3),
+            keyspace_start: Vec::new(),
+            keyspace_end: vec![64],
+            state: RangeState::Sealed,
+            active_segment: None,
+            sealed_segments: Box::new([]),
+            split_into: Some((RangeId(0), RangeId(4))),
+            merged_into: None,
+            merged_from: None,
+        });
+        ranges.push(RangeDetail {
+            range_id: RangeId(4),
+            keyspace_start: vec![64],
+            keyspace_end: vec![128],
+            state: RangeState::Active,
+            active_segment: None,
+            sealed_segments: Box::new([]),
+            split_into: None,
+            merged_into: None,
+            merged_from: None,
+        });
+        ranges.push(RangeDetail {
+            range_id: RangeId(99),
+            keyspace_start: vec![200],
+            keyspace_end: vec![255],
+            state: RangeState::Active,
+            active_segment: None,
+            sealed_segments: Box::new([]),
+            split_into: None,
+            merged_into: None,
+            merged_from: None,
+        });
+        let topic = TopicDetail {
+            topic_id: TopicId(0),
+            name: "test".to_string(),
+            state: TopicState::Active,
+            ranges: ranges.into_boxed_slice(),
+        };
+
+        let required = topic
+            .checkpoint_lookup_ranges(&[RangeId(1)])
+            .into_vec()
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            required,
+            HashSet::from([RangeId(1), RangeId(0), RangeId(3)])
+        );
     }
 }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -46,6 +46,9 @@ pub enum ClientError {
         sealed_generation: GenerationId,
     },
 
+    #[error("consumer checkpoint lookup failed for ranges {ranges:?}: {reason}")]
+    ConsumerCheckpointLookupFailed { ranges: Box<[u64]>, reason: String },
+
     /// A consumer range-control command could not be delivered or acknowledged.
     #[error("consumer {operation} failed for range {range_id}: {reason}")]
     ConsumerControl {
@@ -81,5 +84,12 @@ impl ClientError {
         let reason = reason.into();
         tracing::warn!(reason, "consumer commit failed");
         ClientError::ConsumerCommit { reason }
+    }
+
+    pub(crate) fn on_checkpoint_lookup(ranges: &[RangeId], reason: impl Into<String>) -> Self {
+        let reason = reason.into();
+        let ranges = ranges.iter().map(|range| **range).collect();
+        tracing::warn!(?ranges, reason, "consumer offset recovery failed");
+        ClientError::ConsumerCheckpointLookupFailed { ranges, reason }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -205,6 +205,7 @@ impl Client {
         &self,
         topic_name: &str,
         consumer_offset_keys: Box<[ConsumerOffsetKey]>,
+        generation: GenerationId,
     ) -> Result<HashMap<RangeId, ConsumerOffsetPosition>, ClientError> {
         let routing = self.resolve_topic_if_missing(topic_name).await?;
 
@@ -216,7 +217,13 @@ impl Client {
                     .write_leader_for_range(range_id)
                     .ok_or(ClientError::StaleRange)?;
                 let served = self
-                    .call(leader.client_addr(), FetchConsumerOffsetRequest(offset))
+                    .call(
+                        leader.client_addr(),
+                        FetchConsumerOffsetRequest {
+                            key: offset,
+                            generation,
+                        },
+                    )
                     .await?;
                 if served.redirected {
                     self.cache.invalidate(topic_name);
@@ -224,6 +231,14 @@ impl Client {
                 match served.response {
                     ClientResponse::DataPlane(DataPlaneResponse::ConsumerOffset(position)) => {
                         Ok(position.map(|p| (range_id, p)))
+                    }
+                    ClientResponse::DataPlane(
+                        DataPlaneResponse::ConsumerOffsetGenerationMismatch(mismatch),
+                    ) if mismatch.observed_generation > generation => {
+                        Err(ClientError::StaleConsumerGroupEpoch {
+                            request_generation: generation,
+                            sealed_generation: mismatch.observed_generation,
+                        })
                     }
                     _ => Err(ClientError::UnexpectedResponse),
                 }
@@ -497,7 +512,8 @@ impl Client {
                 | DataPlaneResponse::RangeOffset { .. } => Redirect::Done,
                 DataPlaneResponse::ConsumerOffsetCommitted
                 | DataPlaneResponse::StaleConsumerGroupEpoch(_)
-                | DataPlaneResponse::ConsumerOffset(_) => Redirect::Done,
+                | DataPlaneResponse::ConsumerOffset(_)
+                | DataPlaneResponse::ConsumerOffsetGenerationMismatch(_) => Redirect::Done,
             },
             ClientResponse::Admin(_) => Redirect::Done,
             // The server's writer-loop sentinel; a client never legitimately reads it.

--- a/src/connections/controller.rs
+++ b/src/connections/controller.rs
@@ -372,16 +372,23 @@ impl ClientController {
 
     async fn handle_fetch_consumer_offset(
         &self,
-        FetchConsumerOffsetRequest(key): FetchConsumerOffsetRequest,
+        req: FetchConsumerOffsetRequest,
     ) -> anyhow::Result<ClientResponse> {
         let (reply, response) = tokio::sync::oneshot::channel();
         self.data_plane_tx
-            .send_async(ReadConsumerOffset { key, reply })
+            .send_async(ReadConsumerOffset {
+                key: req.key,
+                generation: req.generation,
+                reply,
+            })
             .await?;
 
         Ok(match response.await? {
             ReadConsumerOffsetResult::Offset(offset) => {
                 DataPlaneResponse::ConsumerOffset(offset).into()
+            }
+            ReadConsumerOffsetResult::GenerationMismatch(mismatch) => {
+                DataPlaneResponse::ConsumerOffsetGenerationMismatch(mismatch).into()
             }
             ReadConsumerOffsetResult::NotLeader(leader) => DataPlaneResponse::NotWriteLeader {
                 leader_addr: self.resolve_id_to_addr(leader).await,

--- a/src/connections/protocol/control_plane.rs
+++ b/src/connections/protocol/control_plane.rs
@@ -192,6 +192,30 @@ impl TopicDetail {
             .max()
             .unwrap_or_default()
     }
+
+    /// Ranges whose durable checkpoints are needed to start `ranges` safely:
+    /// each requested range plus its complete predecessor lineage.
+    pub(crate) fn checkpoint_lookup_ranges(&self, ranges: &[RangeId]) -> Box<[RangeId]> {
+        let mut required = ranges.iter().copied().collect::<HashSet<_>>();
+        for range_id in ranges {
+            self.collect_checkpoint_ancestors(*range_id, &mut required);
+        }
+        required.into_iter().collect()
+    }
+
+    fn collect_checkpoint_ancestors(&self, range_id: RangeId, required: &mut HashSet<RangeId>) {
+        for parent in self.ranges.iter().filter(|candidate| {
+            // Either split or merge
+            candidate
+                .split_into
+                .is_some_and(|children| children.0 == range_id || children.1 == range_id)
+                || candidate.merged_into == Some(range_id)
+        }) {
+            if required.insert(parent.range_id) {
+                self.collect_checkpoint_ancestors(parent.range_id, required);
+            }
+        }
+    }
 }
 
 pub struct RebalancePlan {

--- a/src/connections/protocol/data_plane.rs
+++ b/src/connections/protocol/data_plane.rs
@@ -99,7 +99,15 @@ pub struct CommitConsumerOffsetRequest(pub ConsumerOffsetUpdate);
 impl_new_struct_wrapper!(CommitConsumerOffsetRequest, ConsumerOffsetUpdate);
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
-pub struct FetchConsumerOffsetRequest(pub ConsumerOffsetKey);
+pub struct FetchConsumerOffsetRequest {
+    pub key: ConsumerOffsetKey,
+    pub generation: GenerationId,
+}
+
+#[derive(Debug, Clone, Copy, BorshSerialize, BorshDeserialize)]
+pub struct ConsumerOffsetGenerationMismatch {
+    pub observed_generation: GenerationId,
+}
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub enum DataPlaneResponse {
@@ -136,6 +144,7 @@ pub enum DataPlaneResponse {
     ConsumerOffsetCommitted,
     StaleConsumerGroupEpoch(GenerationId),
     ConsumerOffset(Option<ConsumerOffsetPosition>),
+    ConsumerOffsetGenerationMismatch(ConsumerOffsetGenerationMismatch),
     InternalError(String),
 }
 

--- a/src/data_plane/consumer_offset_management/manager.rs
+++ b/src/data_plane/consumer_offset_management/manager.rs
@@ -132,6 +132,10 @@ impl ConsumerOffsetManager {
         self.offset_ledger.offset(key)
     }
 
+    pub(crate) fn durable_generation(&self, key: &ConsumerOffsetKey) -> GenerationId {
+        self.offset_ledger.generation(key)
+    }
+
     pub(crate) fn commit_consumer_offset(
         &mut self,
         cmd: CommitConsumerOffset,

--- a/src/data_plane/messages/query.rs
+++ b/src/data_plane/messages/query.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot;
 
-use crate::connections::protocol::RangeProgressSignal;
+use crate::connections::protocol::{ConsumerOffsetGenerationMismatch, RangeProgressSignal};
 use crate::control_plane::NodeId;
+use crate::control_plane::metadata::consumer_group::GenerationId;
 use crate::control_plane::metadata::{EntryId, RangeId, TopicId};
 use crate::data_plane::consumer_offset_management::ledger::{
     ConsumerOffsetKey, ConsumerOffsetPosition,
@@ -85,10 +86,12 @@ pub enum ListOffsetsResult {
 
 pub struct ReadConsumerOffset {
     pub key: ConsumerOffsetKey,
+    pub generation: GenerationId,
     pub reply: oneshot::Sender<ReadConsumerOffsetResult>,
 }
 
 pub enum ReadConsumerOffsetResult {
     Offset(Option<ConsumerOffsetPosition>),
+    GenerationMismatch(ConsumerOffsetGenerationMismatch),
     NotLeader(Option<NodeId>),
 }

--- a/src/data_plane/state.rs
+++ b/src/data_plane/state.rs
@@ -22,6 +22,7 @@ use super::transport::command::DataTransportCommand;
 use super::wal::WalRecord;
 use super::wal::WalStorage;
 use crate::config::DataNodeConfig;
+use crate::connections::protocol::ConsumerOffsetGenerationMismatch;
 use crate::control_plane::consensus::messages::{MultiRaftActorCommand, ProposeSegmentRoll};
 use crate::control_plane::membership::ShardGroupId;
 use crate::control_plane::metadata::EntryId;
@@ -360,7 +361,16 @@ impl<W: WalStorage> DataPlane<W> {
             .consumer_offsets
             .get_replica_set_if_leader(&query.key, &self.node_id)
         {
-            Ok(_) => ReadConsumerOffsetResult::Offset(self.consumer_offsets.offset(&query.key)),
+            Ok(_) => {
+                let observed_generation = self.consumer_offsets.durable_generation(&query.key);
+                if observed_generation == query.generation {
+                    ReadConsumerOffsetResult::Offset(self.consumer_offsets.offset(&query.key))
+                } else {
+                    ReadConsumerOffsetResult::GenerationMismatch(ConsumerOffsetGenerationMismatch {
+                        observed_generation,
+                    })
+                }
+            }
             Err(leader) => ReadConsumerOffsetResult::NotLeader(leader),
         };
         let _ = query.reply.send(result);
@@ -1704,6 +1714,7 @@ impl<T: WalStorage> TAssertInvariant for DataPlane<T> {
 #[cfg(test)]
 mod tests {
     use crate::control_plane::Replicas;
+    use crate::control_plane::metadata::consumer_group::GenerationId;
     use crate::data_plane::consumer_offset_management::ledger::{
         ConsumerOffsetKey, ConsumerOffsetPosition, ConsumerOffsetUpdate, EpochSeal, OffsetLedger,
     };
@@ -1803,6 +1814,44 @@ mod tests {
             range_id: RangeId(0),
             group_id: "group".into(),
         }
+    }
+
+    fn read_consumer_offset(
+        dp: &DataPlane<impl WalStorage>,
+        generation: GenerationId,
+    ) -> ReadConsumerOffsetResult {
+        let (reply, mut response) = oneshot::channel();
+        dp.read_consumer_offset(ReadConsumerOffset {
+            key: consumer_offset_key(),
+            generation,
+            reply,
+        });
+        response.try_recv().unwrap()
+    }
+
+    #[test]
+    fn consumer_offset_read_waits_for_durable_generation_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dp = make_data_plane(&dir);
+        dp.process(assign_segment(test_key(), vec![test_node_id()]));
+        dp.process_peer(DataPlanePeerMessage::ConsumerGroupEpochSealed(EpochSeal {
+            generation: 2.into(),
+            key: consumer_offset_key(),
+        }));
+
+        assert!(matches!(
+            read_consumer_offset(&dp, 2.into()),
+            ReadConsumerOffsetResult::GenerationMismatch(ConsumerOffsetGenerationMismatch {
+                observed_generation: GenerationId(0)
+            })
+        ));
+
+        dp.flush_batch();
+
+        assert!(matches!(
+            read_consumer_offset(&dp, 2.into()),
+            ReadConsumerOffsetResult::Offset(None)
+        ));
     }
 
     #[test]

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -19,6 +19,7 @@ use crate::client::{
 };
 use crate::config::Environment;
 use crate::connections::protocol::ClientResponse;
+use crate::control_plane::metadata::consumer_group::GenerationId;
 use crate::control_plane::metadata::{EntryId, RangeId};
 use crate::control_plane::{NodeAddress, NodeAddressInfo, NodeId};
 use crate::data_plane::consumer_offset_management::ledger::ConsumerOffsetKey;
@@ -350,6 +351,7 @@ fn consumer_offset_read_corrects_stale_write_leader() -> turmoil::Result {
                     group_id: "group".to_string(),
                 }]
                 .into_boxed_slice(),
+                GenerationId(0),
             )
             .await
             .expect("offset read follows the leader redirect");

--- a/src/it/sim/properties.rs
+++ b/src/it/sim/properties.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use std::time::Duration;
 
 use turmoil::Builder;
@@ -62,25 +62,33 @@ fn three_node_sim(simulation_secs: u64, seed: u64) -> turmoil::Sim<'static> {
 fn spawn_node(sim: &mut turmoil::Sim<'static>, i: u8, total: u8, seed: u64) {
     let cp = client_port(i);
     let rp = cluster_port(i);
-    sim.host(node_name(i), move || async move {
-        let name = node_name(i);
-        let me = turmoil::lookup(name.as_str());
-        let seeds: Vec<String> = (1..=total)
-            .filter(|&j| j != i)
-            .map(|j| {
-                format!(
-                    "{}:{}",
-                    turmoil::lookup(node_name(j).as_str()),
-                    cluster_port(j)
-                )
-            })
-            .collect();
-        let mut env = default_env(i as u32, name.clone(), cp, rp);
-        env.advertise_host = Some(me.to_string());
-        env.join_seed_nodes = seeds;
-        env.vnodes_per_node = 3;
-        StartUp::with_env(env, seed).run().await?;
-        Ok(())
+    // Pin every identity input to the simulation seed. A per-host boot counter
+    // keeps restart identities distinct without reintroducing OS randomness.
+    let boot = Arc::new(AtomicU32::new(0));
+    sim.host(node_name(i), move || {
+        let boot = boot.clone();
+        async move {
+            let boot = boot.fetch_add(1, Ordering::SeqCst);
+            let name = node_name(i);
+            let me = turmoil::lookup(name.as_str());
+            let seeds: Vec<String> = (1..=total)
+                .filter(|&j| j != i)
+                .map(|j| {
+                    format!(
+                        "{}:{}",
+                        turmoil::lookup(node_name(j).as_str()),
+                        cluster_port(j)
+                    )
+                })
+                .collect();
+            let mut env = default_env(i as u32, name.clone(), cp, rp);
+            env.node_id_suffix = Some(format!("sim-{seed}-{i}-{boot}"));
+            env.advertise_host = Some(me.to_string());
+            env.join_seed_nodes = seeds;
+            env.vnodes_per_node = 3;
+            StartUp::with_env(env, seed).run().await?;
+            Ok(())
+        }
     });
 }
 


### PR DESCRIPTION
## Changes

- Limit rebalance checkpoint lookups to ranges being started and their transitive split/merge predecessors.
- Use the consumer-group generation as a shared snapshot boundary across independently routed range lookups.
- Require each range leader to observe the durable generation seal before returning a checkpoint.
- Serialize checkpoint lookup with commits from the recovering consumer.
- Keep range actors stopped when checkpoint lookup fails.
- Surface background lookup failures through `Consumer::next_record()`.
- Return lookup failures directly from explicit stale-commit recovery.
- Document the rebalance checkpoint boundary and failure behavior.

## Why
Rebalances previously requested checkpoints for every known topic range. Individual range requests also lacked a common observed boundary, and lookup failures were only logged before an internal retry.

The new flow makes lookup cost proportional to the ranges being provisioned, gives the result set one logical generation boundary, and makes failures visible without treating unavailable state as a missing checkpoint.
