### PR TITLE
feat(client): implement Producer & Consumer graceful shutdown, lightweight  barrier synchronization

### DIFF
--- a/docs/clients/c4_consumer_offset_commits.md
+++ b/docs/clients/c4_consumer_offset_commits.md
@@ -107,6 +107,21 @@ cannot race their local committed markers.
 
 ---
 
+## Explicit Shutdown
+
+Closing a consumer does the following:
+- stops fetching
+- commits currently acknowledged progress 
+- revokes ownership 
+- leaves the group 
+
+Records already fetched into the local delivery queue but not yet returned to the application are discarded: after ownership is revoked, they are no longer valid deliveries from that consumer. In at-least-once mode, unacknowledged records therefore remain beyond the durable checkpoint and replay to a later group member.
+
+Consumer handles share one manager and one delivery stream. Closing any handle closes that
+shared stream, so every clone subsequently observes end of delivery.
+
+---
+
 ## Acknowledgement Validation
 
 An acknowledgement is accepted only when:

--- a/src/bin/eg-cli/commands.rs
+++ b/src/bin/eg-cli/commands.rs
@@ -134,7 +134,7 @@ async fn handle_publish(
     key: String,
     message: String,
 ) -> anyhow::Result<()> {
-    let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+    let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default())?;
     let entry_id = producer.send(key.as_bytes(), message.into_bytes()).await?;
 
     println!(

--- a/src/client/consumer/config.rs
+++ b/src/client/consumer/config.rs
@@ -1,3 +1,5 @@
+use crate::client::ClientError;
+
 #[derive(Debug, Clone)]
 pub enum DeliverySemantic {
     AtLeastOnce,
@@ -30,6 +32,25 @@ impl ConsumerConfig {
             commit_mode: CommitMode::Auto,
         }
     }
+
+    pub(crate) fn validate(&self) -> Result<(), ClientError> {
+        if self.group_id.as_ref().is_some_and(|group| group.is_empty()) {
+            return Err(ClientError::invalid_configuration(
+                "consumer.group_id",
+                "must not be empty",
+            ));
+        }
+        if self.group_id.is_some()
+            && self.commit_mode == CommitMode::Auto
+            && self.auto_commit_interval_ms == 0
+        {
+            return Err(ClientError::invalid_configuration(
+                "consumer.auto_commit_interval_ms",
+                "must be greater than zero when group auto-commit is enabled",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,5 +67,27 @@ impl std::str::FromStr for StartPolicy {
             "earliest" => Ok(StartPolicy::Earliest),
             _ => anyhow::bail!("Start policy must be 'earliest' or 'latest'"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_group_id() {
+        let mut config = ConsumerConfig::new(StartPolicy::Earliest);
+        config.group_id = Some(String::new());
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_group_auto_commit_interval() {
+        let mut config = ConsumerConfig::new(StartPolicy::Earliest);
+        config.group_id = Some("group".to_string());
+        config.auto_commit_interval_ms = 0;
+
+        assert!(config.validate().is_err());
     }
 }

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -49,6 +49,7 @@ pub struct ConsumerGroup {
     consumer_id: Uuid,
     client: Arc<Client>,
     delivery_fenced: AtomicBool,
+    quit: AtomicBool,
     generation: AtomicU64,
     commit_lock: tokio::sync::Mutex<()>,
 }
@@ -69,6 +70,7 @@ impl ConsumerGroup {
             owned_ranges: ArcSwap::from_pointee(HashSet::new()),
             offsets: DashMap::new(),
             delivery_fenced: AtomicBool::new(true),
+            quit: AtomicBool::new(false),
             generation: AtomicU64::new(0),
             commit_lock: tokio::sync::Mutex::new(()),
         };
@@ -210,6 +212,29 @@ impl ConsumerGroup {
         Ok(assignment.ranges.into_vec().into_iter().collect())
     }
 
+    pub(crate) async fn leave(&self) -> Result<(), ClientError> {
+        if self.quit.load(AtomicOrdering::Acquire) {
+            return Ok(());
+        }
+        let request = SyncConsumerGroupRequest {
+            topic_name: self.topic.clone(),
+            group_id: self.group_id.clone(),
+            member_id: self.consumer_id,
+            action: ConsumerGroupSyncAction::Leave,
+        };
+        let served = self
+            .client
+            .call(self.client.next_known_node(), request)
+            .await?;
+        match served.response {
+            ClientResponse::Ok(ClientSuccess::ConsumerGroupLeft) => {
+                self.quit.store(true, AtomicOrdering::Release);
+                Ok(())
+            }
+            _ => Err(ClientError::UnexpectedResponse),
+        }
+    }
+
     pub(crate) fn install_effective_ownership(&self, ranges: HashSet<RangeId>) -> Box<[RangeId]> {
         let previous = self.owned_ranges.load_full();
 
@@ -261,6 +286,9 @@ impl ConsumerGroup {
 
 impl Drop for ConsumerGroup {
     fn drop(&mut self) {
+        if self.quit.load(AtomicOrdering::Acquire) {
+            return;
+        }
         let client = self.client.clone();
         let req = SyncConsumerGroupRequest {
             topic_name: self.topic.clone(),

--- a/src/client/consumer/group.rs
+++ b/src/client/consumer/group.rs
@@ -204,7 +204,10 @@ impl ConsumerGroup {
             .response
         {
             ClientResponse::Ok(ClientSuccess::ConsumerGroupAssignment(assignment)) => assignment,
-            _ => return Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => return Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => {
+                return Err(ClientError::UnexpectedResponse);
+            }
         };
 
         self.generation
@@ -231,7 +234,8 @@ impl ConsumerGroup {
                 self.quit.store(true, AtomicOrdering::Release);
                 Ok(())
             }
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 

--- a/src/client/consumer/messages.rs
+++ b/src/client/consumer/messages.rs
@@ -26,11 +26,16 @@ pub(crate) struct RetryCommitAfterEpochRefresh {
     pub(crate) reply: oneshot::Sender<Result<(), ClientError>>,
 }
 
+pub(crate) struct CloseConsumer {
+    pub(crate) reply: oneshot::Sender<Result<(), ClientError>>,
+}
+
 pub(crate) enum TopicFetchManagerCommand {
     PauseRange(PauseRange),
     ResumeRange(ResumeRange),
     SeekRange(SeekRange),
     RetryCommitAfterEpochRefresh(RetryCommitAfterEpochRefresh),
+    CloseConsumer(CloseConsumer),
 }
 
 impl_from_variant!(
@@ -39,6 +44,7 @@ impl_from_variant!(
     ResumeRange,
     SeekRange,
     RetryCommitAfterEpochRefresh,
+    CloseConsumer,
 );
 
 pub(crate) struct RangeDrained {

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -62,6 +62,13 @@ impl Consumer {
         interest: KeyInterest,
         config: ConsumerConfig,
     ) -> Result<Self, ClientError> {
+        if topic.is_empty() {
+            return Err(ClientError::invalid_configuration(
+                "consumer.topic",
+                "must not be empty",
+            ));
+        }
+        config.validate()?;
         let detail = client.resolve_topic(&topic).await?;
         let mut cursors = PendingCursorStore::build_cursors(&detail, interest, config.start_policy);
 

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -46,6 +46,34 @@ impl ConsumerRecord {
     }
 }
 
+/// A topic consumer backed by one shared fetch manager.
+///
+/// Clones compete for records from the same stream; they do not each receive a copy.
+/// Closing any clone shuts down the shared manager and invalidates the other clones.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use east_guard::client::{
+///     Client, Consumer, ConsumerConfig, KeyInterest, StartPolicy,
+/// };
+/// use std::{net::SocketAddr, sync::Arc};
+///
+/// let seed: SocketAddr = "127.0.0.1:9091".parse()?;
+/// let client = Arc::new(Client::connect([seed])?);
+/// let mut config = ConsumerConfig::new(StartPolicy::Earliest);
+/// config.group_id = Some("billing".to_string());
+///
+/// let consumer =
+///     Consumer::new(client, "orders".to_string(), KeyInterest::AllKeys, config).await?;
+/// if let Some(record) = consumer.next_record().await? {
+///     consumer.ack(&record)?;
+/// }
+/// consumer.close().await?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct Consumer {
     ctx: Arc<ConsumerContext>,
@@ -143,6 +171,10 @@ impl Consumer {
         ));
     }
 
+    /// Commit acknowledged positions for ranges currently owned by this consumer.
+    ///
+    /// A canceled commit may still complete on the server. Retrying is safe because
+    /// committed positions advance monotonically.
     pub async fn commit(&self) -> Result<(), ClientError> {
         let Some(group) = &self.group else {
             return Ok(());
@@ -166,6 +198,9 @@ impl Consumer {
     }
 
     /// Stop fetching, commit acknowledged offsets, revoke ownership, and leave the group.
+    ///
+    /// This affects every clone. Once the command reaches the fetch manager, shutdown
+    /// continues even if this future is canceled; cancellation only loses the result.
     pub async fn close(&self) -> Result<(), ClientError> {
         let (reply, response) = tokio::sync::oneshot::channel();
         self.command_tx
@@ -249,6 +284,8 @@ impl Consumer {
     /// Returns `Ok(Some(record))` when a record is available, and `Ok(None)` when the topic has
     /// been fully consumed (i.e. all lineage paths have been drained to their ends and no active
     /// cursors remain).
+    ///
+    /// Canceling while waiting does not acknowledge or commit a record.
     pub async fn next_record(&self) -> Result<Option<ConsumerRecord>, ClientError> {
         loop {
             let Ok(res) = self.consumer_rx.recv_async().await else {

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -197,7 +197,8 @@ impl Consumer {
         }
     }
 
-    /// Stop fetching, commit acknowledged offsets, revoke ownership, and leave the group.
+    /// Stop fetching, discard prefetched records that were not delivered, commit
+    /// acknowledged offsets, revoke ownership, and leave the group.
     ///
     /// This affects every clone. Once the command reaches the fetch manager, shutdown
     /// continues even if this future is canceled; cancellation only loses the result.
@@ -207,7 +208,16 @@ impl Consumer {
             .send_async(CloseConsumer { reply }.into())
             .await
             .map_err(|_| ClientError::ConsumerClosed)?;
-        response.await.map_err(|_| ClientError::ConsumerClosed)?
+        let result = response.await.map_err(|_| ClientError::ConsumerClosed)?;
+
+        self.purge_prefetched_buffer();
+        result
+    }
+
+    // ! Discards prefetched, undelivered records after fetching stops and ownership is revoked
+    // ! This ensures all clones observe terminiation
+    fn purge_prefetched_buffer(&self) {
+        while self.consumer_rx.try_recv().is_ok() {}
     }
 
     pub fn ack(&self, record: &ConsumerRecord) -> Result<(), ClientError> {

--- a/src/client/consumer/mod.rs
+++ b/src/client/consumer/mod.rs
@@ -165,6 +165,16 @@ impl Consumer {
         }
     }
 
+    /// Stop fetching, commit acknowledged offsets, revoke ownership, and leave the group.
+    pub async fn close(&self) -> Result<(), ClientError> {
+        let (reply, response) = tokio::sync::oneshot::channel();
+        self.command_tx
+            .send_async(CloseConsumer { reply }.into())
+            .await
+            .map_err(|_| ClientError::ConsumerClosed)?;
+        response.await.map_err(|_| ClientError::ConsumerClosed)?
+    }
+
     pub fn ack(&self, record: &ConsumerRecord) -> Result<(), ClientError> {
         let Some(group) = &self.group else {
             return Ok(());

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -15,8 +15,12 @@ use crate::data_plane::messages::query::RangeOffsets;
 
 const EMPTY_FETCHES_BEFORE_REFRESH: u8 = 20;
 
+pub(crate) struct StopRangeFetch {
+    pub(crate) reply: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
 pub(crate) enum RangeFetchActorCommand {
-    Stop,
+    Stop(StopRangeFetch),
     Pause {
         reply: tokio::sync::oneshot::Sender<()>,
     },
@@ -63,7 +67,13 @@ impl RangeFetchActor {
             tokio::select! {
                 cmd = rx.recv_async() => {
                     match cmd {
-                        Ok(RangeFetchActorCommand::Stop) | Err(_) => {
+                        Ok(RangeFetchActorCommand::Stop(command)) => {
+                            if let Some(reply) = command.reply {
+                                let _ = reply.send(());
+                            }
+                            return;
+                        }
+                        Err(_) => {
                             return; // Graceful shutdown
                         }
                         Ok(RangeFetchActorCommand::Pause { reply }) => {

--- a/src/client/consumer/range_fetcher.rs
+++ b/src/client/consumer/range_fetcher.rs
@@ -179,7 +179,8 @@ impl RangeFetchActor {
                 self.ctx.refresh_metadata().await?;
                 Ok(true)
             }
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 

--- a/src/client/consumer/topic_fetch_manager.rs
+++ b/src/client/consumer/topic_fetch_manager.rs
@@ -3,7 +3,9 @@ use super::RangeCursor;
 use super::messages::*;
 use crate::client::consumer::config::StartPolicy;
 use crate::client::consumer::group::ConsumerGroup;
-use crate::client::consumer::range_fetcher::{RangeFetchActor, RangeFetchActorCommand};
+use crate::client::consumer::range_fetcher::{
+    RangeFetchActor, RangeFetchActorCommand, StopRangeFetch,
+};
 use crate::client::consumer::{
     ConsumerContext, ConsumerRecord, MergeSiblingState, PendingCursorStore,
 };
@@ -140,6 +142,10 @@ impl TopicFetchManagerState {
                 let result = self.retry_commit_after_epoch_refresh(ctx).await;
                 let _ = command.reply.send(result);
             }
+            TopicFetchManagerCommand::CloseConsumer(command) => {
+                let result = self.close().await;
+                let _ = command.reply.send(result);
+            }
         }
     }
 
@@ -176,7 +182,7 @@ impl TopicFetchManagerState {
     fn fence_group_fetchers(&mut self, group: &ConsumerGroup) {
         group.fence_delivery();
         for (_, stop_tx) in self.senders.drain() {
-            let _ = stop_tx.send(RangeFetchActorCommand::Stop);
+            let _ = stop_tx.send(RangeFetchActorCommand::Stop(StopRangeFetch { reply: None }));
         }
         self.pending_cursors.clear();
         group.clear_effective_ownership();
@@ -259,7 +265,7 @@ impl TopicFetchManagerState {
         for range in to_drop {
             // Revoke ownership: send Stop, remove cursor and stop channel.
             if let Some(stop_tx) = self.senders.remove(&range) {
-                let _ = stop_tx.send(RangeFetchActorCommand::Stop);
+                let _ = stop_tx.send(RangeFetchActorCommand::Stop(StopRangeFetch { reply: None }));
             }
             self.pending_cursors.remove(range);
         }
@@ -397,13 +403,38 @@ impl TopicFetchManagerState {
         Ok(EntryId::default())
     }
 
-    async fn abort_all(&mut self) {
-        for (_, stop_tx) in self.senders.drain() {
-            let _ = stop_tx.send(RangeFetchActorCommand::Stop);
+    async fn stop_all(&mut self) {
+        let stops = self.senders.drain().map(|(_, stop_tx)| async move {
+            let (reply, response) = oneshot::channel();
+            if stop_tx
+                .send_async(RangeFetchActorCommand::Stop(StopRangeFetch {
+                    reply: Some(reply),
+                }))
+                .await
+                .is_ok()
+            {
+                let _ = response.await;
+            }
+        });
+        futures::future::join_all(stops).await;
+    }
+
+    async fn close(&mut self) -> Result<(), ClientError> {
+        let group = self.consumer_group.take();
+        if let Some(group) = &group {
+            group.fence_delivery();
         }
-        if let Some(group) = &self.consumer_group {
-            let _ = tokio::time::timeout(Duration::from_secs(1), group.commit()).await;
+        self.stop_all().await;
+        self.pending_cursors.clear();
+
+        if let Some(group) = group {
+            let commit = group.commit().await;
+            group.clear_effective_ownership();
+            let leave = group.leave().await;
+            commit?;
+            leave?;
         }
+        Ok(())
     }
 
     /// Returns true if this range should NOT be started. Consolidates:
@@ -556,6 +587,9 @@ pub(crate) async fn run_topic_fetch_manager(
             res = command_rx.recv_async() => {
                 let Ok(command) = res else { break };
                 state.handle_command(command, &ctx).await;
+                if state.should_exit() {
+                    return;
+                }
             }
 
             _ = commit_interval.tick(), if state.should_auto_commit() => {
@@ -575,7 +609,7 @@ pub(crate) async fn run_topic_fetch_manager(
         state.assert_invariants();
     }
 
-    state.abort_all().await;
+    state.stop_all().await;
 }
 
 #[cfg(any(test, debug_assertions))]

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -5,10 +5,22 @@ use crate::client::RangeId;
 use crate::control_plane::metadata::consumer_group::GenerationId;
 use crate::data_plane::ProduceError;
 
+/// A client configuration value that cannot produce a coherent runtime policy.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid client configuration `{field}`: {reason}")]
+pub struct InvalidConfiguration {
+    pub field: &'static str,
+    pub reason: &'static str,
+}
+
 /// Errors a caller decides on. Redirect-following, reconnect, and retry-within-deadline
 /// are handled internally.
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum ClientError {
+    #[error(transparent)]
+    InvalidConfiguration(InvalidConfiguration),
+
     /// Could not reach `addr`. Internal to the pool — the retry loop catches it and
     /// re-resolves; a persistent failure surfaces as `Timeout`, not this.
     #[error("connection to {addr} unavailable: {reason}")]
@@ -66,6 +78,10 @@ pub enum ClientError {
 }
 
 impl ClientError {
+    pub(crate) fn invalid_configuration(field: &'static str, reason: &'static str) -> Self {
+        Self::InvalidConfiguration(InvalidConfiguration { field, reason })
+    }
+
     pub(crate) fn on_ack(range_id: RangeId, reason: &'static str) -> Self {
         Self::on_control("ack", range_id, reason)
     }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -54,6 +54,9 @@ pub enum ClientError {
     #[error("producer is closed")]
     ProducerClosed,
 
+    #[error("consumer is closed")]
+    ConsumerClosed,
+
     #[error("produce rejected: {0}")]
     ProduceRejected(ProduceError),
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::client::RangeId;
+use crate::connections::protocol::ServerError;
 use crate::control_plane::metadata::consumer_group::GenerationId;
 use crate::data_plane::ProduceError;
 
@@ -46,6 +47,9 @@ pub enum ClientError {
     /// Response didn't match the request — a wire/version mismatch, not routing.
     #[error("unexpected response for request")]
     UnexpectedResponse,
+
+    #[error(transparent)]
+    Server(ServerError),
 
     /// Expected range has split or metadata is stale.
     #[error("stale range routing")]

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -51,6 +51,9 @@ pub enum ClientError {
     #[error("stale range routing")]
     StaleRange,
 
+    #[error("producer is closed")]
+    ProducerClosed,
+
     #[error("produce rejected: {0}")]
     ProduceRejected(ProduceError),
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,6 +5,14 @@
 //! that keeps the cache honest. The server never proxies — it redirects, and this
 //! library follows. Producer (C2) and consumer (C3) layer on top of this core.
 //!
+//! # Cancellation
+//!
+//! Canceling a future stops waiting locally; it does not retract a request already
+//! written to a server. Mutating operations may therefore complete after their future
+//! is dropped. Producer batching has a stronger contract documented on
+//! [`Producer::send`]. Use [`Producer::close`] and [`Consumer::close`] for explicit
+//! graceful shutdown; dropping a handle performs only best-effort cleanup.
+//!
 //! `#![allow(dead_code)]` — C1 is the foundation; its tests and the later C2/C3 phases
 //! are the first non-test consumers (mirrors `consumer`).
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -162,7 +162,10 @@ impl Client {
                 ClientResponse::Err(ServerError::SegmentNotLocal) => {
                     last_error = Some("range offsets segment not local".to_string());
                 }
-                _ => return Err(ClientError::UnexpectedResponse),
+                ClientResponse::Err(error) => return Err(ClientError::Server(error)),
+                ClientResponse::Ok(_) | ClientResponse::Stop => {
+                    return Err(ClientError::UnexpectedResponse);
+                }
             }
 
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -197,7 +200,8 @@ impl Client {
                     sealed_generation: stale,
                 })
             }
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 
@@ -240,7 +244,10 @@ impl Client {
                             sealed_generation: mismatch.observed_generation,
                         })
                     }
-                    _ => Err(ClientError::UnexpectedResponse),
+                    ClientResponse::Err(error) => Err(ClientError::Server(error)),
+                    ClientResponse::Ok(_) | ClientResponse::Stop => {
+                        Err(ClientError::UnexpectedResponse)
+                    }
                 }
             }
         });
@@ -262,7 +269,8 @@ impl Client {
         match served.response {
             ClientResponse::Ok(ClientSuccess::TopicCreated) => Ok(true),
             ClientResponse::Err(ServerError::AlreadyExists) => Ok(false),
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 
@@ -276,7 +284,8 @@ impl Client {
         self.cache.invalidate(name);
         match served.response {
             ClientResponse::Ok(ClientSuccess::TopicDeleted) => Ok(()),
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 
@@ -304,10 +313,8 @@ impl Client {
                 self.cache.insert(&detail);
                 Ok(detail)
             }
-            err => {
-                tracing::error!("{err:?}{}{}", file!(), line!());
-                Err(ClientError::UnexpectedResponse)
-            }
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 
@@ -320,7 +327,8 @@ impl Client {
             .await?;
         match served.response {
             ClientResponse::Ok(ClientSuccess::ProducerSessionOpened(session)) => Ok(session),
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 
@@ -372,7 +380,8 @@ impl Client {
             ClientResponse::Err(ServerError::ProduceRejected(error)) => {
                 Err(ClientError::ProduceRejected(error))
             }
-            _ => Err(ClientError::UnexpectedResponse),
+            ClientResponse::Err(error) => Err(ClientError::Server(error)),
+            ClientResponse::Ok(_) | ClientResponse::Stop => Err(ClientError::UnexpectedResponse),
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,7 +38,7 @@ pub use consumer::{
     CommitMode, Consumer, ConsumerConfig, ConsumerRecord, DeliverySemantic, KeyInterest,
     StartPolicy,
 };
-pub use error::ClientError;
+pub use error::{ClientError, InvalidConfiguration};
 use pool::ConnectionPool;
 pub use producer::{BufferConfig, Producer, ProducerConfig};
 use uuid::Uuid;
@@ -86,6 +86,7 @@ impl Client {
         if seeds.is_empty() {
             return Err(ClientError::NoSeeds);
         }
+        retry.validate()?;
         Ok(Self {
             pool: ConnectionPool::new(),
             cache: RoutingCache::new(),

--- a/src/client/producer/buffers.rs
+++ b/src/client/producer/buffers.rs
@@ -161,9 +161,9 @@ impl ProducerBuffers {
     }
 
     /// Take and clear all records from the buffer for a specific partition, if the task sequence matches the current batch.
-    pub fn take(&self, range_id: RangeId, task_batch_seq: u64) -> Option<Vec<PendingRecord>> {
+    pub fn take(&self, range_id: RangeId, batch_seq: u64) -> Option<Vec<PendingRecord>> {
         let mut buf = self.inner.get_mut(&range_id)?;
-        if buf.current_batch_seq != task_batch_seq {
+        if buf.current_batch_seq != batch_seq {
             return None;
         }
         if buf.records.is_empty() {

--- a/src/client/producer/config.rs
+++ b/src/client/producer/config.rs
@@ -1,9 +1,17 @@
-use crate::client::CompressionCodec;
+use crate::client::{ClientError, CompressionCodec};
 use std::time::Duration;
 
 fn parse_duration_ms(s: &str) -> Result<Duration, String> {
     let ms: u64 = s.parse().map_err(|e| format!("invalid duration: {}", e))?;
     Ok(Duration::from_millis(ms))
+}
+
+fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
+    let val: usize = s.parse().map_err(|e| format!("invalid number: {}", e))?;
+    if val == 0 {
+        return Err("must be greater than zero".to_string());
+    }
+    Ok(val)
 }
 
 /// Configuration specific to buffer management.
@@ -14,11 +22,11 @@ pub struct BufferConfig {
     pub linger: Duration,
 
     /// Maximum serialized bytes in a batch before triggering a flush.
-    #[arg(long, env = "PRODUCER_MAX_BATCH_BYTES", default_value = "1048576")]
+    #[arg(long, env = "PRODUCER_MAX_BATCH_BYTES", default_value = "1048576", value_parser = parse_nonzero_usize)]
     pub max_batch_bytes: usize,
 
     /// Maximum number of records in a batch before triggering a flush.
-    #[arg(long, env = "PRODUCER_MAX_BATCH_RECORDS", default_value = "1000")]
+    #[arg(long, env = "PRODUCER_MAX_BATCH_RECORDS", default_value = "1000", value_parser = parse_nonzero_usize)]
     pub max_batch_records: usize,
 }
 
@@ -29,6 +37,24 @@ impl Default for BufferConfig {
             max_batch_bytes: 1024 * 1024, // 1 MB
             max_batch_records: 1000,
         }
+    }
+}
+
+impl BufferConfig {
+    pub(crate) fn validate(&self) -> Result<(), ClientError> {
+        if self.max_batch_bytes == 0 {
+            return Err(ClientError::invalid_configuration(
+                "producer.buffer.max_batch_bytes",
+                "must be greater than zero",
+            ));
+        }
+        if self.max_batch_records == 0 {
+            return Err(ClientError::invalid_configuration(
+                "producer.buffer.max_batch_records",
+                "must be greater than zero",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -50,5 +76,54 @@ impl Default for ProducerConfig {
             buffer: BufferConfig::default(),
             codec: CompressionCodec::None,
         }
+    }
+}
+
+impl ProducerConfig {
+    pub(crate) fn validate(&self) -> Result<(), ClientError> {
+        self.buffer.validate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct CommandWrapper {
+        #[command(flatten)]
+        buffer: BufferConfig,
+    }
+
+    #[test]
+    fn rejects_zero_batch_limits() {
+        let zero_bytes = BufferConfig {
+            max_batch_bytes: 0,
+            ..BufferConfig::default()
+        };
+        assert!(zero_bytes.validate().is_err());
+
+        let zero_records = BufferConfig {
+            max_batch_records: 0,
+            ..BufferConfig::default()
+        };
+        assert!(zero_records.validate().is_err());
+    }
+
+    #[test]
+    fn clap_rejects_zero_batch_limits() {
+        assert!(CommandWrapper::try_parse_from(["app", "--max-batch-bytes", "0"]).is_err());
+        assert!(CommandWrapper::try_parse_from(["app", "--max-batch-records", "0"]).is_err());
+        assert!(
+            CommandWrapper::try_parse_from([
+                "app",
+                "--max-batch-bytes",
+                "1024",
+                "--max-batch-records",
+                "100"
+            ])
+            .is_ok()
+        );
     }
 }

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -137,15 +137,10 @@ impl Inner {
             return Err(self.flush_timeout());
         }
 
-        let routing = match tokio::time::timeout(
-            remaining,
-            self.client.resolve_topic_if_missing(&self.topic),
-        )
-        .await
-        {
-            Ok(result) => result?,
-            Err(_) => return Err(self.flush_timeout()),
-        };
+        let routing =
+            tokio::time::timeout(remaining, self.client.resolve_topic_if_missing(&self.topic))
+                .await
+                .map_err(|_| self.flush_timeout())??;
 
         let session = self
             .session_manager
@@ -268,7 +263,7 @@ impl Inner {
             }
         };
         let digest = crc32fast::hash(&payload);
-        let result = match tokio::time::timeout(
+        let result = tokio::time::timeout(
             deadline.saturating_duration_since(Instant::now()),
             self.client.produce_to_range(
                 &self.topic,
@@ -280,10 +275,7 @@ impl Inner {
             ),
         )
         .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(self.flush_timeout()),
-        };
+        .unwrap_or_else(|_| Err(self.flush_timeout()));
 
         match result {
             Ok(entry_id) => {
@@ -329,22 +321,19 @@ impl Inner {
             return Err(ClientError::ProducerClosed);
         }
 
-        let order = self.next_record_order.fetch_add(1, Ordering::Relaxed);
-        let routing = self.client.resolve_topic_if_missing(&self.topic).await?;
-        let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
-
         let (tx, rx) = oneshot::channel();
 
         let pending = PendingRecord {
-            order,
+            order: self.next_record_order.fetch_add(1, Ordering::Relaxed),
             key: key.to_vec(),
             value,
             tx,
         };
 
-        let push_res = self.buffers.push(range_id, pending);
+        let routing = self.client.resolve_topic_if_missing(&self.topic).await?;
+        let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
 
-        match push_res {
+        match self.buffers.push(range_id, pending) {
             PushResult::Flush(records_to_flush) => {
                 let flush = self.flush_gate.clone().read_owned().await;
                 self.flush_in_background(records_to_flush, flush);

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -7,12 +7,10 @@ use crate::client::routing::TopicRouting;
 use crate::client::{Client, CompressionCodec};
 use crate::control_plane::metadata::{EntryId, RangeId};
 use crate::data_plane::ProduceError;
-use crate::impl_new_struct_wrapper;
 use buffers::{PendingRecord, ProducerBuffers, PushResult};
 pub use config::{BufferConfig, ProducerConfig};
 use session::{ClientProducerSession, ClientProducerSessionManager};
 use std::collections::BTreeMap;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::sync::{RwLock, oneshot};
@@ -48,8 +46,9 @@ use uuid::Uuid;
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct Producer(Arc<Inner>);
-impl_new_struct_wrapper!(Producer, Arc<Inner>);
+pub struct Producer {
+    inner: Arc<Inner>,
+}
 
 /// # Synchronization & Deadlock Prevention Model
 ///
@@ -93,7 +92,7 @@ impl_new_struct_wrapper!(Producer, Arc<Inner>);
 /// [`send()`]: Producer::send
 /// [`flush()`]: Producer::flush
 /// [`close()`]: Producer::close
-pub struct Inner {
+struct Inner {
     client: Arc<Client>,
     topic: String,
     buffers: ProducerBuffers,
@@ -103,6 +102,12 @@ pub struct Inner {
     flush_gate: Arc<RwLock<()>>,
     should_reject: AtomicBool,
     next_record_order: AtomicU64,
+}
+
+impl Inner {
+    async fn resolve_topic_if_missing(&self) -> Result<Arc<TopicRouting>, ClientError> {
+        self.client.resolve_topic_if_missing(&self.topic).await
+    }
 }
 
 impl Producer {
@@ -123,17 +128,19 @@ impl Producer {
         }
         config.validate()?;
 
-        Ok(Self(Arc::new(Inner {
-            client,
-            topic,
-            buffers: ProducerBuffers::new(config.buffer.clone()),
-            codec: config.codec,
-            session_manager: ClientProducerSessionManager::new(producer_id),
-            send_gate: RwLock::new(()),
-            flush_gate: Arc::new(RwLock::new(())),
-            should_reject: AtomicBool::new(false),
-            next_record_order: AtomicU64::new(0),
-        })))
+        Ok(Self {
+            inner: Arc::new(Inner {
+                client,
+                topic,
+                buffers: ProducerBuffers::new(config.buffer.clone()),
+                codec: config.codec,
+                session_manager: ClientProducerSessionManager::new(producer_id),
+                send_gate: RwLock::new(()),
+                flush_gate: Arc::new(RwLock::new(())),
+                should_reject: AtomicBool::new(false),
+                next_record_order: AtomicU64::new(0),
+            }),
+        })
     }
 
     /// Produce a single record. Returns the committed entry ID once the batch flushes.
@@ -142,13 +149,13 @@ impl Producer {
     /// publication is shared work and may still complete; canceling only discards this
     /// caller's acknowledgement.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
-        let send_guard = self.send_gate.read().await;
-        if self.should_reject.load(Ordering::Acquire) {
+        let send_guard = self.inner.send_gate.read().await;
+        if self.inner.should_reject.load(Ordering::Acquire) {
             return Err(ClientError::ProducerClosed);
         }
 
-        let order = self.next_record_order.fetch_add(1, Ordering::Relaxed);
-        let routing = self.client.resolve_topic_if_missing(&self.topic).await?;
+        let order = self.inner.next_record_order.fetch_add(1, Ordering::Relaxed);
+        let routing = self.inner.resolve_topic_if_missing().await?;
         let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
 
         let (tx, rx) = oneshot::channel();
@@ -160,11 +167,11 @@ impl Producer {
             tx,
         };
 
-        let push_res = self.buffers.push(range_id, pending);
+        let push_res = self.inner.buffers.push(range_id, pending);
 
         match push_res {
             PushResult::Flush(records_to_flush) => {
-                let flush = self.flush_gate.clone().read_owned().await;
+                let flush = self.inner.flush_gate.clone().read_owned().await;
                 self.flush_in_background(records_to_flush, flush);
             }
             PushResult::SpawnLinger(linger, seq) => {
@@ -197,8 +204,8 @@ impl Producer {
 
     /// Flush the buffered records for a specific range if they exist.
     async fn flush_range(&self, range_id: RangeId, task_batch_seq: u64) {
-        let _flush = self.flush_gate.read().await;
-        if let Some(records_to_flush) = self.buffers.take(range_id, task_batch_seq) {
+        let _flush = self.inner.flush_gate.read().await;
+        if let Some(records_to_flush) = self.inner.buffers.take(range_id, task_batch_seq) {
             self.flush_records(records_to_flush).await;
         }
     }
@@ -206,8 +213,8 @@ impl Producer {
     pub async fn flush(&self) {
         let producer = self.clone();
         let handle = tokio::spawn(async move {
-            let _exclusive = producer.send_gate.write().await;
-            let _flush = producer.flush_gate.write().await;
+            let _exclusive = producer.inner.send_gate.write().await;
+            let _flush = producer.inner.flush_gate.write().await;
             producer.flush_buffers().await;
         });
         // ! If the caller's timeout/cancellation fires, Tokio drops the flush() future—which "drops" handle.
@@ -221,12 +228,12 @@ impl Producer {
     /// New sends fail with [`ClientError::ProducerClosed`]. Canceling this future keeps
     /// the producer closed, while the producer-owned drain continues in the background.
     pub async fn close(&self) {
-        self.should_reject.store(true, Ordering::Release);
+        self.inner.should_reject.store(true, Ordering::Release);
         self.flush().await;
     }
 
     async fn flush_buffers(&self) {
-        let batches = self.buffers.take_all();
+        let batches = self.inner.buffers.take_all();
         let futures = batches
             .into_iter()
             .map(|(_, records)| self.flush_records(records));
@@ -236,8 +243,8 @@ impl Producer {
     /// Serialize, compress, and publish a batch of records.
     async fn flush_records(&self, mut records_to_publish: Vec<PendingRecord>) {
         records_to_publish.sort_unstable_by_key(|record| record.order);
-        let deadline = Instant::now() + self.client.retry.deadline;
-        let mut backoff = self.client.retry.initial_backoff;
+        let deadline = Instant::now() + self.inner.client.retry.deadline;
+        let mut backoff = self.inner.client.retry.initial_backoff;
 
         loop {
             if records_to_publish.is_empty() {
@@ -252,7 +259,12 @@ impl Producer {
                 }
             };
 
-            let session = match self.session_manager.ensure(&self.client, &self.topic).await {
+            let session = match self
+                .inner
+                .session_manager
+                .ensure(&self.inner.client, &self.inner.topic)
+                .await
+            {
                 Ok(session) => session,
                 Err(error) => {
                     PendingRecord::complete_all(records_to_publish, Err(error));
@@ -260,7 +272,8 @@ impl Producer {
                 }
             };
 
-            self.session_manager
+            self.inner
+                .session_manager
                 .observe_topology(session, routing.active_range_ids());
 
             let mut next_retry_records = Vec::new();
@@ -279,7 +292,7 @@ impl Producer {
 
             let backoff_remaining = deadline.saturating_duration_since(Instant::now());
             tokio::time::sleep(backoff.min(backoff_remaining)).await;
-            backoff = (backoff * 2).min(self.client.retry.max_backoff);
+            backoff = (backoff * 2).min(self.inner.client.retry.max_backoff);
             records_to_publish = next_retry_records;
         }
     }
@@ -290,9 +303,7 @@ impl Producer {
             return Err(self.flush_timeout());
         }
 
-        match tokio::time::timeout(remaining, self.client.resolve_topic_if_missing(&self.topic))
-            .await
-        {
+        match tokio::time::timeout(remaining, self.inner.resolve_topic_if_missing()).await {
             Ok(result) => result,
             Err(_) => Err(self.flush_timeout()),
         }
@@ -325,11 +336,11 @@ impl Producer {
         records: Vec<PendingRecord>,
         deadline: Instant,
     ) -> Option<Vec<PendingRecord>> {
-        let sequence = self.session_manager.sequence_for(session, range_id);
+        let sequence = self.inner.session_manager.sequence_for(session, range_id);
         // Contiguous per-range sequences require serialization through durability.
         let mut sequence = sequence.lock().await;
 
-        let payload = match self.codec.encode_payload(&records) {
+        let payload = match self.inner.codec.encode_payload(&records) {
             Ok(payload) => payload,
             Err(error) => {
                 tracing::error!(?error, "failed to encode producer batch");
@@ -340,8 +351,8 @@ impl Producer {
         let digest = crc32fast::hash(&payload);
         let result = match tokio::time::timeout(
             deadline.saturating_duration_since(Instant::now()),
-            self.client.produce_to_range(
-                &self.topic,
+            self.inner.client.produce_to_range(
+                &self.inner.topic,
                 range_id,
                 &records[0].key,
                 payload,
@@ -362,14 +373,14 @@ impl Producer {
                 None
             }
             Err(ClientError::StaleRange) => {
-                self.client.cache.invalidate(&self.topic);
+                self.inner.client.cache.invalidate(&self.inner.topic);
                 Some(records)
             }
             Err(ClientError::ProduceRejected(
                 ProduceError::SessionNotInstalled | ProduceError::RequestInFlight,
             )) => Some(records),
             Err(ClientError::ProduceRejected(ProduceError::SessionExpired)) => {
-                self.session_manager.mark_expired(session).await;
+                self.inner.session_manager.mark_expired(session).await;
                 Some(records)
             }
             Err(error) => {
@@ -381,7 +392,7 @@ impl Producer {
 
     fn flush_timeout(&self) -> ClientError {
         ClientError::Timeout {
-            waited: self.client.retry.deadline,
+            waited: self.inner.client.retry.deadline,
             last_error: Some("producer flush deadline elapsed".to_string()),
         }
     }

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -100,7 +100,7 @@ pub struct Inner {
     codec: CompressionCodec,
     session_manager: ClientProducerSessionManager,
     send_gate: RwLock<()>,
-    flush_gate: RwLock<()>,
+    flush_gate: Arc<RwLock<()>>,
     should_reject: AtomicBool,
     next_record_order: AtomicU64,
 }
@@ -130,7 +130,7 @@ impl Producer {
             codec: config.codec,
             session_manager: ClientProducerSessionManager::new(producer_id),
             send_gate: RwLock::new(()),
-            flush_gate: RwLock::new(()),
+            flush_gate: Arc::new(RwLock::new(())),
             should_reject: AtomicBool::new(false),
             next_record_order: AtomicU64::new(0),
         })))
@@ -142,7 +142,7 @@ impl Producer {
     /// publication is shared work and may still complete; canceling only discards this
     /// caller's acknowledgement.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
-        let _active_send = self.send_gate.read().await;
+        let send_guard = self.send_gate.read().await;
         if self.should_reject.load(Ordering::Acquire) {
             return Err(ClientError::ProducerClosed);
         }
@@ -164,7 +164,8 @@ impl Producer {
 
         match push_res {
             PushResult::Flush(records_to_flush) => {
-                self.spawn_flush(records_to_flush);
+                let flush = self.flush_gate.clone().read_owned().await;
+                self.flush_in_background(records_to_flush, flush);
             }
             PushResult::SpawnLinger(linger, seq) => {
                 let producer = self.clone();
@@ -175,16 +176,21 @@ impl Producer {
             }
             PushResult::Buffered => {}
         }
+        drop(send_guard);
 
         rx.await.map_err(|_| ClientError::UnexpectedResponse)?
     }
 
     // ! Dedicated spawning is required because otherwise when the client cancels the operation,
     // ! It would accidantely cancel all other records in that shared batch.
-    fn spawn_flush(&self, records: Vec<PendingRecord>) {
+    fn flush_in_background(
+        &self,
+        records: Vec<PendingRecord>,
+        flush: tokio::sync::OwnedRwLockReadGuard<()>,
+    ) {
         let producer = self.clone();
         tokio::spawn(async move {
-            let _flush = producer.flush_gate.read().await;
+            let _flush = flush;
             producer.flush_records(records).await;
         });
     }

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -105,8 +105,263 @@ struct Inner {
 }
 
 impl Inner {
+    async fn read_send_gate(&self) -> tokio::sync::RwLockReadGuard<'_, ()> {
+        self.send_gate.read().await
+    }
+
+    async fn read_owned_flush_gate(&self) -> tokio::sync::OwnedRwLockReadGuard<()> {
+        self.flush_gate.clone().read_owned().await
+    }
+
+    fn should_reject(&self) -> bool {
+        self.should_reject.load(Ordering::Acquire)
+    }
+
+    fn next_record_order(&self) -> u64 {
+        self.next_record_order.fetch_add(1, Ordering::Relaxed)
+    }
+
     async fn resolve_topic_if_missing(&self) -> Result<Arc<TopicRouting>, ClientError> {
         self.client.resolve_topic_if_missing(&self.topic).await
+    }
+
+    fn push_record(&self, range_id: RangeId, pending: PendingRecord) -> PushResult {
+        self.buffers.push(range_id, pending)
+    }
+
+    async fn produce_to_range(
+        &self,
+        range_id: RangeId,
+        first_key: &[u8],
+        payload: Vec<u8>,
+        record_count: u32,
+        append_identity: Option<crate::data_plane::ProducerAppendIdentity>,
+    ) -> Result<EntryId, ClientError> {
+        self.client
+            .produce_to_range(
+                &self.topic,
+                range_id,
+                first_key,
+                payload,
+                record_count,
+                append_identity,
+            )
+            .await
+    }
+
+    fn invalidate_cache(&self) {
+        self.client.cache.invalidate(&self.topic);
+    }
+
+    fn retry_deadline(&self) -> std::time::Duration {
+        self.client.retry.deadline
+    }
+
+    fn initial_backoff(&self) -> std::time::Duration {
+        self.client.retry.initial_backoff
+    }
+
+    fn max_backoff(&self) -> std::time::Duration {
+        self.client.retry.max_backoff
+    }
+
+    fn flush_timeout(&self) -> ClientError {
+        ClientError::Timeout {
+            waited: self.client.retry.deadline,
+            last_error: Some("producer flush deadline elapsed".to_string()),
+        }
+    }
+
+    async fn resolve_routing_and_session(
+        &self,
+        deadline: Instant,
+    ) -> Result<(Arc<TopicRouting>, ClientProducerSession), ClientError> {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(self.flush_timeout());
+        }
+
+        let routing = match tokio::time::timeout(remaining, self.resolve_topic_if_missing()).await {
+            Ok(result) => result?,
+            Err(_) => return Err(self.flush_timeout()),
+        };
+
+        let session = self
+            .session_manager
+            .ensure(&self.client, &self.topic)
+            .await?;
+
+        self.session_manager
+            .observe_topology(session, routing.active_range_ids());
+
+        Ok((routing, session))
+    }
+
+    // ! Dedicated spawning is required because otherwise when the client cancels the operation,
+    // ! It would accidantely cancel all other records in that shared batch.
+    fn flush_in_background(
+        self: &Arc<Self>,
+        records: Vec<PendingRecord>,
+        flush: tokio::sync::OwnedRwLockReadGuard<()>,
+    ) {
+        let inner = self.clone();
+        tokio::spawn(async move {
+            let _flush = flush;
+            inner.flush_records(records).await;
+        });
+    }
+
+    /// Flush the buffered records for a specific range if they exist.
+    async fn flush_range(self: &Arc<Self>, range_id: RangeId, task_batch_seq: u64) {
+        let _flush = self.flush_gate.read().await;
+        if let Some(records_to_flush) = self.buffers.take(range_id, task_batch_seq) {
+            self.flush_records(records_to_flush).await;
+        }
+    }
+
+    async fn flush_buffers(self: &Arc<Self>) {
+        let batches = self.buffers.take_all();
+        let futures = batches
+            .into_iter()
+            .map(|(_, records)| self.flush_records(records));
+        futures::future::join_all(futures).await;
+    }
+
+    /// Serialize, compress, and publish a batch of records.
+    async fn flush_records(self: &Arc<Self>, mut records_to_publish: Vec<PendingRecord>) {
+        records_to_publish.sort_unstable_by_key(|record| record.order);
+        let deadline = Instant::now() + self.retry_deadline();
+        let mut backoff = self.initial_backoff();
+
+        loop {
+            if records_to_publish.is_empty() {
+                return;
+            }
+
+            let (routing, session) = match self.resolve_routing_and_session(deadline).await {
+                Ok(res) => res,
+                Err(error) => {
+                    PendingRecord::complete_all(records_to_publish, Err(error));
+                    return;
+                }
+            };
+
+            let mut next_retry_records = Vec::new();
+            for (range_id, records) in Self::group_by_range(records_to_publish, &routing) {
+                if let Some(records) = self
+                    .publish_range_attempt(session, range_id, records, deadline)
+                    .await
+                {
+                    next_retry_records.extend(records);
+                }
+            }
+
+            if next_retry_records.is_empty() {
+                return;
+            }
+
+            let backoff_remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(backoff.min(backoff_remaining)).await;
+            backoff = (backoff * 2).min(self.max_backoff());
+            records_to_publish = next_retry_records;
+        }
+    }
+
+    fn group_by_range(
+        records: Vec<PendingRecord>,
+        routing: &TopicRouting,
+    ) -> BTreeMap<RangeId, Vec<PendingRecord>> {
+        let mut grouped: BTreeMap<RangeId, Vec<PendingRecord>> = BTreeMap::new();
+        for pending in records {
+            match routing.range_id(&pending.key) {
+                Some(range_id) => grouped.entry(range_id).or_default().push(pending),
+                None => {
+                    let _ = pending.tx.send(Err(ClientError::UnexpectedResponse));
+                }
+            }
+        }
+        grouped
+    }
+
+    /// Own one range batch for one network attempt.
+    ///
+    /// Returns the records only when the caller must retry them. Every other
+    /// outcome completes their senders before returning `None`.
+    async fn publish_range_attempt(
+        &self,
+        session: ClientProducerSession,
+        range_id: RangeId,
+        records: Vec<PendingRecord>,
+        deadline: Instant,
+    ) -> Option<Vec<PendingRecord>> {
+        let sequence = self.session_manager.sequence_for(session, range_id);
+        // Contiguous per-range sequences require serialization through durability.
+        let mut sequence = sequence.lock().await;
+
+        let payload = match self.codec.encode_payload(&records) {
+            Ok(payload) => payload,
+            Err(error) => {
+                tracing::error!(?error, "failed to encode producer batch");
+                PendingRecord::complete_all(records, Err(ClientError::UnexpectedResponse));
+                return None;
+            }
+        };
+        let digest = crc32fast::hash(&payload);
+        let result = match tokio::time::timeout(
+            deadline.saturating_duration_since(Instant::now()),
+            self.produce_to_range(
+                range_id,
+                &records[0].key,
+                payload,
+                records.len() as u32,
+                Some(session.append_identity(*sequence, digest)),
+            ),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(self.flush_timeout()),
+        };
+
+        match result {
+            Ok(entry_id) => {
+                *sequence += 1;
+                PendingRecord::complete_all(records, Ok(entry_id));
+                None
+            }
+            Err(ClientError::StaleRange) => {
+                self.invalidate_cache();
+                Some(records)
+            }
+            Err(ClientError::ProduceRejected(
+                ProduceError::SessionNotInstalled | ProduceError::RequestInFlight,
+            )) => Some(records),
+            Err(ClientError::ProduceRejected(ProduceError::SessionExpired)) => {
+                self.session_manager.mark_expired(session).await;
+                Some(records)
+            }
+            Err(error) => {
+                PendingRecord::complete_all(records, Err(error));
+                None
+            }
+        }
+    }
+    async fn flush(self: &Arc<Self>) {
+        let inner = self.clone();
+        let handle = tokio::spawn(async move {
+            let _exclusive = inner.send_gate.write().await;
+            let _flush = inner.flush_gate.write().await;
+            inner.flush_buffers().await;
+        });
+        // ! If the caller's timeout/cancellation fires, Tokio drops the flush() future—which "drops" handle.
+        // ! Dropping handle simply detaches the task, which is different than handle.abort();
+        // ! So, cancellation loses only the caller's knowledge of when the drain finished.
+        let _ = handle.await;
+    }
+
+    async fn close(self: &Arc<Self>) {
+        self.should_reject.store(true, Ordering::Release);
+        self.flush().await;
     }
 }
 
@@ -149,12 +404,12 @@ impl Producer {
     /// publication is shared work and may still complete; canceling only discards this
     /// caller's acknowledgement.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
-        let send_guard = self.inner.send_gate.read().await;
-        if self.inner.should_reject.load(Ordering::Acquire) {
+        let send_guard = self.inner.read_send_gate().await;
+        if self.inner.should_reject() {
             return Err(ClientError::ProducerClosed);
         }
 
-        let order = self.inner.next_record_order.fetch_add(1, Ordering::Relaxed);
+        let order = self.inner.next_record_order();
         let routing = self.inner.resolve_topic_if_missing().await?;
         let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
 
@@ -167,18 +422,18 @@ impl Producer {
             tx,
         };
 
-        let push_res = self.inner.buffers.push(range_id, pending);
+        let push_res = self.inner.push_record(range_id, pending);
 
         match push_res {
             PushResult::Flush(records_to_flush) => {
-                let flush = self.inner.flush_gate.clone().read_owned().await;
-                self.flush_in_background(records_to_flush, flush);
+                let flush = self.inner.read_owned_flush_gate().await;
+                self.inner.flush_in_background(records_to_flush, flush);
             }
             PushResult::SpawnLinger(linger, seq) => {
-                let producer = self.clone();
+                let inner = self.inner.clone();
                 tokio::spawn(async move {
                     tokio::time::sleep(linger).await;
-                    producer.flush_range(range_id, seq).await;
+                    inner.flush_range(range_id, seq).await;
                 });
             }
             PushResult::Buffered => {}
@@ -188,39 +443,8 @@ impl Producer {
         rx.await.map_err(|_| ClientError::UnexpectedResponse)?
     }
 
-    // ! Dedicated spawning is required because otherwise when the client cancels the operation,
-    // ! It would accidantely cancel all other records in that shared batch.
-    fn flush_in_background(
-        &self,
-        records: Vec<PendingRecord>,
-        flush: tokio::sync::OwnedRwLockReadGuard<()>,
-    ) {
-        let producer = self.clone();
-        tokio::spawn(async move {
-            let _flush = flush;
-            producer.flush_records(records).await;
-        });
-    }
-
-    /// Flush the buffered records for a specific range if they exist.
-    async fn flush_range(&self, range_id: RangeId, task_batch_seq: u64) {
-        let _flush = self.inner.flush_gate.read().await;
-        if let Some(records_to_flush) = self.inner.buffers.take(range_id, task_batch_seq) {
-            self.flush_records(records_to_flush).await;
-        }
-    }
-
     pub async fn flush(&self) {
-        let producer = self.clone();
-        let handle = tokio::spawn(async move {
-            let _exclusive = producer.inner.send_gate.write().await;
-            let _flush = producer.inner.flush_gate.write().await;
-            producer.flush_buffers().await;
-        });
-        // ! If the caller's timeout/cancellation fires, Tokio drops the flush() future—which "drops" handle.
-        // ! Dropping handle simply detaches the task, which is different than handle.abort();
-        // ! So, cancellation loses only the caller's knowledge of when the drain finished.
-        let _ = handle.await;
+        self.inner.flush().await;
     }
 
     /// Close every clone and wait for accepted records to finish.
@@ -228,173 +452,7 @@ impl Producer {
     /// New sends fail with [`ClientError::ProducerClosed`]. Canceling this future keeps
     /// the producer closed, while the producer-owned drain continues in the background.
     pub async fn close(&self) {
-        self.inner.should_reject.store(true, Ordering::Release);
-        self.flush().await;
-    }
-
-    async fn flush_buffers(&self) {
-        let batches = self.inner.buffers.take_all();
-        let futures = batches
-            .into_iter()
-            .map(|(_, records)| self.flush_records(records));
-        futures::future::join_all(futures).await;
-    }
-
-    /// Serialize, compress, and publish a batch of records.
-    async fn flush_records(&self, mut records_to_publish: Vec<PendingRecord>) {
-        records_to_publish.sort_unstable_by_key(|record| record.order);
-        let deadline = Instant::now() + self.inner.client.retry.deadline;
-        let mut backoff = self.inner.client.retry.initial_backoff;
-
-        loop {
-            if records_to_publish.is_empty() {
-                return;
-            }
-
-            let routing = match self.resolve_routing(deadline).await {
-                Ok(routing) => routing,
-                Err(error) => {
-                    PendingRecord::complete_all(records_to_publish, Err(error));
-                    return;
-                }
-            };
-
-            let session = match self
-                .inner
-                .session_manager
-                .ensure(&self.inner.client, &self.inner.topic)
-                .await
-            {
-                Ok(session) => session,
-                Err(error) => {
-                    PendingRecord::complete_all(records_to_publish, Err(error));
-                    return;
-                }
-            };
-
-            self.inner
-                .session_manager
-                .observe_topology(session, routing.active_range_ids());
-
-            let mut next_retry_records = Vec::new();
-            for (range_id, records) in Self::group_by_range(records_to_publish, &routing) {
-                if let Some(records) = self
-                    .publish_range_attempt(session, range_id, records, deadline)
-                    .await
-                {
-                    next_retry_records.extend(records);
-                }
-            }
-
-            if next_retry_records.is_empty() {
-                return;
-            }
-
-            let backoff_remaining = deadline.saturating_duration_since(Instant::now());
-            tokio::time::sleep(backoff.min(backoff_remaining)).await;
-            backoff = (backoff * 2).min(self.inner.client.retry.max_backoff);
-            records_to_publish = next_retry_records;
-        }
-    }
-
-    async fn resolve_routing(&self, deadline: Instant) -> Result<Arc<TopicRouting>, ClientError> {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            return Err(self.flush_timeout());
-        }
-
-        match tokio::time::timeout(remaining, self.inner.resolve_topic_if_missing()).await {
-            Ok(result) => result,
-            Err(_) => Err(self.flush_timeout()),
-        }
-    }
-
-    fn group_by_range(
-        records: Vec<PendingRecord>,
-        routing: &TopicRouting,
-    ) -> BTreeMap<RangeId, Vec<PendingRecord>> {
-        let mut grouped: BTreeMap<RangeId, Vec<PendingRecord>> = BTreeMap::new();
-        for pending in records {
-            match routing.range_id(&pending.key) {
-                Some(range_id) => grouped.entry(range_id).or_default().push(pending),
-                None => {
-                    let _ = pending.tx.send(Err(ClientError::UnexpectedResponse));
-                }
-            }
-        }
-        grouped
-    }
-
-    /// Own one range batch for one network attempt.
-    ///
-    /// Returns the records only when the caller must retry them. Every other
-    /// outcome completes their senders before returning `None`.
-    async fn publish_range_attempt(
-        &self,
-        session: ClientProducerSession,
-        range_id: RangeId,
-        records: Vec<PendingRecord>,
-        deadline: Instant,
-    ) -> Option<Vec<PendingRecord>> {
-        let sequence = self.inner.session_manager.sequence_for(session, range_id);
-        // Contiguous per-range sequences require serialization through durability.
-        let mut sequence = sequence.lock().await;
-
-        let payload = match self.inner.codec.encode_payload(&records) {
-            Ok(payload) => payload,
-            Err(error) => {
-                tracing::error!(?error, "failed to encode producer batch");
-                PendingRecord::complete_all(records, Err(ClientError::UnexpectedResponse));
-                return None;
-            }
-        };
-        let digest = crc32fast::hash(&payload);
-        let result = match tokio::time::timeout(
-            deadline.saturating_duration_since(Instant::now()),
-            self.inner.client.produce_to_range(
-                &self.inner.topic,
-                range_id,
-                &records[0].key,
-                payload,
-                records.len() as u32,
-                Some(session.append_identity(*sequence, digest)),
-            ),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(self.flush_timeout()),
-        };
-
-        match result {
-            Ok(entry_id) => {
-                *sequence += 1;
-                PendingRecord::complete_all(records, Ok(entry_id));
-                None
-            }
-            Err(ClientError::StaleRange) => {
-                self.inner.client.cache.invalidate(&self.inner.topic);
-                Some(records)
-            }
-            Err(ClientError::ProduceRejected(
-                ProduceError::SessionNotInstalled | ProduceError::RequestInFlight,
-            )) => Some(records),
-            Err(ClientError::ProduceRejected(ProduceError::SessionExpired)) => {
-                self.inner.session_manager.mark_expired(session).await;
-                Some(records)
-            }
-            Err(error) => {
-                PendingRecord::complete_all(records, Err(error));
-                None
-            }
-        }
-    }
-
-    fn flush_timeout(&self) -> ClientError {
-        ClientError::Timeout {
-            waited: self.inner.client.retry.deadline,
-            last_error: Some("producer flush deadline elapsed".to_string()),
-        }
+        self.inner.close().await;
     }
 }
 

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -105,50 +105,6 @@ struct Inner {
 }
 
 impl Inner {
-    async fn read_send_gate(&self) -> tokio::sync::RwLockReadGuard<'_, ()> {
-        self.send_gate.read().await
-    }
-
-    async fn read_owned_flush_gate(&self) -> tokio::sync::OwnedRwLockReadGuard<()> {
-        self.flush_gate.clone().read_owned().await
-    }
-
-    fn should_reject(&self) -> bool {
-        self.should_reject.load(Ordering::Acquire)
-    }
-
-    fn next_record_order(&self) -> u64 {
-        self.next_record_order.fetch_add(1, Ordering::Relaxed)
-    }
-
-    async fn resolve_topic_if_missing(&self) -> Result<Arc<TopicRouting>, ClientError> {
-        self.client.resolve_topic_if_missing(&self.topic).await
-    }
-
-    fn push_record(&self, range_id: RangeId, pending: PendingRecord) -> PushResult {
-        self.buffers.push(range_id, pending)
-    }
-
-    async fn produce_to_range(
-        &self,
-        range_id: RangeId,
-        first_key: &[u8],
-        payload: Vec<u8>,
-        record_count: u32,
-        append_identity: Option<crate::data_plane::ProducerAppendIdentity>,
-    ) -> Result<EntryId, ClientError> {
-        self.client
-            .produce_to_range(
-                &self.topic,
-                range_id,
-                first_key,
-                payload,
-                record_count,
-                append_identity,
-            )
-            .await
-    }
-
     fn invalidate_cache(&self) {
         self.client.cache.invalidate(&self.topic);
     }
@@ -181,7 +137,12 @@ impl Inner {
             return Err(self.flush_timeout());
         }
 
-        let routing = match tokio::time::timeout(remaining, self.resolve_topic_if_missing()).await {
+        let routing = match tokio::time::timeout(
+            remaining,
+            self.client.resolve_topic_if_missing(&self.topic),
+        )
+        .await
+        {
             Ok(result) => result?,
             Err(_) => return Err(self.flush_timeout()),
         };
@@ -309,7 +270,8 @@ impl Inner {
         let digest = crc32fast::hash(&payload);
         let result = match tokio::time::timeout(
             deadline.saturating_duration_since(Instant::now()),
-            self.produce_to_range(
+            self.client.produce_to_range(
+                &self.topic,
                 range_id,
                 &records[0].key,
                 payload,
@@ -353,15 +315,52 @@ impl Inner {
             let _flush = inner.flush_gate.write().await;
             inner.flush_buffers().await;
         });
-        // ! If the caller's timeout/cancellation fires, Tokio drops the flush() future—which "drops" handle.
-        // ! Dropping handle simply detaches the task, which is different than handle.abort();
-        // ! So, cancellation loses only the caller's knowledge of when the drain finished.
         let _ = handle.await;
     }
 
     async fn close(self: &Arc<Self>) {
         self.should_reject.store(true, Ordering::Release);
         self.flush().await;
+    }
+
+    async fn send(self: &Arc<Self>, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
+        let send_guard = self.send_gate.read().await;
+        if self.should_reject.load(Ordering::Acquire) {
+            return Err(ClientError::ProducerClosed);
+        }
+
+        let order = self.next_record_order.fetch_add(1, Ordering::Relaxed);
+        let routing = self.client.resolve_topic_if_missing(&self.topic).await?;
+        let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
+
+        let (tx, rx) = oneshot::channel();
+
+        let pending = PendingRecord {
+            order,
+            key: key.to_vec(),
+            value,
+            tx,
+        };
+
+        let push_res = self.buffers.push(range_id, pending);
+
+        match push_res {
+            PushResult::Flush(records_to_flush) => {
+                let flush = self.flush_gate.clone().read_owned().await;
+                self.flush_in_background(records_to_flush, flush);
+            }
+            PushResult::SpawnLinger(linger, seq) => {
+                let inner = self.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(linger).await;
+                    inner.flush_range(range_id, seq).await;
+                });
+            }
+            PushResult::Buffered => {}
+        }
+        drop(send_guard);
+
+        rx.await.map_err(|_| ClientError::UnexpectedResponse)?
     }
 }
 
@@ -404,43 +403,7 @@ impl Producer {
     /// publication is shared work and may still complete; canceling only discards this
     /// caller's acknowledgement.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
-        let send_guard = self.inner.read_send_gate().await;
-        if self.inner.should_reject() {
-            return Err(ClientError::ProducerClosed);
-        }
-
-        let order = self.inner.next_record_order();
-        let routing = self.inner.resolve_topic_if_missing().await?;
-        let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
-
-        let (tx, rx) = oneshot::channel();
-
-        let pending = PendingRecord {
-            order,
-            key: key.to_vec(),
-            value,
-            tx,
-        };
-
-        let push_res = self.inner.push_record(range_id, pending);
-
-        match push_res {
-            PushResult::Flush(records_to_flush) => {
-                let flush = self.inner.read_owned_flush_gate().await;
-                self.inner.flush_in_background(records_to_flush, flush);
-            }
-            PushResult::SpawnLinger(linger, seq) => {
-                let inner = self.inner.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(linger).await;
-                    inner.flush_range(range_id, seq).await;
-                });
-            }
-            PushResult::Buffered => {}
-        }
-        drop(send_guard);
-
-        rx.await.map_err(|_| ClientError::UnexpectedResponse)?
+        self.inner.send(key, value).await
     }
 
     pub async fn flush(&self) {

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -21,6 +21,32 @@ use uuid::Uuid;
 
 /// A thread-safe, internally synchronized producer for a single topic.
 /// Cheap to clone and share across tasks.
+///
+/// Every clone refers to the same buffers and shutdown state. Closing any clone
+/// closes the producer for all clones.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use east_guard::client::{Client, Producer, ProducerConfig};
+/// use std::{net::SocketAddr, sync::Arc};
+///
+/// let seed: SocketAddr = "127.0.0.1:9091".parse()?;
+/// let client = Arc::new(Client::connect([seed])?);
+/// let producer = Producer::new(client, "orders".to_string(), ProducerConfig::default())?;
+///
+/// let sender = producer.clone();
+/// let sent = tokio::spawn(async move {
+///     sender.send(b"customer-42", b"created".to_vec()).await
+/// });
+/// let committed_entry = sent.await??;
+///
+/// producer.close().await;
+/// # let _ = committed_entry;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct Producer(Arc<Inner>);
 impl_new_struct_wrapper!(Producer, Arc<Inner>);
@@ -171,14 +197,23 @@ impl Producer {
         }
     }
 
-    /// Wait for active sends, then flush records left buffered by canceled send futures.
     pub async fn flush(&self) {
-        let _exclusive = self.send_gate.write().await;
-        let _flush = self.flush_gate.write().await;
-        self.flush_buffers().await;
+        let producer = self.clone();
+        let handle = tokio::spawn(async move {
+            let _exclusive = producer.send_gate.write().await;
+            let _flush = producer.flush_gate.write().await;
+            producer.flush_buffers().await;
+        });
+        // ! If the caller's timeout/cancellation fires, Tokio drops the flush() future—which "drops" handle.
+        // ! Dropping handle simply detaches the task, which is different than handle.abort();
+        // ! So, cancellation loses only the caller's knowledge of when the drain finished.
+        let _ = handle.await;
     }
 
-    /// This serves as the public SDK entry point for external applications to gracefully shut down a producer
+    /// Close every clone and wait for accepted records to finish.
+    ///
+    /// New sends fail with [`ClientError::ProducerClosed`]. Canceling this future keeps
+    /// the producer closed, while the producer-owned drain continues in the background.
     pub async fn close(&self) {
         self.should_reject.store(true, Ordering::Release);
         self.flush().await;

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -11,11 +11,11 @@ use crate::impl_new_struct_wrapper;
 use buffers::{PendingRecord, ProducerBuffers, PushResult};
 pub use config::{BufferConfig, ProducerConfig};
 use session::{ClientProducerSession, ClientProducerSessionManager};
-
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::sync::Arc;
-use tokio::sync::oneshot;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tokio::sync::{RwLock, oneshot};
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -23,16 +23,60 @@ use uuid::Uuid;
 /// Cheap to clone and share across tasks.
 #[derive(Clone)]
 pub struct Producer(Arc<Inner>);
-
 impl_new_struct_wrapper!(Producer, Arc<Inner>);
 
+/// # Synchronization & Deadlock Prevention Model
+///
+/// The producer relies on two distinct `RwLock` gates to coordinate async application
+/// callers, background linger tasks, and explicit `flush()` / `close()` barriers:
+///
+/// 1. **[`send_gate`] (Application Invocation Barrier)**:
+///    - Every [`send()`] call holds [`send_gate`].read() across its entire execution
+///      (routing, pushing to buffer, and awaiting `oneshot` completion).
+///    - [`flush()`] and [`close()`] acquire [`send_gate`].write() to wait for all pre-existing
+///      `send()` callers to finish before returning.
+///
+/// 2. **[`flush_gate`] (Batch Ownership & Network Publication Barrier)**:
+///    - Any task publishing a batch over the network (immediate push or background linger task)
+///      holds [`flush_gate`].read() during payload encoding and broker RPCs.
+///    - [`flush()`] and [`close()`] acquire `flush_gate.write() after draining buffers to guarantee
+///      [`flush()`] does not return while a background linger task is still in-flight.
+///
+/// ### Why [`send_gate`]
+/// Imagine if [`flush()`] simply drained ProducerBuffers without a send gate:
+///
+/// ```text
+///     Task A (send caller)                      Task B (flush caller)
+///  --------------------                      ---------------------
+///  1. Calls producer.send(k, v)
+///  2. Awaits resolve_topic...
+///     (Record is NOT in buffer yet!)
+///                                            3. Calls producer.flush()
+///                                            4. Drains ProducerBuffers (finds 0 records)
+///                                            5. flush() RETURNS OK!
+///  6. Pushes record into buffer!
+/// ```
+///
+/// The **Bug**: Task B’s flush().await returned, assuring the application that all previously initiated records were flushed—when in reality, Task A’s record was still
+/// sitting in memory un-flushed.
+/// [`send_gate`]'s read guard allow concurrent send execution while by the time flush is really made it forces write lock acqusition for serialization.
+///
+///
+/// [`send_gate`]: Inner::send_gate
+/// [`flush_gate`]: Inner::flush_gate
+/// [`send()`]: Producer::send
+/// [`flush()`]: Producer::flush
+/// [`close()`]: Producer::close
 pub struct Inner {
     client: Arc<Client>,
     topic: String,
     buffers: ProducerBuffers,
     codec: CompressionCodec,
     session_manager: ClientProducerSessionManager,
-    next_record_order: std::sync::atomic::AtomicU64,
+    send_gate: RwLock<()>,
+    flush_gate: RwLock<()>,
+    should_reject: AtomicBool,
+    next_record_order: AtomicU64,
 }
 
 impl Producer {
@@ -59,19 +103,22 @@ impl Producer {
             buffers: ProducerBuffers::new(config.buffer.clone()),
             codec: config.codec,
             session_manager: ClientProducerSessionManager::new(producer_id),
-            next_record_order: std::sync::atomic::AtomicU64::new(0),
+            send_gate: RwLock::new(()),
+            flush_gate: RwLock::new(()),
+            should_reject: AtomicBool::new(false),
+            next_record_order: AtomicU64::new(0),
         })))
     }
 
     /// Produce a single record. Returns the committed entry ID once the batch flushes.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
-        let order = self
-            .next_record_order
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let topic = &self.topic;
-        let client = &self.client;
+        let _active_send = self.send_gate.read().await;
+        if self.should_reject.load(Ordering::Acquire) {
+            return Err(ClientError::ProducerClosed);
+        }
 
-        let routing = client.resolve_topic_if_missing(topic).await?;
+        let order = self.next_record_order.fetch_add(1, Ordering::Relaxed);
+        let routing = self.client.resolve_topic_if_missing(&self.topic).await?;
         let range_id = routing.range_id(key).ok_or(ClientError::TopicNotFound)?;
 
         let (tx, rx) = oneshot::channel();
@@ -87,6 +134,7 @@ impl Producer {
 
         match push_res {
             PushResult::Flush(records_to_flush) => {
+                let _flush = self.flush_gate.read().await;
                 self.flush_records(records_to_flush).await;
             }
             PushResult::SpawnLinger(linger, seq) => {
@@ -104,17 +152,27 @@ impl Producer {
 
     /// Flush the buffered records for a specific range if they exist.
     async fn flush_range(&self, range_id: RangeId, task_batch_seq: u64) {
+        let _flush = self.flush_gate.read().await;
         if let Some(records_to_flush) = self.buffers.take(range_id, task_batch_seq) {
             self.flush_records(records_to_flush).await;
         }
     }
 
-    /// Flush all currently buffered records across all partitions and wait for their completion.
+    /// Wait for active sends, then flush records left buffered by canceled send futures.
     pub async fn flush(&self) {
+        let _exclusive = self.send_gate.write().await;
+        let _flush = self.flush_gate.write().await;
+        self.flush_buffers().await;
+    }
+
+    /// This serves as the public SDK entry point for external applications to gracefully shut down a producer
+    pub async fn close(&self) {
+        self.should_reject.store(true, Ordering::Release);
+        self.flush().await;
+    }
+
+    async fn flush_buffers(&self) {
         let batches = self.buffers.take_all();
-        if batches.is_empty() {
-            return;
-        }
         let futures = batches
             .into_iter()
             .map(|(_, records)| self.flush_records(records));
@@ -272,5 +330,28 @@ impl Producer {
             waited: self.client.retry.deadline,
             last_error: Some("producer flush deadline elapsed".to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    fn producer() -> Producer {
+        let seed = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9));
+        let client = Arc::new(Client::connect(vec![seed]).unwrap());
+        Producer::new(client, "topic".to_string(), ProducerConfig::default()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn close_empty_producer_rejects_future_sends() {
+        let producer = producer();
+
+        producer.close().await;
+        assert!(matches!(
+            producer.send(b"key", b"value".to_vec()).await,
+            Err(ClientError::ProducerClosed)
+        ));
     }
 }

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -99,7 +99,7 @@ struct Inner {
     codec: CompressionCodec,
     session_manager: ClientProducerSessionManager,
     send_gate: RwLock<()>,
-    flush_gate: Arc<RwLock<()>>,
+    flush_gate: RwLock<()>,
     should_reject: AtomicBool,
     next_record_order: AtomicU64,
 }
@@ -155,24 +155,28 @@ impl Inner {
 
     // ! Dedicated spawning is required because otherwise when the client cancels the operation,
     // ! It would accidantely cancel all other records in that shared batch.
-    fn flush_in_background(
-        self: &Arc<Self>,
-        records: Vec<PendingRecord>,
-        flush: tokio::sync::OwnedRwLockReadGuard<()>,
-    ) {
+    fn flush_in_background(self: &Arc<Self>, records: Vec<PendingRecord>) {
         let inner = self.clone();
         tokio::spawn(async move {
-            let _flush = flush;
+            let _flush = inner.flush_gate.read().await;
             inner.flush_records(records).await;
         });
     }
-
-    /// Flush the buffered records for a specific range if they exist.
-    async fn flush_range(self: &Arc<Self>, range_id: RangeId, task_batch_seq: u64) {
-        let _flush = self.flush_gate.read().await;
-        if let Some(records_to_flush) = self.buffers.take(range_id, task_batch_seq) {
-            self.flush_records(records_to_flush).await;
-        }
+    fn flush_range_in_background(
+        self: &Arc<Self>,
+        range_id: RangeId,
+        linger: std::time::Duration,
+        seq: u64,
+    ) {
+        let inner = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(linger).await;
+            // Flush the buffered records for a specific range if they exist.
+            let _flush = inner.flush_gate.read().await;
+            if let Some(records_to_flush) = inner.buffers.take(range_id, seq) {
+                inner.flush_records(records_to_flush).await;
+            }
+        });
     }
 
     async fn flush_buffers(self: &Arc<Self>) {
@@ -335,15 +339,10 @@ impl Inner {
 
         match self.buffers.push(range_id, pending) {
             PushResult::Flush(records_to_flush) => {
-                let flush = self.flush_gate.clone().read_owned().await;
-                self.flush_in_background(records_to_flush, flush);
+                self.flush_in_background(records_to_flush);
             }
             PushResult::SpawnLinger(linger, seq) => {
-                let inner = self.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(linger).await;
-                    inner.flush_range(range_id, seq).await;
-                });
+                self.flush_range_in_background(range_id, linger, seq);
             }
             PushResult::Buffered => {}
         }
@@ -379,7 +378,7 @@ impl Producer {
                 codec: config.codec,
                 session_manager: ClientProducerSessionManager::new(producer_id),
                 send_gate: RwLock::new(()),
-                flush_gate: Arc::new(RwLock::new(())),
+                flush_gate: RwLock::new(()),
                 should_reject: AtomicBool::new(false),
                 next_record_order: AtomicU64::new(0),
             }),

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -36,27 +36,31 @@ pub struct Inner {
 }
 
 impl Producer {
-    /// Create a new producer for the specified topic.
-    pub fn new(client: Arc<Client>, topic: String, config: ProducerConfig) -> Self {
-        // Generate a globally unique UUID for the producer session ID (idempotency seam)
-        let producer_id = Uuid::new_v4();
-
-        Self::new_with_producer_id(client, topic, config, producer_id)
-    }
-    pub fn new_with_producer_id(
+    /// Create a producer, returning a structured error for invalid configuration.
+    pub fn new(
         client: Arc<Client>,
         topic: String,
         config: ProducerConfig,
-        producer_id: Uuid,
-    ) -> Self {
-        Self(Arc::new(Inner {
+    ) -> Result<Self, ClientError> {
+        // Generate a globally unique UUID for the producer session ID (idempotency seam)
+        let producer_id = Uuid::new_v4();
+
+        if topic.is_empty() {
+            return Err(ClientError::invalid_configuration(
+                "producer.topic",
+                "must not be empty",
+            ));
+        }
+        config.validate()?;
+
+        Ok(Self(Arc::new(Inner {
             client,
             topic,
             buffers: ProducerBuffers::new(config.buffer.clone()),
             codec: config.codec,
             session_manager: ClientProducerSessionManager::new(producer_id),
             next_record_order: std::sync::atomic::AtomicU64::new(0),
-        }))
+        })))
     }
 
     /// Produce a single record. Returns the committed entry ID once the batch flushes.

--- a/src/client/producer/mod.rs
+++ b/src/client/producer/mod.rs
@@ -111,6 +111,10 @@ impl Producer {
     }
 
     /// Produce a single record. Returns the committed entry ID once the batch flushes.
+    ///
+    /// Canceling before the record enters a batch prevents publication. Once buffered,
+    /// publication is shared work and may still complete; canceling only discards this
+    /// caller's acknowledgement.
     pub async fn send(&self, key: &[u8], value: Vec<u8>) -> Result<EntryId, ClientError> {
         let _active_send = self.send_gate.read().await;
         if self.should_reject.load(Ordering::Acquire) {
@@ -134,8 +138,7 @@ impl Producer {
 
         match push_res {
             PushResult::Flush(records_to_flush) => {
-                let _flush = self.flush_gate.read().await;
-                self.flush_records(records_to_flush).await;
+                self.spawn_flush(records_to_flush);
             }
             PushResult::SpawnLinger(linger, seq) => {
                 let producer = self.clone();
@@ -148,6 +151,16 @@ impl Producer {
         }
 
         rx.await.map_err(|_| ClientError::UnexpectedResponse)?
+    }
+
+    // ! Dedicated spawning is required because otherwise when the client cancels the operation,
+    // ! It would accidantely cancel all other records in that shared batch.
+    fn spawn_flush(&self, records: Vec<PendingRecord>) {
+        let producer = self.clone();
+        tokio::spawn(async move {
+            let _flush = producer.flush_gate.read().await;
+            producer.flush_records(records).await;
+        });
     }
 
     /// Flush the buffered records for a specific range if they exist.

--- a/src/client/redirect.rs
+++ b/src/client/redirect.rs
@@ -42,6 +42,30 @@ impl Default for RetryPolicy {
     }
 }
 
+impl RetryPolicy {
+    pub(crate) fn validate(&self) -> Result<(), ClientError> {
+        if self.deadline.is_zero() {
+            return Err(ClientError::invalid_configuration(
+                "retry.deadline",
+                "must be non-zero",
+            ));
+        }
+        if self.initial_backoff.is_zero() {
+            return Err(ClientError::invalid_configuration(
+                "retry.initial_backoff",
+                "must be non-zero",
+            ));
+        }
+        if self.max_backoff < self.initial_backoff {
+            return Err(ClientError::invalid_configuration(
+                "retry.max_backoff",
+                "must be greater than or equal to retry.initial_backoff",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// The response that served the call. `redirected` ⇒ the starting target was wrong
 /// (a follow/re-resolve happened), so the caller can refresh its cache.
 #[derive(Debug)]
@@ -199,5 +223,21 @@ mod tests {
             classify(&ClientResponse::Ok(ClientSuccess::Produced(7.into()))),
             "done"
         );
+    }
+
+    #[test]
+    fn retry_policy_rejects_zero_deadline_and_inverted_backoff() {
+        let zero_deadline = RetryPolicy {
+            deadline: Duration::ZERO,
+            ..RetryPolicy::default()
+        };
+        assert!(zero_deadline.validate().is_err());
+
+        let inverted = RetryPolicy {
+            initial_backoff: Duration::from_secs(2),
+            max_backoff: Duration::from_secs(1),
+            ..RetryPolicy::default()
+        };
+        assert!(inverted.validate().is_err());
     }
 }

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -488,7 +488,8 @@ fn producer_compression_lz4_end_to_end() -> turmoil::Result {
                 },
                 codec: CompressionCodec::Lz4,
             },
-        );
+        )
+        .unwrap();
 
         // Send 2 records concurrently so they get batched and compressed
         let (res1, res2) = tokio::join!(
@@ -584,7 +585,8 @@ fn producer_compression_zstd_end_to_end() -> turmoil::Result {
                 },
                 codec: CompressionCodec::Zstd,
             },
-        );
+        )
+        .unwrap();
 
         // Send 2 records concurrently so they get batched and compressed
         let (res1, res2) = tokio::join!(
@@ -667,18 +669,21 @@ fn producer_concurrency_stress() -> turmoil::Result {
         // Warm the cache
         client.resolve_topic("prod-stress").await.expect("resolve");
 
-        let producer = Arc::new(Producer::new(
-            client.clone(),
-            "prod-stress".to_string(),
-            ProducerConfig {
-                buffer: BufferConfig {
-                    linger: Duration::from_millis(30),
-                    max_batch_bytes: 1024 * 1024,
-                    max_batch_records: 100,
+        let producer = Arc::new(
+            Producer::new(
+                client.clone(),
+                "prod-stress".to_string(),
+                ProducerConfig {
+                    buffer: BufferConfig {
+                        linger: Duration::from_millis(30),
+                        max_batch_bytes: 1024 * 1024,
+                        max_batch_records: 100,
+                    },
+                    codec: CompressionCodec::None,
                 },
-                codec: CompressionCodec::None,
-            },
-        ));
+            )
+            .unwrap(),
+        );
 
         const TASKS: usize = 50;
         const RECORDS_PER_TASK: usize = 10;
@@ -778,7 +783,8 @@ fn producer_overlapping_linger_scenario() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         // 1) Send Record 1 -> spawns Linger 1 (100ms)
         let f1 = producer.send(b"key-1", b"val-1".to_vec());
@@ -880,7 +886,8 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         for i in 0..5 {
             let key = format!("key-{}", i);
@@ -988,7 +995,8 @@ fn producer_resumes_cleanly_after_session_lease_expiration() -> turmoil::Result 
             client.clone(),
             "session-expire-test".into(),
             ProducerConfig::default(),
-        );
+        )
+        .unwrap();
 
         // 1. Send initial record
         let entry1 = producer
@@ -1058,7 +1066,8 @@ fn consumer_latest_starts_at_end_of_active_segment() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         // Produce 5 records into the active segment (no roll)
         for i in 0..5 {
@@ -1147,7 +1156,8 @@ fn consumer_key_filtering_multi_range() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         for i in 0..3 {
             producer
@@ -1250,7 +1260,8 @@ fn consumer_range_split_consume() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         // 1. Produce 3 records to parent range, waiting for segment rolls in between
         for i in 0..3 {
@@ -1362,7 +1373,8 @@ fn consumer_retention_recovery() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         // 1. Produce record 1 (goes to segment 0, entry 0)
         producer
@@ -1451,7 +1463,8 @@ fn consumer_prefetch_sealed_segments() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         // Produce 3 records across 3 different segments by rolling them
         producer
@@ -1540,7 +1553,8 @@ fn consumer_pause_seek_resume_live_range() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         let (rec0, rec1, rec2) = tokio::join!(
             producer.send(b"k", b"rec-0".to_vec()),
@@ -1633,7 +1647,8 @@ fn consumer_seek_resume_after_sealed_segment_reassignment() -> turmoil::Result {
                 },
                 codec: CompressionCodec::None,
             },
-        );
+        )
+        .unwrap();
 
         let record = |idx: usize| {
             let mut value = format!("sealed-rec-{idx}").into_bytes();
@@ -1763,7 +1778,8 @@ fn consumer_linger_batching_end_to_end() -> turmoil::Result {
                 },
                 codec: CompressionCodec::Lz4,
             },
-        );
+        )
+        .unwrap();
 
         // Send 3 records concurrently so they get batched together as Entry 0
         let (res1, res2, res3) = tokio::join!(
@@ -1981,18 +1997,21 @@ fn producer_split_fence_retry() -> turmoil::Result {
             .expect("resolve topic initial");
         assert_eq!(detail_initial.ranges.len(), 1, "Must start with 1 range");
 
-        let producer = Arc::new(Producer::new(
-            client1.clone(),
-            topic.to_string(),
-            ProducerConfig {
-                buffer: BufferConfig {
-                    linger: Duration::from_secs(60),
-                    max_batch_bytes: 1024 * 1024,
-                    max_batch_records: 1000,
+        let producer = Arc::new(
+            Producer::new(
+                client1.clone(),
+                topic.to_string(),
+                ProducerConfig {
+                    buffer: BufferConfig {
+                        linger: Duration::from_secs(60),
+                        max_batch_bytes: 1024 * 1024,
+                        max_batch_records: 1000,
+                    },
+                    codec: CompressionCodec::None,
                 },
-                codec: CompressionCodec::None,
-            },
-        ));
+            )
+            .unwrap(),
+        );
 
         // Both keys enter the parent batch before the range splits.
         let left = {

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -913,6 +913,62 @@ fn producer_shared_batch_cancellation_does_not_abort_surviving_senders() -> turm
     sim.run()
 }
 
+#[test]
+#[serial_test::serial]
+fn producer_close_drains_buffered_sends_and_fences_clones() -> turmoil::Result {
+    let mut sim = build_sim(60);
+    host_cluster(&mut sim, &NODES, sim_cluster);
+
+    sim.client("test-client", async {
+        let client = Arc::new(Client::connect(client_seeds()).expect("client connects"));
+        client
+            .create_topic("producer-close", policy())
+            .await
+            .expect("create topic");
+        client
+            .resolve_topic("producer-close")
+            .await
+            .expect("warm routing");
+
+        let producer = Producer::new(
+            client,
+            "producer-close".to_string(),
+            ProducerConfig {
+                buffer: BufferConfig {
+                    linger: Duration::from_secs(30),
+                    max_batch_bytes: 1024 * 1024,
+                    max_batch_records: 1000,
+                },
+                codec: CompressionCodec::None,
+            },
+        )
+        .unwrap();
+
+        let sending = {
+            let producer = producer.clone();
+            tokio::spawn(async move { producer.send(b"key", b"value".to_vec()).await })
+        };
+        tokio::task::yield_now().await;
+
+        tokio::time::timeout(Duration::from_secs(5), producer.close())
+            .await
+            .expect("close drains without waiting for linger");
+        sending
+            .await
+            .expect("sender task")
+            .expect("buffered send is acknowledged");
+
+        assert!(matches!(
+            producer.send(b"later", b"rejected".to_vec()).await,
+            Err(ClientError::ProducerClosed)
+        ));
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
 /// E2E Consumer Test 1: Basic Consume.
 /// Produce 5 records, consume them with StartPolicy::Earliest and KeyInterest::AllKeys,
 /// and assert exact ordered delivery.
@@ -1042,6 +1098,22 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
             .close()
             .await
             .expect("close latest consumer");
+        assert!(
+            consumer
+                .next_record()
+                .await
+                .expect("closed consumer")
+                .is_none(),
+            "close terminates the earliest consumer stream"
+        );
+        assert!(
+            consumer_latest
+                .next_record()
+                .await
+                .expect("closed latest consumer")
+                .is_none(),
+            "close terminates the latest consumer stream"
+        );
 
         Ok(())
     });

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -967,6 +967,12 @@ fn consumer_basic_consume_earliest() -> turmoil::Result {
             "Latest consumer should not receive historical records"
         );
 
+        consumer.close().await.expect("close earliest consumer");
+        consumer_latest
+            .close()
+            .await
+            .expect("close latest consumer");
+
         Ok(())
     });
 

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -837,8 +837,48 @@ fn producer_overlapping_linger_scenario() -> turmoil::Result {
             .expect("Record 4");
         assert_ne!(id3, id4);
 
-        // Cancel the send that triggers a full batch. The batch is shared work:
-        // canceling this caller must not cancel the other record in the batch.
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Exercises batch cancellation semantics:
+/// Canceling the threshold `send()` caller after the batch is buffered must not abort
+/// surviving senders sharing the batch.
+#[test]
+#[serial_test::serial]
+fn producer_shared_batch_cancellation_does_not_abort_surviving_senders() -> turmoil::Result {
+    let mut sim = build_sim(91);
+    host_cluster(&mut sim, &NODES, sim_cluster);
+
+    sim.client("test-client", async {
+        let client = Arc::new(Client::connect(client_seeds()).expect("client connects"));
+        client
+            .create_topic("batch-cancel", policy())
+            .await
+            .expect("create topic");
+
+        client
+            .resolve_topic("batch-cancel")
+            .await
+            .expect("resolve");
+
+        let producer = Producer::new(
+            client.clone(),
+            "batch-cancel".to_string(),
+            ProducerConfig {
+                buffer: BufferConfig {
+                    linger: Duration::from_millis(500),
+                    max_batch_bytes: 1024 * 1024,
+                    max_batch_records: 2,
+                },
+                codec: CompressionCodec::None,
+            },
+        )
+        .unwrap();
+
+        // 1) Submit first record (survivor) -> sits in buffer (records = 1).
         let first = {
             let producer = producer.clone();
             tokio::spawn(async move {
@@ -849,15 +889,18 @@ fn producer_overlapping_linger_scenario() -> turmoil::Result {
         };
         tokio::task::yield_now().await;
 
-        let mut trigger =
-            Box::pin(producer.send(b"cancel-key", b"canceled-caller".to_vec()));
+        // 2) Submit threshold record (trigger) -> reaches max_batch_records: 2 -> triggers PushResult::Flush.
+        let mut trigger = Box::pin(producer.send(b"cancel-key", b"canceled-caller".to_vec()));
         tokio::select! {
             biased;
             result = &mut trigger => panic!("threshold send completed before cancellation: {result:?}"),
             _ = tokio::task::yield_now() => {}
         }
+
+        // 3) Cancel the threshold sender by dropping its future.
         drop(trigger);
 
+        // 4) Assert that the surviving sender in the shared batch completes successfully.
         tokio::time::timeout(Duration::from_secs(5), first)
             .await
             .expect("surviving sender completes")

--- a/src/it/e2e/client_sdk.rs
+++ b/src/it/e2e/client_sdk.rs
@@ -837,6 +837,33 @@ fn producer_overlapping_linger_scenario() -> turmoil::Result {
             .expect("Record 4");
         assert_ne!(id3, id4);
 
+        // Cancel the send that triggers a full batch. The batch is shared work:
+        // canceling this caller must not cancel the other record in the batch.
+        let first = {
+            let producer = producer.clone();
+            tokio::spawn(async move {
+                producer
+                    .send(b"cancel-key", b"survivor".to_vec())
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+
+        let mut trigger =
+            Box::pin(producer.send(b"cancel-key", b"canceled-caller".to_vec()));
+        tokio::select! {
+            biased;
+            result = &mut trigger => panic!("threshold send completed before cancellation: {result:?}"),
+            _ = tokio::task::yield_now() => {}
+        }
+        drop(trigger);
+
+        tokio::time::timeout(Duration::from_secs(5), first)
+            .await
+            .expect("surviving sender completes")
+            .expect("surviving sender task")
+            .expect("shared batch completes");
+
         Ok(())
     });
 

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -92,7 +92,7 @@ fn at_least_once_auto_commit_does_not_commit_unacked_delivery() {
             client.clone(),
             topic.clone(),
             KeyInterest::AllKeys,
-            group_config(group_id),
+            group_config(group_id.clone()),
         )
         .await
         .unwrap();
@@ -105,6 +105,17 @@ fn at_least_once_auto_commit_does_not_commit_unacked_delivery() {
         assert_eq!(replayed.value, b"first");
         c2.ack(&replayed).unwrap();
         c2.close().await.unwrap();
+
+        let c3 = Consumer::new(client, topic, KeyInterest::AllKeys, group_config(group_id))
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), c3.next_record())
+                .await
+                .is_err(),
+            "final close commit prevents replay"
+        );
+        c3.close().await.unwrap();
 
         Ok(())
     });

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -85,7 +85,7 @@ fn at_least_once_auto_commit_does_not_commit_unacked_delivery() {
         assert_eq!(first.value, b"first");
 
         tokio::time::sleep(Duration::from_millis(1500)).await;
-        drop(c1);
+        c1.close().await.unwrap();
         tokio::time::sleep(Duration::from_secs(4)).await;
 
         let c2 = Consumer::new(
@@ -104,6 +104,7 @@ fn at_least_once_auto_commit_does_not_commit_unacked_delivery() {
             .unwrap();
         assert_eq!(replayed.value, b"first");
         c2.ack(&replayed).unwrap();
+        c2.close().await.unwrap();
 
         Ok(())
     });

--- a/src/it/e2e/consumer_group_test.rs
+++ b/src/it/e2e/consumer_group_test.rs
@@ -63,7 +63,8 @@ fn at_least_once_auto_commit_does_not_commit_unacked_delivery() {
         let topic = format!("at_least_once_{}", Uuid::new_v4());
         create_group_test_topics(&client, &topic).await;
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer =
+            Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
         producer.send(b"k", b"first".to_vec()).await.unwrap();
 
         let group_id = format!("group-{}", Uuid::new_v4());
@@ -130,7 +131,8 @@ fn at_most_once_auto_commit_commits_delivery() {
         let topic = format!("at_most_once_{}", Uuid::new_v4());
         create_group_test_topics(&client, &topic).await;
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer =
+            Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
         producer.send(b"k", b"first".to_vec()).await.unwrap();
 
         let group_id = format!("group-{}", Uuid::new_v4());
@@ -209,7 +211,8 @@ fn consumer_group_assignment_and_offsets() {
             .await
             .unwrap();
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer =
+            Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
 
         // Publish some messages to different ranges
         for i in 0..10 {
@@ -322,7 +325,7 @@ fn consumer_group_scale_out_and_rebalance() {
         let topic = format!("test_scale_out_{}", Uuid::new_v4());
         client.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::Fixed }).await.unwrap();
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
         let group_id = "scale-group".to_string();
 
         let c1 = Consumer::new(
@@ -466,7 +469,8 @@ fn consumer_group_failover() {
             client_prod.clone(),
             topic.clone(),
             ProducerConfig::default(),
-        );
+        )
+        .unwrap();
         for i in 0..6 {
             producer
                 .send(format!("primer_{}", i).as_bytes(), b"data".to_vec())
@@ -558,7 +562,7 @@ fn consumer_group_independent_groups() {
         let topic = format!("test_independent_{}", Uuid::new_v4());
         client.create_topic(&topic, StoragePolicy { retention_ms: None, replication_factor: 3, partition_strategy: PartitionStrategy::Fixed }).await.unwrap();
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
         for i in 0..10 {
             producer.send(format!("key_{}", i).as_bytes(), b"data".to_vec()).await.unwrap();
         }
@@ -642,7 +646,8 @@ fn consumer_group_rebalance_survives_broker_restart_without_offset_replay() {
             producer_client,
             topic.to_string(),
             ProducerConfig::default(),
-        );
+        )
+        .unwrap();
         let group_id = "rebalance-restart-group".to_string();
         let first = Consumer::new(
             first_client,
@@ -770,7 +775,8 @@ fn restarted_offset_replica_bootstraps_missed_epoch_before_commit_ack() {
             producer_client,
             topic.to_string(),
             ProducerConfig::default(),
-        );
+        )
+        .unwrap();
         let group_id = "offset-replica-epoch-bootstrap-group".to_string();
         let first = Consumer::new(
             first_client,
@@ -886,7 +892,8 @@ fn consumer_group_split_rebalance() {
             .await
             .unwrap();
 
-        let producer = Producer::new(client.clone(), topic.clone(), ProducerConfig::default());
+        let producer =
+            Producer::new(client.clone(), topic.clone(), ProducerConfig::default()).unwrap();
         let group_id = "split-group".to_string();
 
         let c1 = Consumer::new(


### PR DESCRIPTION
closes #188 

## Summary of Changes

This PR enhances the client SDK (`Producer` and `Consumer`) with deterministic graceful shutdown protocols, lightweight dual-gate synchronization, cancellation resilience for shared batches, and CLI
configuration validation.

### 1. Producer Architecture & Synchronization
- **Dual-Gate Barrier Synchronization**:
- `send_gate: RwLock<()>`: Gates active application `send()` calls against `flush()` and `close()`.
- `flush_gate: Arc<RwLock<()>>`: Gates batch network publication against buffer draining, closing the linger-timer race window.
- Documented Tokio's writer-preferring (fair) `RwLock` deadlock prevention rationale in `Inner` struct rustdoc.
- **Cancellation-Safe Shared Batch Spawning (`spawn_flush`)**:
- Decoupled size-triggered batch flushes into detached `tokio::spawn` background tasks under `flush_gate.read()`.
- Cancelling an individual caller's `send()` future discards only that caller's ACK (`oneshot::Receiver`), allowing shared batch publication to complete durably for surviving senders.
- **Non-Cancellable Drains**:
- `flush()` and `close()` execute producer-owned background drains that continue to completion even if the caller drops the `flush()` / `close()` future.

### 2. Consumer Graceful Shutdown (`Consumer::close`)
- **5-Stage Ordered Shutdown Protocol**:
1. **Delivery Fencing**: `group.fence_delivery()` prevents new records from reaching caller iterators.
2. **Range Fetcher Join**: `stop_all()` dispatches `StopRangeFetch` with `oneshot` replies to all `RangeFetchActor`s and awaits their exit.
3. **Acked Offset Commit**: `group.commit()` persists *only* explicitly `ack()`ed consumer offsets.
4. **Revoke Ownership**: `group.clear_effective_ownership()` clears local partition assignments.
5. **Group Leave**: `group.leave()` sends `SyncConsumerGroupAction::Leave` to the coordinator, awaits confirmation, and sets `quit = true`.
- **Prefetch Buffer Purge**: Purges leftover prefetched records from `consumer_rx` upon shutdown to guarantee immediate termination visibility across all consumer clones.
- **Drop Idempotency**: `ConsumerGroup::drop` checks the `quit` atomic flag to make `drop()` a no-op when `close().await` was called, preserving a best-effort background leave fallback for un-closed drops.

### 3. Configuration & Error Handling
- **CLI & Environment Validation**: Added `clap` `value_parser = parse_nonzero_usize` for `max_batch_bytes` and `max_batch_records` in `BufferConfig`, while maintaining runtime `BufferConfig::validate()` domain error validation.
- **Error Variants**: Added `ClientError::ConsumerClosed` and enhanced client redirect error mapping.