### PR TITLE
fix: authorization gap in multiraft RPC

### DIFF
--- a/.claude/rules/raft-transport.md
+++ b/.claude/rules/raft-transport.md
@@ -31,4 +31,8 @@ Length-prefixed bincode frames:
 
 5. **Frame sizes are bounded.** Handshake frames capped at 1KB; message frames at 4MB. Without bounds, a malicious or buggy peer can exhaust memory by sending a giant length prefix before any payload.
 
-6. **Transport never inspects or modifies RPC payloads.** Wire messages are routed by their `shard_group_id` envelope; the payload bytes are opaque to the transport layer. Maintains layer separation — bugs in transport cannot corrupt consensus semantics.
+6. **Transport validates envelope identity but never interprets the RPC.** The
+connection peer must match the envelope `sender`; a mismatch closes that
+connection. The transport routes by `shard_group_id` and passes the authenticated
+peer onward, but the RPC remains opaque. Voter, learner, leader, term, and log
+checks belong to the target Raft state machine.

--- a/.claude/rules/raft.md
+++ b/.claude/rules/raft.md
@@ -72,10 +72,12 @@ Relaxed compared to typical Raft — DS-RSM manages metadata (topic assignments,
 - `ElectionTimeout` ignored if node is Leader.
 - `HeartbeatTimeout` ignored if node is Follower or Candidate.
 
-The state machine first validates that the authenticated sender has the voter or
-learner role required by the RPC. Authorized RPCs may arrive while the local node
-is in any role (per Raft §5.1), but role-specific actions such as counting votes
-and tracking replication progress still guard internally.
+Every RPC must first match its connection identity. Election messages require a
+committed voter, while replication responses require a committed voter or staged
+learner. However, claimed-leader replication requests (`AppendEntries` and
+`InstallSnapshot`) do not check local membership—this allows lagging replicas to
+receive updates from new leaders and catch up. Raft term and log rules validate
+these requests instead.
 
 ## State Transitions
 
@@ -133,16 +135,20 @@ Converge to `next_index = match_index + 1` once peer caught up. Initial probing 
 
 9. **A learner never counts toward the commit quorum.** `learner_states` is replicated to like `peers` but excluded from `try_advance_commit_index`; and being outside `peers`, a learner is never sent `RequestVote` nor counted in an election either. This makes *"a membership addition can never reduce availability"* true by construction: staging a node that turns out unreachable (no instance, partitioned) leaves the group live on its real voters, and only a caught-up learner is promoted into the quorum. Prevents the phantom-voter freeze — where an added-but-non-participating member pushes the commit quorum out of the reach of the live members and stalls the group (the failure the coordinator-crash repair e2e exercises).
 
-10. **Installed snapshots become visible only after durable validation.** A follower buffers bounded transfer chunks without changing metadata, validates the completed size and checksum, persists the snapshot atomically, and only then replaces its application state and committed membership. An interrupted or corrupt transfer leaves the previous durable state visible.
+10. **Installed snapshots become visible only after durable validation.** A
+follower buffers bounded transfer chunks without changing metadata, validates
+the completed size and checksum, persists the snapshot atomically, and only then
+replaces its application state and committed voter set. An interrupted or corrupt
+transfer leaves the previous durable state visible.
 
 11. **A candidate counts each committed voter at most once per term.** Candidate
 vote state is a set of voter identities containing self; every other identity must
 belong to the committed peer set. Duplicate responses and responses from
 non-voters cannot manufacture a quorum.
 
-12. **RPC sender authorization precedes consensus mutation.** Vote and leader
-requests require a committed voter whose embedded identity matches the
-transport-authenticated sender. Replication and snapshot responses require a
-current voter or staged learner and the matching local role. An unauthorized RPC
-cannot advance term, reset timers, grant or count votes, recognize a leader,
-change the log, stage a snapshot, or update replication progress.
+12. **RPC identity and role authorization precede consensus mutation.** Every RPC
+must first match its connection identity. Election messages require a committed
+voter, while replication responses require a committed voter or staged learner.
+Claimed-leader replication requests skip local voter checks so out-of-date nodes
+can receive updates from new leaders—Raft term, log, and snapshot checks handle
+validation instead.

--- a/.claude/rules/raft.md
+++ b/.claude/rules/raft.md
@@ -36,7 +36,7 @@ Raft (pure sync state machine, one per shard group)
 | Type | Description |
 |---|---|
 | `Raft` | Core state machine. Holds term, role, log, peers, commit_index, last_applied. |
-| `Role` | `Follower`, `Candidate { votes_received }`, `Leader` |
+| `Role` | `Follower`, `Candidate { voters }`, `Leader` |
 | `PeerState` | Leader-only. `next_index` (guess) and `match_index` (confirmed truth). |
 | `MemLog` | In-memory log store. 1-based indexing. |
 | `LogEntry` | `{ term, index, command }` |
@@ -72,7 +72,10 @@ Relaxed compared to typical Raft — DS-RSM manages metadata (topic assignments,
 - `ElectionTimeout` ignored if node is Leader.
 - `HeartbeatTimeout` ignored if node is Follower or Candidate.
 
-All `step()` handlers accept RPCs from any role (per Raft spec §5.1), but role-specific actions (counting votes, tracking peer state) guard internally.
+The state machine first validates that the authenticated sender has the voter or
+learner role required by the RPC. Authorized RPCs may arrive while the local node
+is in any role (per Raft §5.1), but role-specific actions such as counting votes
+and tracking replication progress still guard internally.
 
 ## State Transitions
 
@@ -84,7 +87,7 @@ Follower ──[ElectionTimeout]──> Candidate ──[majority votes]──> 
 ```
 
 - **Follower → Candidate**: Election timeout fires. Increments term, votes for self, sends `RequestVote` to all peers.
-- **Candidate → Leader**: Receives majority votes. Initializes `peer_states`, cancels election timer, starts heartbeat timer, sends initial heartbeats.
+- **Candidate → Leader**: Receives votes from a unique majority of committed voters. Initializes `peer_states`, cancels election timer, starts heartbeat timer, sends initial heartbeats.
 - **Any → Follower**: Receives RPC with higher term. Resets term, clears `voted_for`, cancels timers, starts election timer.
 - **Candidate → Follower**: Receives `AppendEntries` with same term (another node already won).
 - **Single-node**: Candidate with no peers immediately becomes Leader.
@@ -114,7 +117,7 @@ Converge to `next_index = match_index + 1` once peer caught up. Initial probing 
 
 1. **Only the leader can propose.** `propose()` returns `Err(ProposeError::NotLeader)` if called on a follower or candidate. Followers may apply, never originate.
 
-2. **At most one leader per term.** Enforced by vote deduplication (`voted_for`) and the log-up-to-date check (§5.4.1). Two leaders in the same term would commit conflicting entries — Raft's primary safety violation.
+2. **At most one leader per term.** Enforced by `voted_for`, candidate-side voter-identity deduplication, and the log-up-to-date check (§5.4.1). Two leaders in the same term would commit conflicting entries — Raft's primary safety violation.
 
 3. **A leader commits only entries from its own term.** Entries from prior terms become committed implicitly when a current-term entry is committed (Figure 8). Direct commit of an old-term entry can be retroactively overwritten by a yet-older leader's truncation — a safety violation.
 
@@ -131,3 +134,15 @@ Converge to `next_index = match_index + 1` once peer caught up. Initial probing 
 9. **A learner never counts toward the commit quorum.** `learner_states` is replicated to like `peers` but excluded from `try_advance_commit_index`; and being outside `peers`, a learner is never sent `RequestVote` nor counted in an election either. This makes *"a membership addition can never reduce availability"* true by construction: staging a node that turns out unreachable (no instance, partitioned) leaves the group live on its real voters, and only a caught-up learner is promoted into the quorum. Prevents the phantom-voter freeze — where an added-but-non-participating member pushes the commit quorum out of the reach of the live members and stalls the group (the failure the coordinator-crash repair e2e exercises).
 
 10. **Installed snapshots become visible only after durable validation.** A follower buffers bounded transfer chunks without changing metadata, validates the completed size and checksum, persists the snapshot atomically, and only then replaces its application state and committed membership. An interrupted or corrupt transfer leaves the previous durable state visible.
+
+11. **A candidate counts each committed voter at most once per term.** Candidate
+vote state is a set of voter identities containing self; every other identity must
+belong to the committed peer set. Duplicate responses and responses from
+non-voters cannot manufacture a quorum.
+
+12. **RPC sender authorization precedes consensus mutation.** Vote and leader
+requests require a committed voter whose embedded identity matches the
+transport-authenticated sender. Replication and snapshot responses require a
+current voter or staged learner and the matching local role. An unauthorized RPC
+cannot advance term, reset timers, grant or count votes, recognize a leader,
+change the log, stage a snapshot, or update replication progress.

--- a/docs/metadata-management/d4_membership_and_shard_reconciliation.md
+++ b/docs/metadata-management/d4_membership_and_shard_reconciliation.md
@@ -54,7 +54,7 @@ Periodic reconciliation repeats the comparison. This handles missed one-shot eve
 
 ---
 
-## Ring intent and committed membership can drift
+## Ring intent and committed voter set can drift
 
 The hash ring changes promptly as nodes join and die. A Raft group changes only through its own committed history. Temporary drift is expected:
 

--- a/docs/metadata-management/d8_raft_rpc_sender_authorization.md
+++ b/docs/metadata-management/d8_raft_rpc_sender_authorization.md
@@ -43,12 +43,11 @@ Healthy traffic for other groups continues.
 
 ---
 
-## Current Gap
+## Gap Closed by D8
 
-The existing transport forwards the group, claimed sender, and RPC to MultiRaft.
-MultiRaft looks up the local group and dispatches the RPC. The target Raft state
-machine applies term and local-role rules, but it does not yet apply a complete
-sender-authorization check before those rules.
+Before D8, the transport forwarded the group, claimed sender, and RPC to
+MultiRaft. The target Raft state machine applied term and local-role rules before
+complete sender authorization.
 
 This creates four concrete gaps:
 
@@ -58,8 +57,10 @@ This creates four concrete gaps:
 - append and snapshot messages do not consistently bind embedded identities to
   the authenticated sender and committed group role.
 
-The security transport supplies trustworthy peer identity. D8 makes every Raft
-handler use it before mutating consensus state.
+D8 binds each envelope sender to the connection peer and makes every Raft handler
+authorize that peer before mutating consensus state. The current handshake
+provides this identity seam. Security S1 will replace its trust basis with TLS
+without changing the Raft API.
 
 ---
 
@@ -158,19 +159,22 @@ groups continue using the connection.
 
 ---
 
-## Implementation Work
+## Implementation Shape
 
-1. Carry the authenticated peer identity from transport to each inbound Raft RPC.
-2. Add one authorization step at the target Raft state-machine boundary.
-3. Check embedded candidate, leader, and responder identities against that peer.
-4. Apply the RPC-specific voter or learner requirement from the matrix.
-5. Replace the scalar candidate vote count with unique voter identities.
-6. Reject unauthorized RPCs before term or state processing.
-7. Emit bounded audit events without returning a connection-close instruction.
+1. Transport carries the connection peer identity with each inbound Raft RPC.
+2. The target Raft state-machine boundary performs one authorization step.
+3. Candidate, leader, and responder identities must match that peer.
+4. The RPC-specific voter or learner requirement comes from the matrix.
+5. Candidate votes are unique voter identities rather than a scalar count.
+6. Unauthorized RPCs return before term or state processing.
 
 The transport remains unaware of Raft membership and role. MultiRaft remains a
 group router. The target Raft instance owns the decision because only it has the
 committed membership and current local role.
+
+TLS authentication and structured security audit events remain security-roadmap
+work. They replace the handshake trust basis and rejection diagnostics,
+respectively; they do not change the application authorization rules.
 
 ---
 

--- a/docs/metadata-management/d8_raft_rpc_sender_authorization.md
+++ b/docs/metadata-management/d8_raft_rpc_sender_authorization.md
@@ -1,0 +1,211 @@
+# D8 — Raft RPC Sender Authorization
+
+**Goal:** Ensure that each Raft group accepts an RPC only from a node authorized
+for that RPC, without coupling consensus membership to the shared TCP connection.
+
+**Depends on:** [D2 — Replicated Apply and Durability](d2_replicated_apply_and_durability.md),
+[D4 — Membership and Shard Reconciliation](d4_membership_and_shard_reconciliation.md),
+and the authenticated peer identity defined by the
+[security roadmap](../security/roadmap.md).
+
+---
+
+## Boundary
+
+One TCP connection carries Raft traffic for many shard groups. TLS authenticates
+the node that owns the connection. It does not decide which groups that node may
+access.
+
+```
+TLS transport
+  validates certificate + connection identity emits 
+  { authenticated peer, group, RPC }
+                         |
+                         v
+          MultiRaft routes by group
+                         |
+                         v
+target Raft group authorizes peer for this RPC
+                         |
+              reject ----+---- accept
+                |                 |
+                v                 v
+          drop one RPC      apply Raft rules
+          keep TCP open
+```
+
+Transport rejects a frame only when framing fails or its claimed sender differs
+from the authenticated connection peer. Group membership, local role, term, vote,
+leader, and log checks remain application logic.
+
+**Connection rule:** Rejecting one group's RPC never closes the shared connection.
+Healthy traffic for other groups continues.
+
+---
+
+## Current Gap
+
+The existing transport forwards the group, claimed sender, and RPC to MultiRaft.
+MultiRaft looks up the local group and dispatches the RPC. The target Raft state
+machine applies term and local-role rules, but it does not yet apply a complete
+sender-authorization check before those rules.
+
+This creates four concrete gaps:
+
+- a non-voter can send a higher-term vote request and make a member step down;
+- a vote request can claim a candidate different from its envelope sender;
+- vote responses are counted without voter identity deduplication;
+- append and snapshot messages do not consistently bind embedded identities to
+  the authenticated sender and committed group role.
+
+The security transport supplies trustworthy peer identity. D8 makes every Raft
+handler use it before mutating consensus state.
+
+---
+
+## RPC Authorization Matrix
+
+| RPC | Required sender authority |
+|---|---|
+| Vote request | Authenticated peer equals the candidate; candidate is a committed voter |
+| Vote response | Authenticated peer equals the responder; responder is a committed voter; local node is a candidate; voter has not already responded in this term |
+| Append entries | Authenticated peer equals the claimed leader; leader is a committed voter |
+| Append response | Authenticated peer equals the responder; responder is a current voter or staged learner; local node is leader |
+| Install snapshot | Authenticated peer equals the claimed leader; leader is a committed voter |
+| Snapshot response | Authenticated peer equals the responder; responder is a current voter or staged learner; local node is leader |
+
+Voters may campaign, vote, lead, replicate, and acknowledge replication. Learners
+may receive logs or snapshots and acknowledge their progress. Learners cannot
+campaign, vote, lead, or count toward quorum.
+
+An unknown local group or unauthorized sender causes a single-RPC rejection. The
+application emits a rate-limited audit event and leaves the shared connection
+alone.
+
+---
+
+## Validation Order
+
+Sender authorization runs before any RPC can affect term, role, timers, votes,
+leader recognition, log state, snapshot state, or replication progress.
+
+```
+authenticated peer + target group + RPC
+                  │
+                  ▼
+      target group exists locally?
+                  │
+              No  ├──► drop RPC
+                  │
+             Yes  │
+                  ▼
+     embedded identity matches peer?
+                  │
+              No  ├──► drop RPC + audit
+                  │
+             Yes  │
+                  ▼
+   peer has role required by this RPC?
+                  │
+              No  ├──► drop RPC + audit
+                  │
+             Yes  │
+                  ▼
+apply term, role, log, and snapshot rules
+```
+
+This order matters. A rejected outsider must not advance the term, reset an
+election timer, grant or count a vote, install itself as leader, append a log
+entry, or stage a snapshot.
+
+---
+
+## Vote Identity and Deduplication
+
+A candidate begins each election with its own vote and an empty set of remote
+voters. A granted response adds the authenticated voter identity to that set.
+Adding the same voter again is a no-op.
+
+```
+term 42 votes = {self}
+
+response from B, granted  -> {self, B}
+duplicate from B          -> {self, B}
+response from outsider X  -> rejected
+response from C, granted  -> {self, B, C}
+```
+
+The vote set is cleared when the node leaves candidate state or advances term.
+Leadership follows from the size of the unique authorized vote set, never from a
+raw response counter.
+
+---
+
+## Membership Changes
+
+Sender authorization reads the target group's current committed voter set.
+Membership remains a Raft decision:
+
+- removing a voter takes effect when the removal entry applies;
+- adding a voter takes effect when the promotion entry applies;
+- a staged learner is authorized only for learner replication traffic;
+- SWIM or ring intent cannot directly authorize a Raft RPC.
+
+Temporary disagreement is handled as a stale RPC, not a transport failure. For
+example, a recently removed voter may send one last response over an otherwise
+healthy node-to-node connection. The old group rejects that response while other
+groups continue using the connection.
+
+---
+
+## Implementation Work
+
+1. Carry the authenticated peer identity from transport to each inbound Raft RPC.
+2. Add one authorization step at the target Raft state-machine boundary.
+3. Check embedded candidate, leader, and responder identities against that peer.
+4. Apply the RPC-specific voter or learner requirement from the matrix.
+5. Replace the scalar candidate vote count with unique voter identities.
+6. Reject unauthorized RPCs before term or state processing.
+7. Emit bounded audit events without returning a connection-close instruction.
+
+The transport remains unaware of Raft membership and role. MultiRaft remains a
+group router. The target Raft instance owns the decision because only it has the
+committed membership and current local role.
+
+---
+
+## Validation
+
+- Send a higher-term vote request from a non-voter. Term, role, vote, and election
+  timer remain unchanged.
+- Send a vote request whose candidate differs from the authenticated peer.
+- Replay one granted vote response until quorum would be reached without
+  deduplication. It contributes one vote.
+- Send append entries from a non-voter and from a voter claiming another leader.
+- Send append and snapshot responses from unknown nodes.
+- Verify a learner can acknowledge catch-up but cannot campaign or vote.
+- Remove a voter, then deliver its delayed RPC after the removal applies.
+- Reject an RPC for one group, then process a valid RPC for another group over the
+  same TCP connection without reconnecting.
+- Fuzz unauthorized RPCs and verify that rejection does not mutate consensus
+  state or create unbounded audit output.
+
+---
+
+## Design Rules
+
+1. **Transport authenticates; Raft authorizes.** TLS proves the peer identity, but
+   only the target group can interpret voter, learner, leader, and term state.
+2. **Authorization precedes consensus mutation.** An unauthorized RPC cannot alter
+   term, role, timer, vote, leader, log, snapshot, or replication progress.
+3. **RPC authority is group- and operation-specific.** Cluster membership alone
+   does not grant universal Raft authority.
+4. **Votes are identities, not a counter.** One committed voter contributes at
+   most one vote in a term.
+5. **Learners have replication authority only.** Catch-up does not confer election
+   or quorum authority.
+6. **Application rejection preserves transport.** A stale or unauthorized RPC
+   drops one message and never disrupts unrelated groups on the shared connection.
+
+See `.agents/rules/raft.md` for the exact consensus contracts and
+`.agents/rules/raft-transport.md` for the transport boundary.

--- a/docs/metadata-management/d8_raft_rpc_sender_authorization.md
+++ b/docs/metadata-management/d8_raft_rpc_sender_authorization.md
@@ -54,8 +54,8 @@ This creates four concrete gaps:
 - a non-voter can send a higher-term vote request and make a member step down;
 - a vote request can claim a candidate different from its envelope sender;
 - vote responses are counted without voter identity deduplication;
-- append and snapshot messages do not consistently bind embedded identities to
-  the authenticated sender and committed group role.
+- append and snapshot messages do not consistently bind their claimed leader to
+  the authenticated sender.
 
 D8 binds each envelope sender to the connection peer and makes every Raft handler
 authorize that peer before mutating consensus state. The current handshake
@@ -70,14 +70,28 @@ without changing the Raft API.
 |---|---|
 | Vote request | Authenticated peer equals the candidate; candidate is a committed voter |
 | Vote response | Authenticated peer equals the responder; responder is a committed voter; local node is a candidate; voter has not already responded in this term |
-| Append entries | Authenticated peer equals the claimed leader; leader is a committed voter |
-| Append response | Authenticated peer equals the responder; responder is a current voter or staged learner; local node is leader |
-| Install snapshot | Authenticated peer equals the claimed leader; leader is a committed voter |
-| Snapshot response | Authenticated peer equals the responder; responder is a current voter or staged learner; local node is leader |
+| Append entries | Authenticated peer equals the claimed leader; Raft validates term and log continuity |
+| Append response | Authenticated peer equals the responder; responder is a committed voter or staged learner; local node is leader |
+| Install snapshot | Authenticated peer equals the claimed leader; Raft validates term and snapshot continuity |
+| Snapshot response | Authenticated peer equals the responder; responder is a committed voter or staged learner; local node is leader |
 
 Voters may campaign, vote, lead, replicate, and acknowledge replication. Learners
 may receive logs or snapshots and acknowledge their progress. Learners cannot
 campaign, vote, lead, or count toward quorum.
+
+This document uses three precise terms:
+
+- **Claimed leader:** The node named as leader inside an incoming append or
+  snapshot request. Raft has not recognized it as the current leader yet.
+- **Committed voter:** A node in the applied Raft voting configuration.
+- **Staged learner:** A leader-local replication target catching up before a
+  committed promotion. It is not part of committed group membership.
+
+Claimed-leader replication requests deliberately do not consult the receiver's
+local voter set. A lagging replica may need an append or snapshot to learn the
+configuration that added the current leader. Requiring that configuration before
+accepting the replication creates a circular dependency and can strand the
+replica permanently.
 
 An unknown local group or unauthorized sender causes a single-RPC rejection. The
 application emits a rate-limited audit event and leaves the shared connection
@@ -106,7 +120,8 @@ authenticated peer + target group + RPC
                   │
              Yes  │
                   ▼
-   peer has role required by this RPC?
+   response or election sender is
+   an authorized committed voter or staged learner?
                   │
               No  ├──► drop RPC + audit
                   │
@@ -115,9 +130,11 @@ authenticated peer + target group + RPC
 apply term, role, log, and snapshot rules
 ```
 
-This order matters. A rejected outsider must not advance the term, reset an
-election timer, grant or count a vote, install itself as leader, append a log
-entry, or stage a snapshot.
+This order matters. A rejected election sender cannot advance the term, reset an
+election timer, grant or count a vote, or update replication progress. A leader
+replication request proceeds to Raft only when its claimed leader matches the
+authenticated peer; term, log, and snapshot validation then determine whether it
+can change state.
 
 ---
 
@@ -144,13 +161,20 @@ raw response counter.
 
 ## Membership Changes
 
-Sender authorization reads the target group's current committed voter set.
-Membership remains a Raft decision:
+Sender authorization reads the target group's current committed voter set for
+elections, quorum acknowledgements, and learner progress. Membership remains a
+Raft decision:
 
 - removing a voter takes effect when the removal entry applies;
 - adding a voter takes effect when the promotion entry applies;
 - a staged learner is authorized only for learner replication traffic;
 - SWIM or ring intent cannot directly authorize a Raft RPC.
+
+Claimed-leader replication requests are the exception to the local-membership
+lookup, not an exception to identity authentication. The receiver binds the
+claimed leader to the connection peer and lets Raft validate the request. This is
+necessary because the receiver's committed configuration may lag behind the
+leader's while the receiver is catching up.
 
 Temporary disagreement is handled as a stale RPC, not a transport failure. For
 example, a recently removed voter may send one last response over an otherwise
@@ -163,14 +187,17 @@ groups continue using the connection.
 
 1. Transport carries the connection peer identity with each inbound Raft RPC.
 2. The target Raft state-machine boundary performs one authorization step.
-3. Candidate, leader, and responder identities must match that peer.
-4. The RPC-specific voter or learner requirement comes from the matrix.
+3. Candidate, claimed-leader, and responder identities must match that peer.
+4. Election and response RPCs enforce the committed-voter or staged-learner
+   requirement from the matrix.
 5. Candidate votes are unique voter identities rather than a scalar count.
-6. Unauthorized RPCs return before term or state processing.
+6. Unauthorized election and response RPCs return before term or state
+   processing; claimed-leader replication requests continue through ordinary
+   Raft validation.
 
 The transport remains unaware of Raft membership and role. MultiRaft remains a
 group router. The target Raft instance owns the decision because only it has the
-committed membership and current local role.
+committed voter set, staged learners, and current local role.
 
 TLS authentication and structured security audit events remain security-roadmap
 work. They replace the handshake trust basis and rejection diagnostics,

--- a/src/control_plane/consensus/multi_raft.rs
+++ b/src/control_plane/consensus/multi_raft.rs
@@ -2081,17 +2081,34 @@ mod tests {
 
     #[test]
     fn boundary_recovery_dropped_on_step_down() {
-        use crate::control_plane::consensus::messages::{AppendEntries, RaftRpc};
+        use crate::control_plane::consensus::messages::{
+            AppendEntries, AppendEntriesResponse, RaftRpc,
+        };
         use crate::control_plane::metadata::{RangeId, SegmentId, TopicId};
 
         let (storage, _tmp) = temp_storage();
         let me = node("n1");
         let mut store =
             new_store_with_topology(me.clone(), storage, &[node("n1"), node("y"), node("z")]);
-        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone()]));
-        elect_leader(&mut store);
+        let peer = node("y");
+        store.add_group(&shard(TEST_GROUP_ID.0, vec![me.clone(), peer.clone()]));
+        elect_leader_with_peers(&mut store, std::slice::from_ref(&peer));
         store.flush();
         create_topic_via_store(&mut store, "t", vec![node("x"), node("y"), node("z")]);
+        {
+            let raft = store.groups.get_mut(&TEST_GROUP_ID).unwrap();
+            raft.handle_rpc(
+                peer.clone(),
+                AppendEntriesResponse {
+                    term: raft.current_term(),
+                    node_id: peer.clone(),
+                    success: true,
+                    last_log_index: raft.log_last_index(),
+                },
+            );
+            store.dirty.insert(TEST_GROUP_ID);
+        }
+        store.flush();
 
         let seg0 = SegmentKey::new(TopicId((TEST_GROUP_ID.0) << 32), RangeId(0), SegmentId(0));
         store.handle_node_death(node("x"));
@@ -2105,10 +2122,10 @@ mod tests {
         // recovery roll, and the leader-gated ring-check won't fire to prune it.
         store.handle_consensus(InboundRaftRpc {
             shard_group_id: TEST_GROUP_ID,
-            from: node("n2"),
+            from: peer.clone(),
             rpc: RaftRpc::AppendEntries(AppendEntries {
                 term: 99,
-                leader_id: node("n2"),
+                leader_id: peer,
                 prev_log_index: 0,
                 prev_log_term: 0,
                 entries: Box::new([]),

--- a/src/control_plane/consensus/raft/state.rs
+++ b/src/control_plane/consensus/raft/state.rs
@@ -780,6 +780,16 @@ impl Raft {
 
     pub fn handle_rpc(&mut self, from: NodeId, rpc: impl Into<RaftRpc>) {
         let rpc = rpc.into();
+        if !self.is_rpc_sender_authorized(&from, &rpc) {
+            tracing::debug!(
+                node = %self.node_id,
+                group = self.shard_group_id.0,
+                from = %from,
+                rpc = ?rpc,
+                "rejected unauthorized Raft RPC",
+            );
+            return;
+        }
         match rpc {
             RaftRpc::RequestVote(req) => self.handle_request_vote(from, req),
             RaftRpc::RequestVoteResponse(resp) => self.handle_request_vote_response(resp),
@@ -790,6 +800,29 @@ impl Raft {
         }
         #[cfg(any(test, debug_assertions))]
         self.assert_invariants();
+    }
+
+    fn is_rpc_sender_authorized(&self, from: &NodeId, rpc: &RaftRpc) -> bool {
+        match rpc {
+            RaftRpc::RequestVote(req) => &req.candidate_id == from && self.peers.contains(from),
+            RaftRpc::RequestVoteResponse(resp) => {
+                &resp.node_id == from
+                    && self.peers.contains(from)
+                    && matches!(self.consensus.role(), Role::Candidate { .. })
+            }
+            RaftRpc::AppendEntries(req) => &req.leader_id == from,
+            RaftRpc::AppendEntriesResponse(resp) => {
+                &resp.node_id == from
+                    && self.is_leader()
+                    && (self.peers.contains(from) || self.consensus.is_learner(from))
+            }
+            RaftRpc::InstallSnapshot(req) => &req.leader_id == from,
+            RaftRpc::InstallSnapshotResponse(resp) => {
+                &resp.node_id == from
+                    && self.is_leader()
+                    && (self.peers.contains(from) || self.consensus.is_learner(from))
+            }
+        }
     }
 
     // -------------------------------------------------------------------
@@ -894,7 +927,7 @@ impl Raft {
         }
         if self
             .consensus
-            .record_vote(resp.term, resp.vote_granted, self.quorum())
+            .record_vote(resp.term, resp.node_id, resp.vote_granted, self.quorum())
         {
             self.become_leader();
         }
@@ -1798,7 +1831,7 @@ impl crate::test_traits::TAssertInvariant for Raft {
 
         // Invariant: peer_states exists only on the leader (and matches the peer
         // set when leader). Followers/candidates carry an empty peer_states.
-        match *self.consensus.role() {
+        match self.consensus.role() {
             Role::Leader => {
                 for peer in &self.peers {
                     assert!(
@@ -1848,6 +1881,19 @@ impl crate::test_traits::TAssertInvariant for Raft {
                     self.consensus.learner_state_count(),
                 );
             }
+        }
+
+        if let Role::Candidate { voters } = self.consensus.role() {
+            assert!(
+                voters.contains(&self.node_id),
+                "candidate vote set does not contain self",
+            );
+            assert!(
+                voters
+                    .iter()
+                    .all(|voter| voter == &self.node_id || self.peers.contains(voter)),
+                "candidate vote set contains a non-voter: {voters:?}",
+            );
         }
 
         // Invariant (partial): self is never in peers. The peer set is otherwise
@@ -1949,6 +1995,23 @@ mod tests {
     fn three_node_raft(id: &str) -> Raft {
         let all = ["node-1", "node-2", "node-3"];
         let peers: HashSet<NodeId> = all.iter().filter(|&&n| n != id).map(|&n| node(n)).collect();
+        Raft::new(
+            node(id),
+            peers,
+            RaftPersistentState::default(),
+            0,
+            TEST_SHARD,
+            test_timer_seqs(),
+        )
+    }
+
+    fn five_node_raft(id: &str) -> Raft {
+        let all = ["node-1", "node-2", "node-3", "node-4", "node-5"];
+        let peers = all
+            .iter()
+            .filter(|&&node_id| node_id != id)
+            .map(|&node_id| node(node_id))
+            .collect();
         Raft::new(
             node(id),
             peers,
@@ -2067,8 +2130,9 @@ mod tests {
         });
 
         assert!(matches!(
-            *raft.consensus.role(),
-            Role::Candidate { votes_received: 1 }
+            raft.consensus.role(),
+            Role::Candidate { voters }
+                if voters == &HashSet::from([NodeId::new("node-1")])
         ));
         assert_eq!(raft.consensus.current_term(), 1);
 
@@ -2104,6 +2168,47 @@ mod tests {
             raft.consensus.voted_for().cloned(),
             Some(NodeId::new("node-1"))
         );
+    }
+
+    #[test]
+    fn non_voter_vote_request_cannot_advance_term() {
+        let mut raft = three_node_raft("node-2");
+        drain(&mut raft);
+
+        raft.handle_rpc(
+            node("outsider"),
+            RequestVote {
+                term: 9,
+                candidate_id: node("outsider"),
+                last_log_index: 0,
+                last_log_term: 0,
+            },
+        );
+
+        assert_eq!(raft.current_term(), 0);
+        assert_eq!(raft.voted_for(), None);
+        assert_eq!(raft.consensus.role(), &Role::Follower);
+        assert!(raft.take_events().is_empty());
+    }
+
+    #[test]
+    fn vote_request_candidate_must_match_sender() {
+        let mut raft = three_node_raft("node-2");
+        drain(&mut raft);
+
+        raft.handle_rpc(
+            node("node-1"),
+            RequestVote {
+                term: 9,
+                candidate_id: node("node-3"),
+                last_log_index: 0,
+                last_log_term: 0,
+            },
+        );
+
+        assert_eq!(raft.current_term(), 0);
+        assert_eq!(raft.voted_for(), None);
+        assert!(raft.take_events().is_empty());
     }
 
     #[test]
@@ -2156,6 +2261,62 @@ mod tests {
         raft.handle_rpc(node("node-2"), resp);
 
         assert_eq!(*raft.consensus.role(), Role::Leader);
+    }
+
+    #[test]
+    fn duplicate_vote_response_counts_once() {
+        let mut raft = five_node_raft("node-1");
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
+        });
+        drain(&mut raft);
+
+        let node_2_vote = RequestVoteResponse {
+            term: 1,
+            node_id: node("node-2"),
+            vote_granted: true,
+        };
+        raft.handle_rpc(node("node-2"), node_2_vote.clone());
+        raft.handle_rpc(node("node-2"), node_2_vote);
+
+        assert!(matches!(
+            raft.consensus.role(),
+            Role::Candidate { voters } if voters.len() == 2
+        ));
+
+        raft.handle_rpc(
+            node("node-3"),
+            RequestVoteResponse {
+                term: 1,
+                node_id: node("node-3"),
+                vote_granted: true,
+            },
+        );
+
+        assert_eq!(raft.consensus.role(), &Role::Leader);
+    }
+
+    #[test]
+    fn vote_response_identity_must_match_sender() {
+        let mut raft = three_node_raft("node-1");
+        raft.handle_timeout(RaftTimeoutCallback::ElectionTimeout {
+            shard_group_id: TEST_SHARD,
+            epoch: u64::MAX,
+        });
+        drain(&mut raft);
+
+        raft.handle_rpc(
+            node("node-2"),
+            RequestVoteResponse {
+                term: 9,
+                node_id: node("node-3"),
+                vote_granted: true,
+            },
+        );
+
+        assert_eq!(raft.current_term(), 1);
+        assert!(matches!(raft.consensus.role(), Role::Candidate { .. }));
     }
 
     #[test]
@@ -2300,6 +2461,55 @@ mod tests {
             _ => panic!("expected AppendEntriesResponse"),
         }
         assert_eq!(raft.log_last_index(), 1);
+    }
+
+    #[test]
+    fn append_entries_leader_must_match_sender() {
+        let mut raft = three_node_raft("node-2");
+        drain(&mut raft);
+
+        raft.handle_rpc(
+            node("node-1"),
+            AppendEntries {
+                term: 9,
+                leader_id: node("node-3"),
+                prev_log_index: 0,
+                prev_log_term: 0,
+                entries: Default::default(),
+                leader_commit: 0,
+            },
+        );
+
+        assert_eq!(raft.current_term(), 0);
+        assert_eq!(raft.current_leader(), None);
+        assert!(raft.take_events().is_empty());
+    }
+
+    #[test]
+    fn snapshot_leader_must_match_sender() {
+        let mut raft = three_node_raft("node-2");
+        drain(&mut raft);
+
+        raft.handle_rpc(
+            node("node-1"),
+            InstallSnapshot {
+                term: 9,
+                leader_id: node("node-3"),
+                header: RaftSnapshotHeader {
+                    last_included_index: 5,
+                    last_included_term: 9,
+                    checksum: 0,
+                    size_bytes: 0,
+                },
+                offset: 0,
+                data: Default::default(),
+                done: true,
+            },
+        );
+
+        assert_eq!(raft.current_term(), 0);
+        assert_eq!(raft.consensus.last_included_index(), 0);
+        assert!(raft.take_events().is_empty());
     }
 
     #[test]
@@ -2526,6 +2736,33 @@ mod tests {
         );
 
         assert!(packets(&mut raft).is_empty());
+    }
+
+    #[test]
+    fn non_peer_responses_cannot_step_down_leader() {
+        let responses = [
+            RaftRpc::AppendEntriesResponse(AppendEntriesResponse {
+                term: 9,
+                node_id: node("outsider"),
+                success: true,
+                last_log_index: 1,
+            }),
+            RaftRpc::InstallSnapshotResponse(InstallSnapshotResponse {
+                term: 9,
+                node_id: node("outsider"),
+                last_included_index: 5,
+                next_byte_offset: 0,
+                success: true,
+            }),
+        ];
+
+        for response in responses {
+            let mut raft = three_node_raft_as_leader("node-1");
+            raft.handle_rpc(node("outsider"), response);
+
+            assert_eq!(raft.current_term(), 1);
+            assert_eq!(raft.consensus.role(), &Role::Leader);
+        }
     }
 
     // -------------------------------------------------------------------

--- a/src/control_plane/consensus/raft/states/consensus/mod.rs
+++ b/src/control_plane/consensus/raft/states/consensus/mod.rs
@@ -159,11 +159,17 @@ impl ConsensusState {
 
     pub(crate) fn begin_campaign(&mut self, node_id: &NodeId) -> u64 {
         let term = self.log.begin_election(node_id);
-        self.transient.begin_campaign();
+        self.transient.begin_campaign(node_id);
         term
     }
-    pub(crate) fn record_vote(&mut self, term: u64, granted: bool, quorum: u32) -> bool {
-        term == self.current_term() && granted && self.transient.record_vote(quorum)
+    pub(crate) fn record_vote(
+        &mut self,
+        term: u64,
+        voter: NodeId,
+        granted: bool,
+        quorum: u32,
+    ) -> bool {
+        term == self.current_term() && granted && self.transient.record_vote(voter, quorum)
     }
     pub(crate) fn role(&self) -> &Role {
         &self.transient.role

--- a/src/control_plane/consensus/raft/states/consensus/transient_state.rs
+++ b/src/control_plane/consensus/raft/states/consensus/transient_state.rs
@@ -38,7 +38,7 @@ impl ElectionJitter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
     Follower,
-    Candidate { votes_received: u32 },
+    Candidate { voters: HashSet<NodeId> },
     Leader,
 }
 
@@ -193,16 +193,18 @@ impl TransientState {
         }));
     }
 
-    pub(crate) fn begin_campaign(&mut self) {
-        self.role = Role::Candidate { votes_received: 1 };
+    pub(crate) fn begin_campaign(&mut self, node_id: &NodeId) {
+        self.role = Role::Candidate {
+            voters: HashSet::from([node_id.clone()]),
+        };
     }
 
-    pub(crate) fn record_vote(&mut self, quorum: u32) -> bool {
-        let Role::Candidate { votes_received } = &mut self.role else {
+    pub(crate) fn record_vote(&mut self, voter: NodeId, quorum: u32) -> bool {
+        let Role::Candidate { voters } = &mut self.role else {
             return false;
         };
-        *votes_received += 1;
-        *votes_received >= quorum
+        voters.insert(voter);
+        voters.len() as u32 >= quorum
     }
 
     pub(crate) fn reset_for_follower(&mut self) {

--- a/src/control_plane/consensus/transport/inbound.rs
+++ b/src/control_plane/consensus/transport/inbound.rs
@@ -29,14 +29,22 @@ impl RaftRpcListener {
         Ok(msg)
     }
 
-    pub(super) async fn run(mut self, tx: MutlRaftSender) {
+    pub(super) async fn run(mut self, tx: MutlRaftSender, peer: NodeId) {
         loop {
             match self.read_message().await {
                 Ok(msg) => {
+                    if msg.sender != peer {
+                        tracing::warn!(
+                            transport_peer = %peer,
+                            claimed_sender = %msg.sender,
+                            "rejected Raft message whose sender differs from the connection peer",
+                        );
+                        break;
+                    }
                     let _ = tx
                         .send(InboundRaftRpc {
                             shard_group_id: msg.shard_group_id,
-                            from: msg.sender,
+                            from: peer.clone(),
                             rpc: msg.rpc,
                         })
                         .await;

--- a/src/control_plane/consensus/transport/mod.rs
+++ b/src/control_plane/consensus/transport/mod.rs
@@ -68,7 +68,9 @@ impl RaftTransportActor {
 mod tests {
     use super::*;
     use crate::control_plane::consensus::actor::MultiRaftActor;
-    use crate::control_plane::consensus::messages::{RaftRpc, RequestVote, WireRaftMessage};
+    use crate::control_plane::consensus::messages::{
+        MultiRaftActorCommand, RaftProtocolMessage, RaftRpc, RequestVote, WireRaftMessage,
+    };
     use crate::control_plane::membership::ShardGroupId;
     use crate::net::OwnedWriteHalf;
     use crate::net::TcpStream;
@@ -162,6 +164,62 @@ mod tests {
                 },
             )
             .await?;
+            Ok(())
+        });
+
+        sim.run()
+    }
+
+    #[test]
+    fn reader_binds_message_sender_to_connection_peer() -> turmoil::Result {
+        let mut sim = Builder::new()
+            .simulation_duration(Duration::from_secs(5))
+            .build();
+
+        sim.host("server", || async {
+            let listener = TcpListener::bind("0.0.0.0:9000").await?;
+            let (stream, _) = listener.accept().await?;
+            let (read_half, _) = stream.into_split();
+            let mut reader = RaftRpcListener(read_half);
+            let peer = reader.read_node_id().await?;
+            let (raft_tx, mut raft_rx) = MultiRaftActor::channel(8);
+
+            reader.run(raft_tx, peer.clone()).await;
+
+            let Some(MultiRaftActorCommand::ProtocolMessage(RaftProtocolMessage::InboundRaftRpc(
+                cmd,
+            ))) = raft_rx.recv().await
+            else {
+                panic!("expected one inbound Raft RPC")
+            };
+            assert_eq!(cmd.from, peer);
+            assert_eq!(cmd.shard_group_id, ShardGroupId(1));
+            assert!(raft_rx.try_recv().is_err());
+            Ok(())
+        });
+
+        sim.host("client", || async {
+            let addr = turmoil::lookup("server");
+            let stream = TcpStream::connect((addr, 9000)).await?;
+            let (_, mut writer) = stream.into_split();
+            write_frame(&mut writer, &NodeId::new("node-a")).await?;
+
+            for (group, sender) in [(1, "node-a"), (2, "node-b")] {
+                write_frame(
+                    &mut writer,
+                    &WireRaftMessage {
+                        shard_group_id: ShardGroupId(group),
+                        sender: NodeId::new(sender),
+                        rpc: RaftRpc::RequestVote(RequestVote {
+                            term: 1,
+                            candidate_id: NodeId::new(sender),
+                            last_log_index: 0,
+                            last_log_term: 0,
+                        }),
+                    },
+                )
+                .await?;
+            }
             Ok(())
         });
 

--- a/src/control_plane/consensus/transport/outbound.rs
+++ b/src/control_plane/consensus/transport/outbound.rs
@@ -79,8 +79,8 @@ impl RaftRpcDispatcher {
             return;
         }
 
-        self.writers.insert(peer_id, write_half);
-        tokio::spawn(reader.run(raft_tx.clone()));
+        self.writers.insert(peer_id.clone(), write_half);
+        tokio::spawn(reader.run(raft_tx.clone(), peer_id));
     }
 
     pub(super) async fn send(&mut self, packets: Vec<OutboundRaftPacket>, swim_tx: &SwimSender) {
@@ -185,7 +185,7 @@ impl RaftRpcDispatcher {
             return;
         }
         self.writers.insert(target.clone(), write_half);
-        tokio::spawn(reader.run(raft_tx.clone()));
+        tokio::spawn(reader.run(raft_tx.clone(), target.clone()));
 
         if !buffered.is_empty() {
             let _ = self.write_messages_to(&target, &buffered).await;


### PR DESCRIPTION
## Changes

- Connection peer and envelope sender binding.
- Claimed-leader identity validation.
- Committed-voter checks for elections.
- Committed-voter/staged-learner checks for replication responses.
- Unique vote counting.
- Per-RPC rejection without closing shared connections.
- Consistent documentation and Raft rules.